### PR TITLE
refactor(cd): promote-to-stable creates PR instead of direct merge

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,12 +47,40 @@ jobs:
           chmod +x .github/scripts/check-ci-cd-status.sh
           ./.github/scripts/check-ci-cd-status.sh --branch=dev
 
-      - name: Merge dev to main
+      - name: Create PR to promote dev to main
         env:
-          AUTO_RESOLVE_FILES: "CHANGELOG.md,package.json,.github/workflows/cd.yml"
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          chmod +x .github/scripts/merge-with-auto-resolve.sh
-          ./.github/scripts/merge-with-auto-resolve.sh --source=dev --target=main --files="$AUTO_RESOLVE_FILES"
+          # Check if PR already exists
+          EXISTING_PR=$(gh pr list --base main --head dev --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for dev -> main"
+            echo "URL: https://github.com/${{ github.repository }}/pull/$EXISTING_PR"
+            exit 0
+          fi
+
+          # Get latest release version from dev
+          LATEST_TAG=$(git describe --tags --abbrev=0 origin/dev 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            PR_TITLE="chore: promote dev to main"
+          else
+            PR_TITLE="chore: promote dev to main ($LATEST_TAG)"
+          fi
+
+          # Create PR
+          gh pr create \
+            --base main \
+            --head dev \
+            --title "$PR_TITLE" \
+            --body "## Promote dev to main
+
+          This PR promotes the latest changes from \`dev\` branch to \`main\`.
+
+          ### Pre-checks passed:
+          - ✅ CI workflow passed on dev
+          - ✅ CD workflow passed on dev
+
+          ### Latest beta version: $LATEST_TAG"
 
   release:
     name: Semantic Release

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bin/
 .env
 logs_*/
 *.log
+.jules/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-05-22 - Information Leakage in Error Objects
-**Vulnerability:** `NotionMCPError` was including raw error objects in its `details` property, which were then exposed to the client. This leaked sensitive information like Authorization headers from Axios errors.
-**Learning:** Generic error handling that blindly wraps unknown errors is a common source of leaks. Always sanitize or whitelist properties when enhancing errors for client consumption.
-**Prevention:** Use a `sanitizeErrorDetails` helper that whitelists safe properties (message, code, status) and strips everything else before attaching to custom error objects.


### PR DESCRIPTION
## Changes
- Change `promote-to-stable` job to create PR instead of merging directly
- Add `.jules/` to `.gitignore`
- Remove `.jules/sentinel.md` (Jules agent metadata)

## Why
Per repo-structure skill: all changes to dev/main must go through PR.
Only semantic-release commits are allowed to bypass via Repository admin bypass.