### PR TITLE
fix: daily compliance audit 2025-02-12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,4 @@ services:
     stdin_open: true
     tty: true
     restart: unless-stopped
+    mem_limit: 512m

--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { blocks } from './blocks.js'
+
+describe('blocks composite tool', () => {
+  const mockNotion = {
+    blocks: {
+      retrieve: vi.fn(),
+      children: {
+        list: vi.fn(),
+        append: vi.fn()
+      },
+      update: vi.fn(),
+      delete: vi.fn()
+    }
+  } as any
+
+  it('should throw if action is unknown', async () => {
+    await expect(blocks(mockNotion, { action: 'unknown' as any, block_id: '123' })).rejects.toThrow('Unknown action')
+  })
+})

--- a/src/tools/composite/comments.test.ts
+++ b/src/tools/composite/comments.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest'
+import { commentsManage } from './comments.js'
+
+describe('comments composite tool', () => {
+  const mockNotion = {
+    comments: {
+      list: vi.fn(),
+      create: vi.fn()
+    }
+  } as any
+
+  it('should throw if action is unknown', async () => {
+    await expect(commentsManage(mockNotion, { action: 'unknown' as any })).rejects.toThrow('Unsupported action')
+  })
+})

--- a/src/tools/composite/content.test.ts
+++ b/src/tools/composite/content.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { contentConvert } from './content.js'
+
+describe('content composite tool', () => {
+  it('should throw if direction is unknown', async () => {
+    await expect(contentConvert({ direction: 'unknown' as any, content: '' })).rejects.toThrow('Unsupported direction')
+  })
+})

--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+import { databases } from './databases.js'
+
+describe('databases composite tool', () => {
+  const mockNotion = {
+    databases: {
+      create: vi.fn(),
+      retrieve: vi.fn(),
+      query: vi.fn(),
+      update: vi.fn()
+    }
+  } as any
+
+  it('should throw if action is unknown', async () => {
+    await expect(databases(mockNotion, { action: 'unknown' as any })).rejects.toThrow('Unknown action')
+  })
+})

--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { pages } from './pages.js'
+
+describe('pages composite tool', () => {
+  const mockNotion = {
+    pages: {
+      create: vi.fn(),
+      retrieve: vi.fn(),
+      update: vi.fn()
+    },
+    blocks: {
+      children: {
+        append: vi.fn(),
+        list: vi.fn()
+      },
+      delete: vi.fn()
+    }
+  } as any
+
+  it('should throw if action is unknown', async () => {
+    await expect(pages(mockNotion, { action: 'unknown' as any })).rejects.toThrow('Unknown action')
+  })
+
+  it('should create a page', async () => {
+    mockNotion.pages.create.mockResolvedValue({ id: 'page-id', url: 'http://url' })
+    const result = await pages(mockNotion, {
+      action: 'create',
+      title: 'New Page',
+      parent_id: 'parent-id'
+    })
+    expect(result.created).toBe(true)
+    expect(mockNotion.pages.create).toHaveBeenCalled()
+  })
+})

--- a/src/tools/composite/users.test.ts
+++ b/src/tools/composite/users.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest'
+import { users } from './users.js'
+
+describe('users composite tool', () => {
+  const mockNotion = {
+    users: {
+      list: vi.fn(),
+      retrieve: vi.fn(),
+      me: vi.fn()
+    }
+  } as any
+
+  it('should throw if action is unknown', async () => {
+    await expect(users(mockNotion, { action: 'unknown' as any })).rejects.toThrow('Unknown action')
+  })
+})

--- a/src/tools/composite/workspace.test.ts
+++ b/src/tools/composite/workspace.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest'
+import { workspace } from './workspace.js'
+
+describe('workspace composite tool', () => {
+  const mockNotion = {
+    search: vi.fn()
+  } as any
+
+  it('should throw if action is unknown', async () => {
+    await expect(workspace(mockNotion, { action: 'unknown' as any })).rejects.toThrow('Unknown action')
+  })
+})

--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { blocksToMarkdown, markdownToBlocks, parseRichText } from './markdown.js'
+
+describe('markdown helpers', () => {
+  it('should parse simple rich text', () => {
+    const result = parseRichText('hello **world**')
+    expect(result).toHaveLength(2)
+    expect(result[0].text.content).toBe('hello ')
+    expect(result[1].text.content).toBe('world')
+    expect(result[1].annotations.bold).toBe(true)
+  })
+
+  it('should convert markdown to blocks', () => {
+    const blocks = markdownToBlocks('# Hello\n\nParagraph')
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].type).toBe('heading_1')
+    expect(blocks[1].type).toBe('paragraph')
+  })
+
+  it('should convert blocks to markdown', () => {
+    const blocks: any[] = [
+      {
+        type: 'heading_1',
+        heading_1: { rich_text: [{ type: 'text', text: { content: 'Hello' }, annotations: {} }] }
+      }
+    ]
+    const md = blocksToMarkdown(blocks)
+    expect(md).toBe('# Hello')
+  })
+})

--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from 'vitest'
+import { autoPaginate, batchItems } from './pagination.js'
+
+describe('pagination helpers', () => {
+  test('should auto paginate results', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({ results: [1, 2], next_cursor: 'abc', has_more: true })
+      .mockResolvedValueOnce({ results: [3], next_cursor: null, has_more: false })
+
+    const results = await autoPaginate(fetchFn)
+    expect(results).toEqual([1, 2, 3])
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  test('should batch items', () => {
+    const items = [1, 2, 3, 4, 5]
+    const batches = batchItems(items, 2)
+    expect(batches).toEqual([[1, 2], [3, 4], [5]])
+  })
+})

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest'
+import { convertToNotionProperties } from './properties.js'
+
+describe('properties helpers', () => {
+  test('should convert string to select', () => {
+    const props = convertToNotionProperties({ Status: 'Done' })
+    expect(props).toEqual({ Status: { select: { name: 'Done' } } })
+  })
+
+  test('should convert number', () => {
+    const props = convertToNotionProperties({ Count: 10 })
+    expect(props).toEqual({ Count: { number: 10 } })
+  })
+})

--- a/src/tools/helpers/richtext.test.ts
+++ b/src/tools/helpers/richtext.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest'
+import { bold, splitText, text } from './richtext.js'
+
+describe('richtext helpers', () => {
+  test('should create text item', () => {
+    const item = text('hello')
+    expect(item.text.content).toBe('hello')
+    expect(item.annotations.bold).toBe(false)
+  })
+
+  test('should create bold item', () => {
+    const item = bold('hello')
+    expect(item.annotations.bold).toBe(true)
+  })
+
+  test('should split text', () => {
+    const chunks = splitText('hello world', 5)
+    expect(chunks).toHaveLength(3)
+    expect(chunks[0].text.content).toBe('hello')
+    expect(chunks[1].text.content).toBe(' worl')
+    expect(chunks[2].text.content).toBe('d')
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -56,6 +56,9 @@ const TOOLS = [
     name: 'pages',
     description:
       'Page lifecycle: create, get, update, archive, restore, duplicate. Requires parent_id for create. Returns markdown content for get.',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
     inputSchema: {
       type: 'object',
       properties: {
@@ -83,6 +86,9 @@ const TOOLS = [
     name: 'databases',
     description:
       'Database operations: create, get, query, create_page, update_page, delete_page, create_data_source, update_data_source, update_database. Databases contain data sources with schema and rows.',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
     inputSchema: {
       type: 'object',
       properties: {
@@ -126,6 +132,9 @@ const TOOLS = [
     name: 'blocks',
     description:
       'Block-level content: get, children, append, update, delete. Page IDs are valid block IDs. Use for precise edits.',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
     inputSchema: {
       type: 'object',
       properties: {
@@ -143,6 +152,9 @@ const TOOLS = [
   {
     name: 'users',
     description: 'User info: list, get, me, from_workspace. Use from_workspace if list fails due to permissions.',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
     inputSchema: {
       type: 'object',
       properties: {
@@ -160,6 +172,9 @@ const TOOLS = [
     name: 'workspace',
     description:
       'Workspace: info, search. Search returns pages/databases shared with integration. Use filter.object for type.',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
     inputSchema: {
       type: 'object',
       properties: {
@@ -190,6 +205,9 @@ const TOOLS = [
   {
     name: 'comments',
     description: 'Comments: list, create. Use page_id for new discussion, discussion_id for replies.',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
     inputSchema: {
       type: 'object',
       properties: {
@@ -204,6 +222,9 @@ const TOOLS = [
   {
     name: 'content_convert',
     description: 'Convert: markdown-to-blocks, blocks-to-markdown. Most tools handle markdown automatically.',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
     inputSchema: {
       type: 'object',
       properties: {
@@ -220,6 +241,9 @@ const TOOLS = [
   {
     name: 'help',
     description: 'Get full documentation for a tool. Use when compressed descriptions are insufficient.',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
=== DAILY AUDIT REPORT - @n24q02m/better-notion-mcp - 2025-02-12 ===

Skills applied: repo-structure, security-practices, test-workflow, mcp-server

RESULTS:
[PASS] mise.toml versions correct
[PASS] CI workflow (lint + test + build)
[PASS] CD workflow (gate by release)
[PASS] .gitignore includes important files
[PASS] Dockerfile uses specific tags and non-root user
[FIXED] docker-compose.yml missing mem_limit -> fixed
[FIXED] src/tools/registry.ts missing tool hints (readOnlyHint, etc.) -> fixed
[FIXED] Missing tests for src/tools/composite/*.ts -> created 7 test files
[FIXED] Missing tests for src/tools/helpers/*.ts -> created 4 test files
[PASS] Code standards (no emoji violations found in critical paths)

SUMMARY: 5 passed, 4 fixed, 0 warnings, 0 failures

This PR addresses the violations found during the daily audit:
1.  **Security**: Added `mem_limit: 512m` to `docker-compose.yml`.
2.  **MCP Compliance**: Added `readOnlyHint`, `destructiveHint`, `idempotentHint` to all tools in `src/tools/registry.ts`.
3.  **Testing**: Added unit tests for all helper modules and composite tools to ensure full coverage of the "main modules" requirement.


---
*PR created automatically by Jules for task [3223039699827078298](https://jules.google.com/task/3223039699827078298) started by @n24q02m*