### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in help tool

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,74 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { registerTools } from './registry.js'
+import { readFileSync } from 'node:fs'
+
+// Mock fs to track calls
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    readFileSync: vi.fn().mockImplementation((path, encoding) => {
+        if (path.includes('README.md')) {
+            return 'SECRET CONTENT'
+        }
+        throw new Error(`File not found: ${path}`)
+    })
+  }
+})
+
+describe('Security: Path Traversal in help tool', () => {
+  let server: Server
+  let requestHandler: any
+
+  beforeEach(() => {
+    server = new Server(
+      { name: 'test-server', version: '1.0.0' },
+      { capabilities: { tools: {} } }
+    )
+
+    // Mock setRequestHandler to capture the handler
+    server.setRequestHandler = vi.fn().mockImplementation((schema, handler) => {
+      if (schema === CallToolRequestSchema) {
+        requestHandler = handler
+      }
+    })
+
+    registerTools(server, 'fake-token')
+  })
+
+  it('should prevent path traversal and return error for invalid tool name', async () => {
+    const toolName = '../README'
+
+    const response = await requestHandler({
+      params: {
+        name: 'help',
+        arguments: { tool_name: toolName }
+      }
+    })
+
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('Invalid tool name')
+    expect(readFileSync).not.toHaveBeenCalled()
+  })
+
+  it('should allow valid tool names', async () => {
+    const toolName = 'pages'
+
+    // We need to mock readFileSync to succeed for valid tools
+    vi.mocked(readFileSync).mockReturnValueOnce('Pages documentation')
+
+    const response = await requestHandler({
+      params: {
+        name: 'help',
+        arguments: { tool_name: toolName }
+      }
+    })
+
+    expect(response.isError).toBeUndefined()
+    expect(response.content[0].text).toContain('Pages documentation')
+    expect(readFileSync).toHaveBeenCalled()
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -372,6 +372,24 @@ export function registerTools(server: Server, notionToken: string) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
+          const VALID_DOCS = [
+            'pages',
+            'databases',
+            'blocks',
+            'users',
+            'workspace',
+            'comments',
+            'content_convert'
+          ]
+
+          if (!VALID_DOCS.includes(toolName)) {
+            throw new NotionMCPError(
+              `Invalid tool name: ${toolName}`,
+              'INVALID_ARGUMENT',
+              `Available: ${VALID_DOCS.join(', ')}`
+            )
+          }
+
           const docFile = `${toolName}.md`
           try {
             const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')


### PR DESCRIPTION
This PR fixes a path traversal vulnerability in the `help` tool. It adds input validation to ensure only allowed tool names are processed, preventing arbitrary file access.

Changes:
- Modified `src/tools/registry.ts` to validate `tool_name`.
- Added `src/tools/registry.test.ts` to test the fix and prevent regression.
- Added critical learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14491757493519296684](https://jules.google.com/task/14491757493519296684) started by @n24q02m*