### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in help tool

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { registerTools } from './registry.js'
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+
+// Mock dependencies
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
+  return {
+    Server: class {
+      handlers = new Map()
+      setRequestHandler(schema: any, handler: any) {
+        this.handlers.set(schema, handler)
+      }
+      connect() {}
+    }
+  }
+})
+
+vi.mock('@notionhq/client', () => ({
+  Client: class {
+    // Removed useless constructor
+  }
+}))
+
+// Mock fs to avoid reading real files
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn((path: string) => {
+    if (path.includes('pages.md')) return '# Pages Docs'
+    throw new Error(`File not found: ${path}`)
+  })
+}))
+
+describe('registerTools Security', () => {
+  let server: any
+  let callToolHandler: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // @ts-expect-error - Mocked Server constructor doesn't match strict type
+    server = new Server()
+
+    // Call registerTools
+    registerTools(server, 'fake-token')
+
+    // Get the handler for CallToolRequestSchema
+    // We need to access the handlers map from our mock
+    // @ts-expect-error - handlers property exists on our mock but not on real Server type
+    callToolHandler = server.handlers.get(CallToolRequestSchema)
+  })
+
+  it('should prevent path traversal in help tool', async () => {
+    const request = {
+      params: {
+        name: 'help',
+        arguments: { tool_name: '../../README' }
+      }
+    }
+
+    const response = await callToolHandler(request)
+
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('Invalid tool name')
+    expect(response.content[0].text).toContain('../../README')
+  })
+
+  it('should allow valid tool names', async () => {
+    // We mocked readFileSync to return '# Pages Docs' for 'pages.md'
+    const request = {
+      params: {
+        name: 'help',
+        arguments: { tool_name: 'pages' }
+      }
+    }
+
+    const response = await callToolHandler(request)
+
+    expect(response.content[0].text).toContain('# Pages Docs')
+  })
+
+  it('should block unknown tool names', async () => {
+    const request = {
+      params: {
+        name: 'help',
+        arguments: { tool_name: 'unknown_tool' }
+      }
+    }
+
+    const response = await callToolHandler(request)
+
+    expect(response.isError).toBe(true)
+    expect(response.content[0].text).toContain('Invalid tool name')
+    expect(response.content[0].text).toContain('unknown_tool')
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -375,6 +375,16 @@ export function registerTools(server: Server, notionToken: string) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
+          const validTools = ['pages', 'databases', 'blocks', 'users', 'workspace', 'comments', 'content_convert']
+
+          if (!validTools.includes(toolName)) {
+            throw new NotionMCPError(
+              `Invalid tool name: ${toolName}`,
+              'INVALID_TOOL_NAME',
+              `Available tools: ${validTools.join(', ')}`
+            )
+          }
+
           const docFile = `${toolName}.md`
           try {
             const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: The `help` tool accepted arbitrary `tool_name` input, which was used to construct a file path (`${tool_name}.md`) without validation. This allowed an attacker to read any `.md` file on the system (e.g., `../../README.md`).
* 🎯 Impact: Information disclosure. An attacker could read sensitive documentation or configuration files if they end in `.md`.
* 🔧 Fix: Implemented a strict allowlist for `tool_name` in `src/tools/registry.ts`. Only known tool names are accepted.
* ✅ Verification: Added a new test suite `src/tools/registry.test.ts` that explicitly tests path traversal attempts and ensures they are blocked. Ran `pnpm test` and all tests passed.

---
*PR created automatically by Jules for task [9178744535745373433](https://jules.google.com/task/9178744535745373433) started by @n24q02m*