### PR TITLE
🧹 Code Health: Remove orphaned JSDoc in pages.ts

### DIFF
--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -298,10 +298,6 @@ async function archivePage(notion: Client, input: PagesInput): Promise<any> {
 }
 
 /**
- * Move page to new parent
- * Maps to: PATCH /v1/pages/{id}
- */
-/**
  * Duplicate page
  * Maps to: GET /v1/pages/{id} + POST /v1/pages + GET/PATCH /v1/blocks
  */


### PR DESCRIPTION
🎯 **What:** Removed an orphaned JSDoc comment ("Move page to new parent") in `src/tools/composite/pages.ts`.

💡 **Why:** The comment described functionality that is not implemented in the subsequent function (`duplicatePage`), which has its own correct JSDoc. Removing it clears up confusion and improves code readability.

✅ **Verification:**
- Ran `pnpm check` (linting + type checking) - PASSED
- Ran `pnpm test` (unit tests) - PASSED

✨ **Result:** The `duplicatePage` function now has a single, correct JSDoc comment.

---
*PR created automatically by Jules for task [4250101337737478195](https://jules.google.com/task/4250101337737478195) started by @n24q02m*