### PR TITLE
🧹 Remove duplicate extractPlainText function

### DIFF
--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -270,13 +270,6 @@ function richTextToMarkdown(richText: RichText[]): string {
     .join('')
 }
 
-/**
- * Extract plain text from rich text
- */
-export function extractPlainText(richText: RichText[]): string {
-  return richText.map((rt) => rt.text.content).join('')
-}
-
 // Helper creators
 function createRichText(
   content: string,


### PR DESCRIPTION
Removed duplicate/unused function `extractPlainText` from `src/tools/helpers/markdown.ts`.

Details:
- Removed `extractPlainText` from `src/tools/helpers/markdown.ts`.
- Verified that the function was unused and not imported by any other module.
- Ran `pnpm check:fix` to ensure formatting and types are correct.
- Ran `pnpm test` to verify no regressions.


---
*PR created automatically by Jules for task [11968287244269867827](https://jules.google.com/task/11968287244269867827) started by @n24q02m*