### PR TITLE
🧹 [Code Health] Remove unused `fetchPage` wrapper

### DIFF
--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -42,17 +42,6 @@ export async function autoPaginate<T>(
 }
 
 /**
- * Fetch single page with cursor
- */
-export async function fetchPage<T>(
-  fetchFn: (cursor?: string, pageSize?: number) => Promise<PaginatedResponse<T>>,
-  cursor?: string,
-  pageSize: number = 100
-): Promise<PaginatedResponse<T>> {
-  return await fetchFn(cursor, pageSize)
-}
-
-/**
  * Create cursor handler for manual pagination
  */
 export function createCursorHandler() {


### PR DESCRIPTION
- Removed `fetchPage` function from `src/tools/helpers/pagination.ts` as it was a redundant wrapper around `fetchFn` and was not used anywhere in the codebase.
- Verified removal with `grep` and ensured code quality with `pnpm check`.

---
*PR created automatically by Jules for task [11425875717098406020](https://jules.google.com/task/11425875717098406020) started by @n24q02m*