### PR TITLE
🧹 Remove unused suggestFixes function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,6 @@ import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 - Custom `NotionMCPError` class: `message`, `code`, `suggestion`, `details`
 - `withErrorHandling()` HOF wrapper for all composite tool functions
 - `retryWithBackoff()` for transient failures
-- `suggestFixes()` for AI-readable error recovery hints
 - Error details sanitized to prevent secret leakage
 
 ### Biome Lint Rules

--- a/remove_suggest_fixes.py
+++ b/remove_suggest_fixes.py
@@ -1,0 +1,57 @@
+import re
+
+file_path = 'src/tools/helpers/errors.ts'
+
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Pattern to remove the function suggestFixes
+# It handles the function body including nested braces if balanced, but regex is hard for nested structures.
+# Instead, since we know the structure is specific here, we can use a simpler approach or just exact string replacement if we had the exact content.
+
+# Let's try to identify the start and end indices.
+start_marker = 'export function suggestFixes(error: NotionMCPError): string[] {'
+end_marker = 'export function withErrorHandling'
+
+start_index = content.find(start_marker)
+if start_index == -1:
+    print(f"Could not find start marker: {start_marker}")
+    exit(1)
+
+# Find the start of the next function
+end_index = content.find(end_marker, start_index)
+if end_index == -1:
+    print(f"Could not find end marker: {end_marker}")
+    exit(1)
+
+# We want to remove everything from start_index up to (but not including) end_index,
+# but we should keep the JSDoc for the next function if it exists.
+# The JSDoc for withErrorHandling starts before 'export function withErrorHandling'.
+
+# Let's look backwards from end_index to find the start of the JSDoc.
+# The JSDoc likely starts with /** and ends before end_marker.
+# But we are removing suggestFixes, so we should remove up to the start of the *next* function's documentation.
+
+# Let's print the context around the end_index to be sure.
+print(f"Context before end_marker:\n{content[end_index-100:end_index]}")
+
+# Actually, let's just find the closing brace of suggestFixes.
+# It ends with 'return suggestions\n}'
+function_end_pattern = r'return suggestions\s*\n}'
+match = re.search(function_end_pattern, content[start_index:])
+if not match:
+    print("Could not find function end")
+    exit(1)
+
+function_end_index = start_index + match.end()
+
+# Now we have the range to delete: start_index to function_end_index
+new_content = content[:start_index] + content[function_end_index:]
+
+# Clean up extra newlines if necessary
+# new_content = re.sub(r'\n{3,}', '\n\n', new_content)
+
+with open(file_path, 'w') as f:
+    f.write(new_content)
+
+print("Successfully removed suggestFixes function.")

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -167,52 +167,6 @@ export function aiReadableMessage(error: NotionMCPError): string {
 }
 
 /**
- * Suggest fixes based on error
- */
-export function suggestFixes(error: NotionMCPError): string[] {
-  const suggestions: string[] = []
-
-  switch (error.code) {
-    case 'UNAUTHORIZED':
-      suggestions.push('Check that NOTION_TOKEN is set in your environment')
-      suggestions.push('Verify token at https://www.notion.so/my-integrations')
-      suggestions.push('Create a new integration token if needed')
-      break
-
-    case 'RESTRICTED_RESOURCE':
-      suggestions.push('Open the page/database in Notion')
-      suggestions.push('Click "..." menu → Add connections → Select your integration')
-      suggestions.push('Grant access to parent pages if needed')
-      break
-
-    case 'NOT_FOUND':
-      suggestions.push('Verify the page/database ID is correct')
-      suggestions.push('Check that the resource was not deleted')
-      suggestions.push('Ensure you have access permissions')
-      break
-
-    case 'VALIDATION_ERROR':
-      suggestions.push('Check parameter types and formats')
-      suggestions.push('Review required vs optional parameters')
-      suggestions.push('Verify property names match database schema')
-      break
-
-    case 'RATE_LIMITED':
-      suggestions.push('Reduce request frequency')
-      suggestions.push('Implement exponential backoff retry logic')
-      suggestions.push('Batch multiple operations together')
-      break
-
-    default:
-      suggestions.push('Check Notion API status at https://status.notion.so')
-      suggestions.push('Review request parameters')
-      suggestions.push('Try again in a few moments')
-  }
-
-  return suggestions
-}
-
-/**
  * Wrap async function with error handling
  */
 export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(


### PR DESCRIPTION
🎯 **What:** Removed the unused `suggestFixes` function from `src/tools/helpers/errors.ts` and its reference in `AGENTS.md`.

💡 **Why:** The function was unused and duplicated logic found in `NotionMCPError` and `handleNotionError`. Removing it simplifies the codebase and prevents confusion.

✅ **Verification:**
- Verified `suggestFixes` is not used anywhere else in the codebase.
- Ran `pnpm test` (passed).
- Ran `pnpm check:fix` (passed).

✨ **Result:** Cleaner codebase with no unused code.

---
*PR created automatically by Jules for task [8686539724081502328](https://jules.google.com/task/8686539724081502328) started by @n24q02m*