### PR TITLE
🧹 Fix fragile block update logic in blocks tool

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { blocks } from './blocks.js'
+
+describe('blocks tool', () => {
+  const mockNotion = {
+    blocks: {
+      retrieve: vi.fn(),
+      children: {
+        list: vi.fn(),
+        append: vi.fn()
+      },
+      update: vi.fn(),
+      delete: vi.fn()
+    }
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('update action', () => {
+    it('should correctly update a block type when markdown suggests a change', async () => {
+      // Mock existing block as a paragraph
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-id',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [{ type: 'text', text: { content: 'Original text' } }]
+        }
+      })
+
+      mockNotion.blocks.update.mockResolvedValue({
+        id: 'block-id',
+        type: 'heading_1',
+        heading_1: {
+          rich_text: [{ type: 'text', text: { content: 'New Heading' } }]
+        }
+      })
+
+      await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-id',
+        content: '# New Heading'
+      })
+
+      // The key fix: verify that the update payload uses the NEW type (heading_1), not the old type (paragraph)
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-id',
+          heading_1: expect.objectContaining({
+            rich_text: expect.arrayContaining([
+              expect.objectContaining({
+                text: expect.objectContaining({ content: 'New Heading' })
+              })
+            ])
+          })
+        })
+      )
+
+      expect(mockNotion.blocks.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          paragraph: expect.anything()
+        })
+      )
+    })
+
+    it('should throw error for unsupported block types', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-id',
+        type: 'paragraph'
+      })
+
+      // Divider is not in the supported list for update
+      await expect(
+        blocks(mockNotion as any, {
+          action: 'update',
+          block_id: 'block-id',
+          content: '---'
+        })
+      ).rejects.toThrow(/Markdown parsed to unsupported type/)
+    })
+  })
+})


### PR DESCRIPTION
🎯 **What:**
Fixed the fragile block update logic in `src/tools/composite/blocks.ts`.

💡 **Why:**
The previous implementation assumed the block type would remain the same during an update. If the provided markdown content parsed to a different block type (e.g., updating a Paragraph with a Heading), the code would fail to find the correct content property, resulting in an empty block update. This refactor ensures the update payload is constructed using the *target* block type derived from the markdown.

✅ **Verification:**
- Added a new test file `src/tools/composite/blocks.test.ts` that specifically tests:
    - Updating a block where the new content implies a different block type (Paragraph -> Heading).
    - Updating a block with an unsupported markdown type (e.g., Divider), which now correctly throws a validation error.
- Verified that existing tests (if any) pass.
- Verified linting and formatting with `pnpm check`.

✨ **Result:**
The `blocks` tool `update` action is now robust and correctly handles block type conversions supported by the Notion API (within the tool's allowed set of text blocks).

---
*PR created automatically by Jules for task [3536467120101719489](https://jules.google.com/task/3536467120101719489) started by @n24q02m*