### PR TITLE
🔒 Fix potential infinite loop in pagination helper

### DIFF
--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { autoPaginate } from './pagination.js'
+
+describe('Pagination Helper Security', () => {
+  it('should stop at safety limit to prevent infinite loops', async () => {
+    let calls = 0
+    const fetchFn = vi.fn().mockImplementation(async () => {
+      calls++
+      if (calls > 1010) {
+        throw new Error('Test: Infinite loop detected')
+      }
+      return {
+        results: ['item'],
+        next_cursor: 'next_cursor',
+        has_more: true
+      }
+    })
+
+    // This should resolve successfully if the safety limit works.
+    // Without the limit, it will loop until the mock throws, causing rejection.
+    await expect(autoPaginate(fetchFn)).resolves.toBeDefined()
+
+    // Confirm it stopped at the safety limit (assuming 1000)
+    expect(calls).toBeLessThanOrEqual(1001)
+  })
+
+  it('should correctly fetch multiple pages', async () => {
+    const pages = [
+      { results: ['a'], next_cursor: 'c1', has_more: true },
+      { results: ['b'], next_cursor: 'c2', has_more: true },
+      { results: ['c'], next_cursor: null, has_more: false }
+    ]
+    let index = 0
+    const fetchFn = vi.fn().mockImplementation(async (_cursor) => {
+      const page = pages[index]
+      index++
+      return page
+    })
+
+    const results = await autoPaginate(fetchFn)
+
+    expect(results).toEqual(['a', 'b', 'c'])
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -14,6 +14,8 @@ export interface PaginationOptions {
   pageSize?: number // Items per page (default: 100)
 }
 
+const SAFETY_LIMIT = 1000 // Prevent infinite loops
+
 /**
  * Fetch all pages automatically
  */
@@ -34,6 +36,12 @@ export async function autoPaginate<T>(
 
     // Stop if max pages reached
     if (maxPages > 0 && pageCount >= maxPages) {
+      break
+    }
+
+    // Safety break
+    if (pageCount >= SAFETY_LIMIT) {
+      console.warn(`[AutoPaginate] Safety limit of ${SAFETY_LIMIT} pages reached. Stopping pagination.`)
       break
     }
   } while (cursor !== null)


### PR DESCRIPTION
* 🎯 **What:** Implemented a safety limit of 1000 pages in `autoPaginate`.
* ⚠️ **Risk:** A runaway API response or infinite `next_cursor` could cause a Denial of Service (DoS) by looping indefinitely.
* 🛡️ **Solution:** Added a `SAFETY_LIMIT` constant (1000) and a check within the pagination loop to break if the limit is exceeded. Added unit tests to verify this behavior and ensure normal pagination still works.

---
*PR created automatically by Jules for task [7332093204815910329](https://jules.google.com/task/7332093204815910329) started by @n24q02m*