### PR TITLE
⚡ Improve processBatches concurrency model and defaults

### DIFF
--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { processBatches } from './pagination.js'
+
+describe('pagination helper', () => {
+  describe('processBatches', () => {
+    it('should process all items', async () => {
+      const items = [1, 2, 3, 4, 5]
+      const results = await processBatches(items, async (item) => item * 2)
+      expect(results).toEqual([2, 4, 6, 8, 10])
+    })
+
+    it('should respect default concurrency (3)', async () => {
+      let active = 0
+      let maxActive = 0
+      const items = Array.from({ length: 10 }, (_, i) => i)
+
+      await processBatches(items, async () => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        active--
+        return true
+      })
+
+      // Default batchSize=1, concurrency=3 -> limit=3
+      expect(maxActive).toBeLessThanOrEqual(3)
+    })
+
+    it('should respect explicit concurrency', async () => {
+      let active = 0
+      let maxActive = 0
+      const items = Array.from({ length: 20 }, (_, i) => i)
+
+      await processBatches(
+        items,
+        async () => {
+          active++
+          maxActive = Math.max(maxActive, active)
+          await new Promise((resolve) => setTimeout(resolve, 10))
+          active--
+          return true
+        },
+        { batchSize: 2, concurrency: 5 } // 2 * 5 = 10
+      )
+
+      expect(maxActive).toBeLessThanOrEqual(10)
+      // It should reach reasonably high concurrency if items are processed fast enough,
+      // but strictly <= 10.
+    })
+
+    it('should handle errors correctly (fail fast)', async () => {
+      const items = [1, 2, 3]
+      const error = new Error('Test Error')
+
+      await expect(
+        processBatches(items, async (item) => {
+          if (item === 2) throw error
+          return item
+        })
+      ).rejects.toThrow(error)
+    })
+
+    it('should handle empty items', async () => {
+      const results = await processBatches([], async (item) => item)
+      expect(results).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
💡 **What:**
- Refactored `processBatches` in `src/tools/helpers/pagination.ts` to use a sliding window concurrency model (using a `Set` of active promises) instead of processing items in sequential chunks (batches of batches).
- Changed the default `batchSize` from `10` to `1` in `processBatches`. The default `concurrency` remains `3`.
- The effective concurrency limit is now calculated as `batchSize * concurrency`.
- Added a new unit test file `src/tools/helpers/pagination.test.ts` to verify concurrency limits and error handling.

🎯 **Why:**
- **Aggressive Concurrency Defaults:** The previous default `batchSize=10` and `concurrency=3` resulted in `30` concurrent requests by default. This is too aggressive for the Notion API (which typically tolerates ~3 requests/second) and can lead to rate limiting (429 errors). Changing the default `batchSize` to `1` reduces the default concurrency to `3` (1 * 3), which is safe.
- **Performance & Efficiency:** The previous implementation waited for an entire batch of batches to finish before starting the next set (generation-based). The new sliding window implementation starts a new item as soon as one finishes, maximizing throughput within the concurrency limit and eliminating idle time caused by slow outlier requests.
- **Backward Compatibility:** By calculating the limit as `batchSize * concurrency`, existing calls that explicitly set `batchSize` (e.g., `duplicatePage` with `{ batchSize: 5, concurrency: 3 }`) will still achieve the intended concurrency (15), ensuring no regressions for tuned heavy operations.

📊 **Measured Improvement:**
- **Baseline (Old Defaults):** Max Concurrency = 30.
- **New Defaults:** Max Concurrency = 3.
- **Explicit Config (`{ batchSize: 5, concurrency: 2 }`):** Max Concurrency = 10 (Preserved).
- **Efficiency:** The sliding window approach removes the "tail latency" effect of chunked processing, making the overall execution smoother and potentially faster for variable-latency tasks.

---
*PR created automatically by Jules for task [17418833822431998235](https://jules.google.com/task/17418833822431998235) started by @n24q02m*