### PR TITLE
🧹 Refactor docs path logic in registry.ts to be robust against execution context

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,26 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { describe, expect, it } from 'vitest'
+import { registerTools } from './registry.js'
+
+describe('registry', () => {
+  it('should resolve docs directory correctly and read resources', async () => {
+    const server = new Server({ name: 'test', version: '1.0' }, { capabilities: {} })
+
+    // Mock setRequestHandler
+    const handlers = new Map()
+    server.setRequestHandler = (schema: any, handler: any) => {
+      handlers.set(schema, handler)
+    }
+
+    registerTools(server, 'fake-token')
+
+    const readResourceHandler = handlers.get(ReadResourceRequestSchema)
+    expect(readResourceHandler).toBeDefined()
+
+    // Try to read a resource
+    const result = await readResourceHandler({ params: { uri: 'notion://docs/pages' } })
+    expect(result.contents[0].text).toBeDefined()
+    expect(result.contents[0].text.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Refactored `src/tools/registry.ts` to use a more robust mechanism for locating the documentation directory.

🎯 **What:** Replaced the fragile path detection logic that relied on checking if `__dirname` ends with 'bin'.
💡 **Why:** The previous implementation was brittle and could break if the directory structure changed or if the code was run in different environments (e.g., tests vs bundled CLI). The new implementation checks multiple potential locations for documentation files and selects the valid one.
✅ **Verification:**
- Added a new test `src/tools/registry.test.ts` that verifies `getDocsDir` works correctly.
- Verified that the bundled CLI builds and starts correctly using `pnpm build && timeout 2s node bin/cli.mjs`.
- Confirmed that linting passes with `pnpm check:fix`.
✨ **Result:** The codebase is now more maintainable and less prone to breakage due to environment changes.

---
*PR created automatically by Jules for task [3267990571030360064](https://jules.google.com/task/3267990571030360064) started by @n24q02m*