### PR TITLE
Refactor Duplicate Documentation Reading Logic

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { readDocumentation } from './registry.js'
+
+describe('Registry Documentation Helper', () => {
+  it('should read existing documentation file', () => {
+    // Use a known file like 'pages.md' which we verified exists in src/docs
+    const content = readDocumentation('pages.md')
+    expect(content).toBeTruthy()
+    expect(typeof content).toBe('string')
+    // Basic check to ensure we got some content
+    expect(content.length).toBeGreaterThan(10)
+  })
+
+  it('should throw error when file does not exist', () => {
+    expect(() => readDocumentation('does-not-exist-12345.md')).toThrow()
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -35,6 +35,13 @@ const DOCS_DIR = __dirname.endsWith('bin')
   : join(__dirname, '..', 'docs')
 
 /**
+ * Helper to read documentation file
+ */
+export function readDocumentation(filename: string): string {
+  return readFileSync(join(DOCS_DIR, filename), 'utf-8')
+}
+
+/**
  * Documentation resources for full tool details
  */
 const RESOURCES = [
@@ -327,7 +334,7 @@ export function registerTools(server: Server, notionToken: string) {
       )
     }
 
-    const content = readFileSync(join(DOCS_DIR, resource.file), 'utf-8')
+    const content = readDocumentation(resource.file)
     return {
       contents: [{ uri, mimeType: 'text/markdown', text: content }]
     }
@@ -377,7 +384,7 @@ export function registerTools(server: Server, notionToken: string) {
           const toolName = (args as { tool_name: string }).tool_name
           const docFile = `${toolName}.md`
           try {
-            const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')
+            const content = readDocumentation(docFile)
             result = { tool: toolName, documentation: content }
           } catch {
             throw new NotionMCPError(`Documentation not found for: ${toolName}`, 'DOC_NOT_FOUND', 'Check tool_name')


### PR DESCRIPTION
Extracted documentation reading logic into a helper function in src/tools/registry.ts to reduce duplication and improve maintainability. Added unit tests for the helper.

---
*PR created automatically by Jules for task [11564918776032535255](https://jules.google.com/task/11564918776032535255) started by @n24q02m*