### PR TITLE
🧹 Refactor: Consolidate RichTextItem interface

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { blocksToMarkdown, extractPlainText, markdownToBlocks, parseRichText } from './markdown.js'
+
+describe('markdown helpers', () => {
+  it('should parse simple markdown', () => {
+    const markdown = 'Hello **world**'
+    const blocks = markdownToBlocks(markdown)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('paragraph')
+    const richText = blocks[0].paragraph.rich_text
+    expect(richText).toHaveLength(2)
+    expect(richText[0].text.content).toBe('Hello ')
+    expect(richText[1].text.content).toBe('world')
+    expect(richText[1].annotations.bold).toBe(true)
+  })
+
+  it('should convert blocks to markdown', () => {
+    // Mock blocks
+    const blocks: any[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'text',
+              text: { content: 'Hello ', link: null },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            },
+            {
+              type: 'text',
+              text: { content: 'world', link: null },
+              annotations: {
+                bold: true,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+
+    const markdown = blocksToMarkdown(blocks)
+    expect(markdown).toBe('Hello **world**')
+  })
+
+  it('should parse rich text', () => {
+    const text = 'Hello **world**'
+    const richText = parseRichText(text)
+    expect(richText).toHaveLength(2)
+    expect(richText[0].text.content).toBe('Hello ')
+    expect(richText[1].text.content).toBe('world')
+    expect(richText[1].annotations.bold).toBe(true)
+  })
+
+  it('should extract plain text', () => {
+    const richText: any[] = [
+      {
+        type: 'text',
+        text: { content: 'Hello ', link: null },
+        annotations: {
+          bold: false,
+          italic: false,
+          strikethrough: false,
+          underline: false,
+          code: false,
+          color: 'default'
+        }
+      },
+      {
+        type: 'text',
+        text: { content: 'world', link: null },
+        annotations: {
+          bold: true,
+          italic: false,
+          strikethrough: false,
+          underline: false,
+          code: false,
+          color: 'default'
+        }
+      }
+    ]
+    expect(extractPlainText(richText)).toBe('Hello world')
+  })
+})

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -3,28 +3,14 @@
  * Converts markdown text to Notion block format
  */
 
+import { extractPlainText, type RichTextItem } from './richtext.js'
+
+export { extractPlainText }
+
 export interface NotionBlock {
   object: 'block'
   type: string
   [key: string]: any
-}
-
-export interface RichText {
-  type: 'text'
-  text: {
-    content: string
-    link?: { url: string } | null
-  }
-  annotations: {
-    bold: boolean
-    italic: boolean
-    strikethrough: boolean
-    underline: boolean
-    code: boolean
-    color: string
-  }
-  plain_text?: string
-  href?: string | null
 }
 
 /**
@@ -153,8 +139,8 @@ export function blocksToMarkdown(blocks: NotionBlock[]): string {
 /**
  * Parse inline markdown formatting to rich text
  */
-export function parseRichText(text: string): RichText[] {
-  const richText: RichText[] = []
+export function parseRichText(text: string): RichTextItem[] {
+  const richText: RichTextItem[] = []
   let current = ''
   let bold = false
   let italic = false
@@ -250,7 +236,7 @@ export function parseRichText(text: string): RichText[] {
 /**
  * Convert rich text array to plain markdown
  */
-function richTextToMarkdown(richText: RichText[]): string {
+function richTextToMarkdown(richText: RichTextItem[]): string {
   if (!richText || !Array.isArray(richText)) return ''
 
   return richText
@@ -270,18 +256,11 @@ function richTextToMarkdown(richText: RichText[]): string {
     .join('')
 }
 
-/**
- * Extract plain text from rich text
- */
-export function extractPlainText(richText: RichText[]): string {
-  return richText.map((rt) => rt.text.content).join('')
-}
-
 // Helper creators
 function createRichText(
   content: string,
   annotations: { bold?: boolean; italic?: boolean; code?: boolean; strikethrough?: boolean } = {}
-): RichText {
+): RichTextItem {
   return {
     type: 'text',
     text: { content, link: null },


### PR DESCRIPTION
**What:**
Consolidated `RichTextItem` interface definition by removing the duplicate `RichText` interface in `src/tools/helpers/markdown.ts` and importing `RichTextItem` from `src/tools/helpers/richtext.ts`. Also removed the duplicate `extractPlainText` function in `markdown.ts` and imported it from `richtext.ts`.

**Why:**
To improve maintainability and prevent divergence between the two definitions. Having a single source of truth for `RichTextItem` ensures consistency across the codebase.

**Verification:**
- Ran `pnpm check` to ensure no type or linting errors.
- Created `src/tools/helpers/markdown.test.ts` to verify `markdownToBlocks`, `blocksToMarkdown`, and `parseRichText` functionality.
- Verified that `properties.ts` was not negatively affected as it imports from `richtext.js`.
- Ran `pnpm test` and all tests passed.

**Result:**
The `RichText` interface is removed from `markdown.ts`, and `RichTextItem` is now consistently used. Code duplication is reduced.

---
*PR created automatically by Jules for task [15560114084986111278](https://jules.google.com/task/15560114084986111278) started by @n24q02m*