### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in help tool

### DIFF
--- a/src/tools/registry.security.test.ts
+++ b/src/tools/registry.security.test.ts
@@ -1,0 +1,38 @@
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerTools } from './registry.js'
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js')
+vi.mock('@notionhq/client')
+
+describe('Registry Security', () => {
+  let serverMock: any
+  let callToolHandler: any
+
+  beforeEach(() => {
+    serverMock = {
+      setRequestHandler: vi.fn((schema, handler) => {
+        if (schema === CallToolRequestSchema) {
+          callToolHandler = handler
+        }
+      })
+    }
+  })
+
+  it('should prevent path traversal in help tool', async () => {
+    registerTools(serverMock as unknown as Server, 'fake-token')
+
+    const maliciousArgs = {
+      name: 'help',
+      arguments: {
+        tool_name: '../../README'
+      }
+    }
+
+    const result = await callToolHandler({ params: maliciousArgs })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Unknown tool')
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -375,6 +375,16 @@ export function registerTools(server: Server, notionToken: string) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
+
+          const allowedTools = ['pages', 'databases', 'blocks', 'users', 'workspace', 'comments', 'content_convert']
+          if (!allowedTools.includes(toolName)) {
+            throw new NotionMCPError(
+              `Unknown tool: ${toolName}`,
+              'VALIDATION_ERROR',
+              `Available tools: ${allowedTools.join(', ')}`
+            )
+          }
+
           const docFile = `${toolName}.md`
           try {
             const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in help tool

🚨 Severity: HIGH
💡 Vulnerability: The `help` tool accepted a `tool_name` argument directly from user input and used it to construct a file path for `readFileSync` without validation, allowing path traversal (e.g., `../../README`).
🎯 Impact: Attackers could read arbitrary .md files on the file system (or potentially other files if the extension wasn't appended, though here it was appended).
🔧 Fix: Validated `tool_name` against a strict allowlist of known tools (`pages`, `databases`, `blocks`, etc.) before using it.
✅ Verification: Created `src/tools/registry.security.test.ts` which simulates the attack. It failed before the fix and passes after.


---
*PR created automatically by Jules for task [1305702468521377391](https://jules.google.com/task/1305702468521377391) started by @n24q02m*