### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in help tool

### DIFF
--- a/src/tools/registry.security.test.ts
+++ b/src/tools/registry.security.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { MockClient, readFileSyncMock } = vi.hoisted(() => ({
+  MockClient: vi.fn(),
+  readFileSyncMock: vi.fn()
+}))
+
+// Mock all composite tools
+vi.mock('./composite/pages.js', () => ({ pages: vi.fn() }))
+vi.mock('./composite/databases.js', () => ({ databases: vi.fn() }))
+vi.mock('./composite/blocks.js', () => ({ blocks: vi.fn() }))
+vi.mock('./composite/comments.js', () => ({ commentsManage: vi.fn() }))
+vi.mock('./composite/content.js', () => ({ contentConvert: vi.fn() }))
+vi.mock('./composite/users.js', () => ({ users: vi.fn() }))
+vi.mock('./composite/workspace.js', () => ({ workspace: vi.fn() }))
+vi.mock('./composite/file-uploads.js', () => ({ fileUploads: vi.fn() }))
+
+// Mock node:fs
+vi.mock('node:fs', () => ({
+  readFileSync: readFileSyncMock
+}))
+
+// Mock @notionhq/client
+vi.mock('@notionhq/client', () => ({
+  Client: MockClient
+}))
+
+import { registerTools } from './registry.js'
+
+function createMockServer() {
+  const handlers: ((...args: any[]) => any)[] = []
+  return {
+    setRequestHandler: vi.fn((_schema: any, handler: (...args: any[]) => any) => {
+      handlers.push(handler)
+    }),
+    getHandler: (index: number) => handlers[index]
+  }
+}
+
+describe('Security: Path Traversal in help tool', () => {
+  let server: ReturnType<typeof createMockServer>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readFileSyncMock.mockReturnValue('# Mock content')
+    server = createMockServer()
+    registerTools(server as any, 'test-token')
+  })
+
+  it('test_help_invalidToolName_returnsError', async () => {
+    const handler = server.getHandler(3)
+    const maliciousInput = '../../README'
+
+    const result = await handler({
+      params: {
+        name: 'help',
+        arguments: { tool_name: maliciousInput }
+      }
+    })
+
+    // Verify that readFileSync was NOT called
+    expect(readFileSyncMock).not.toHaveBeenCalled()
+
+    // Verify error response
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Invalid tool name')
+    expect(result.content[0].text).toContain('../../README')
+  })
+
+  it('test_help_validToolName_returnsDocumentation', async () => {
+    const handler = server.getHandler(3)
+    const validInput = 'pages'
+
+    const result = await handler({
+      params: {
+        name: 'help',
+        arguments: { tool_name: validInput }
+      }
+    })
+
+    // Verify successful read
+    expect(readFileSyncMock).toHaveBeenCalledWith(expect.stringContaining('pages.md'), 'utf-8')
+
+    // Verify success response
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.tool).toBe('pages')
+    expect(parsed.documentation).toBe('# Mock content')
+    expect(result.isError).toBeFalsy()
+  })
+})

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -36,6 +36,21 @@ const DOCS_DIR = __dirname.endsWith('bin')
   : join(__dirname, '..', 'docs')
 
 /**
+ * Allowed tools for help documentation
+ * Prevents path traversal by strictly allowing only known tool names
+ */
+const ALLOWED_DOC_TOOLS = [
+  'pages',
+  'databases',
+  'blocks',
+  'users',
+  'workspace',
+  'comments',
+  'content_convert',
+  'file_uploads'
+]
+
+/**
  * Documentation resources for full tool details
  */
 const RESOURCES = [
@@ -419,6 +434,15 @@ export function registerTools(server: Server, notionToken: string) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
+
+          if (!ALLOWED_DOC_TOOLS.includes(toolName)) {
+            throw new NotionMCPError(
+              `Invalid tool name: ${toolName}`,
+              'INVALID_TOOL',
+              `Allowed: ${ALLOWED_DOC_TOOLS.join(', ')}`
+            )
+          }
+
           const docFile = `${toolName}.md`
           try {
             const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')


### PR DESCRIPTION
Identified and fixed a path traversal vulnerability in the `help` tool (`src/tools/registry.ts`).

-   **Vulnerability:** The `help` tool accepted arbitrary `tool_name` input, allowing attackers to traverse the file system (e.g., `../../README`) and read files relative to the documentation directory.
-   **Fix:** Implemented a strict allowlist (`ALLOWED_DOC_TOOLS`) for `tool_name` input. The tool now throws `INVALID_TOOL` error if the input is not in the allowed list.
-   **Verification:** Added `src/tools/registry.security.test.ts` to reproduce the vulnerability and verify the fix. Confirmed that valid tools still work and invalid inputs are rejected.
-   **Compliance:** Ran existing tests and lint checks to ensure no regressions.
-   **Documentation:** Recorded the vulnerability and learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [606301871017589176](https://jules.google.com/task/606301871017589176) started by @n24q02m*