### PR TITLE
🛡️ Sentinel: Fix Path Traversal Vulnerability in `help` tool

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -396,6 +396,17 @@ describe('registerTools', () => {
       expect(parsed.documentation).toBe('# Pages Documentation\n\nFull docs here.')
     })
 
+    it('should return error for help tool with invalid tool_name', async () => {
+      const handler = server.getHandler(3)
+
+      const result = await handler({
+        params: { name: 'help', arguments: { tool_name: '../../README' } }
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Invalid tool name: ../../README')
+    })
+
     it('should return isError for help tool when doc file is missing', async () => {
       const handler = server.getHandler(3)
       vi.mocked(readFileSync).mockImplementation(() => {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -419,6 +419,17 @@ export function registerTools(server: Server, notionToken: string) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
+
+          // Security check: ensure tool_name is valid to prevent path traversal
+          const validTools = TOOLS.map((t) => t.name)
+          if (!validTools.includes(toolName)) {
+            throw new NotionMCPError(
+              `Invalid tool name: ${toolName}`,
+              'INVALID_TOOL',
+              `Available tools: ${validTools.join(', ')}`
+            )
+          }
+
           const docFile = `${toolName}.md`
           try {
             const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Traversal Vulnerability in `help` tool

🚨 Severity: HIGH
💡 Vulnerability: The `help` tool allowed arbitrary file reads via path traversal (e.g., `../../README`) because it did not validate `tool_name` against the allowed list of tools before constructing the file path.
🎯 Impact: An attacker could potentially read sensitive files on the server or source code, exposing internal configuration or secrets.
🔧 Fix: Implemented a strict allowlist check in `src/tools/registry.ts`. The `tool_name` must now match one of the registered tool names.
✅ Verification: Added a regression test in `src/tools/registry.test.ts` that attempts a path traversal attack and asserts that it is blocked with an `INVALID_TOOL` error. Verified that legitimate help requests still work.

---
*PR created automatically by Jules for task [14241122746767732103](https://jules.google.com/task/14241122746767732103) started by @n24q02m*