### PR TITLE
🛡️ Sentinel: Fix Path Traversal in Help Tool

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -410,6 +410,17 @@ describe('registerTools', () => {
       expect(result.content[0].text).toContain('Documentation not found for: pages')
     })
 
+    it('should prevent path traversal in help tool', async () => {
+      const handler = server.getHandler(3)
+
+      const result = await handler({
+        params: { name: 'help', arguments: { tool_name: '../../README' } }
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('Invalid tool name')
+    })
+
     it('should return error for unknown tool', async () => {
       const handler = server.getHandler(3)
       const result = await handler({

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -419,6 +419,17 @@ export function registerTools(server: Server, notionToken: string) {
           break
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
+
+          // Validate tool_name to prevent path traversal
+          const isValidTool = TOOLS.some((t) => t.name === toolName)
+          if (!isValidTool) {
+            throw new NotionMCPError(
+              `Invalid tool name: ${toolName}`,
+              'INVALID_TOOL',
+              `Available tools: ${TOOLS.map((t) => t.name).join(', ')}`
+            )
+          }
+
           const docFile = `${toolName}.md`
           try {
             const content = readFileSync(join(DOCS_DIR, docFile), 'utf-8')


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Traversal in Help Tool

🚨 Severity: HIGH
💡 Vulnerability: The `help` tool constructed file paths directly from user input (`tool_name`), allowing access to arbitrary files via path traversal (e.g., `../../README`).
🎯 Impact: Attackers could read arbitrary files on the server (restricted by permissions and file extension handling, but clearly unintended access).
🔧 Fix: Added strict validation of `tool_name` against the allowed `TOOLS` list before file access.
✅ Verification: Added a unit test case `should prevent path traversal in help tool` in `src/tools/registry.test.ts` which passes. Verified manually with a reproduction script.

---
*PR created automatically by Jules for task [15946754408282638273](https://jules.google.com/task/15946754408282638273) started by @n24q02m*