### PR TITLE
Refactor markdown helper to use shared RichText definition

### DIFF
--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -6,29 +6,15 @@
  *           equations, columns, table of contents, breadcrumb
  */
 
+import type { RichTextItem } from './richtext'
+
 export interface NotionBlock {
   object: 'block'
   type: string
   [key: string]: any
 }
 
-export interface RichText {
-  type: 'text'
-  text: {
-    content: string
-    link?: { url: string } | null
-  }
-  annotations: {
-    bold: boolean
-    italic: boolean
-    strikethrough: boolean
-    underline: boolean
-    code: boolean
-    color: string
-  }
-  plain_text?: string
-  href?: string | null
-}
+export type RichText = RichTextItem
 
 /**
  * Convert markdown string to Notion blocks


### PR DESCRIPTION
Replaced the local `RichText` interface definition in `src/tools/helpers/markdown.ts` with an import from `src/tools/helpers/richtext.ts` to ensure consistency and reduce code duplication.

Verified with `pnpm check` and `pnpm test`.

---
*PR created automatically by Jules for task [121292718123544932](https://jules.google.com/task/121292718123544932) started by @n24q02m*