### PR TITLE
🧪 Testing Improvement: Fix block update content clearing on type mismatch

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -223,6 +223,43 @@ describe('blocks', () => {
         'content required for update'
       )
     })
+
+    it('should update block content even if markdown produces different block type', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [{ text: { content: 'Old content' } }] }
+      })
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      // Update paragraph with heading markdown
+      const result = await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: '# New Heading'
+      })
+
+      expect(result).toEqual({
+        action: 'update',
+        block_id: 'block-1',
+        type: 'paragraph',
+        updated: true
+      })
+
+      // Should extract rich_text from heading_1 and apply to paragraph
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-1',
+          paragraph: {
+            rich_text: expect.arrayContaining([
+              expect.objectContaining({ text: expect.objectContaining({ content: 'New Heading' }) })
+            ])
+          }
+        })
+      )
+    })
   })
 
   describe('delete', () => {

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -98,8 +98,19 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
             'quote'
           ].includes(blockType)
         ) {
+          const newBlockType = newContent.type
+          const newRichText = (newContent as any)[newBlockType]?.rich_text
+
+          if (!newRichText) {
+            throw new NotionMCPError(
+              `Cannot update block type '${blockType}' with content of type '${newBlockType}'`,
+              'VALIDATION_ERROR',
+              'Content mismatch'
+            )
+          }
+
           updatePayload[blockType] = {
-            rich_text: (newContent as any)[blockType]?.rich_text || []
+            rich_text: newRichText
           }
         } else {
           throw new NotionMCPError(


### PR DESCRIPTION
This PR addresses a testing gap and a bug in `src/tools/composite/blocks.ts` where updating a block with markdown content that parses to a different block type would unintentionally clear the block's content.

### 🎯 What
- Fixed the logic in `blocks.update` to correctly extract `rich_text` from the new block content, regardless of whether the new block type matches the existing block type.
- Added a validation check to ensure the new content has `rich_text` available before updating.

### 📊 Coverage
- Added a new test case in `src/tools/composite/blocks.test.ts`: `should update block content even if markdown produces different block type`.
- This test verifies that updating a `paragraph` block with markdown for a `heading_1` (e.g., `# Heading`) correctly updates the paragraph's text content instead of clearing it.

### ✨ Result
- Improved reliability of the `blocks` tool by preventing data loss when users provide mismatched markdown content.
- Increased test coverage for edge cases in block updates.

---
*PR created automatically by Jules for task [4683408512833296281](https://jules.google.com/task/4683408512833296281) started by @n24q02m*