### PR TITLE
🧪 Improve test coverage for block updates

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -199,6 +199,155 @@ describe('blocks', () => {
         })
       )
     })
+    it('should update heading_2 block', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'heading_2',
+        has_children: false,
+        archived: false,
+        heading_2: { rich_text: [], color: 'default' }
+      })
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: '## Heading 2'
+      })
+
+      expect(result).toEqual({
+        action: 'update',
+        block_id: 'block-1',
+        type: 'heading_2',
+        updated: true
+      })
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-1',
+          heading_2: { rich_text: expect.any(Array) }
+        })
+      )
+    })
+
+    it('should update heading_3 block', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'heading_3',
+        has_children: false,
+        archived: false,
+        heading_3: { rich_text: [], color: 'default' }
+      })
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: '### Heading 3'
+      })
+
+      expect(result).toEqual({
+        action: 'update',
+        block_id: 'block-1',
+        type: 'heading_3',
+        updated: true
+      })
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-1',
+          heading_3: { rich_text: expect.any(Array) }
+        })
+      )
+    })
+
+    it('should update bulleted_list_item block', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'bulleted_list_item',
+        has_children: false,
+        archived: false,
+        bulleted_list_item: { rich_text: [], color: 'default' }
+      })
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: '- Bullet item'
+      })
+
+      expect(result).toEqual({
+        action: 'update',
+        block_id: 'block-1',
+        type: 'bulleted_list_item',
+        updated: true
+      })
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-1',
+          bulleted_list_item: { rich_text: expect.any(Array) }
+        })
+      )
+    })
+
+    it('should update numbered_list_item block', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'numbered_list_item',
+        has_children: false,
+        archived: false,
+        numbered_list_item: { rich_text: [], color: 'default' }
+      })
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: '1. Numbered item'
+      })
+
+      expect(result).toEqual({
+        action: 'update',
+        block_id: 'block-1',
+        type: 'numbered_list_item',
+        updated: true
+      })
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-1',
+          numbered_list_item: { rich_text: expect.any(Array) }
+        })
+      )
+    })
+
+    it('should update quote block', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'quote',
+        has_children: false,
+        archived: false,
+        quote: { rich_text: [], color: 'default' }
+      })
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      const result = await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: '> Quote text'
+      })
+
+      expect(result).toEqual({
+        action: 'update',
+        block_id: 'block-1',
+        type: 'quote',
+        updated: true
+      })
+      expect(mockNotion.blocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          block_id: 'block-1',
+          quote: { rich_text: expect.any(Array) }
+        })
+      )
+    })
 
     it('should throw for unsupported block type', async () => {
       mockNotion.blocks.retrieve.mockResolvedValue({


### PR DESCRIPTION
🎯 **What:** Added tests for updating `heading_2`, `heading_3`, `bulleted_list_item`, `numbered_list_item`, and `quote` block types.
📊 **Coverage:** Ensures all supported block types in the `update` action are explicitly tested.
✨ **Result:** Increased test coverage in `src/tools/composite/blocks.test.ts` from 12 to 17 tests, with full suite passing (429 tests).

---
*PR created automatically by Jules for task [6957084334806614121](https://jules.google.com/task/6957084334806614121) started by @n24q02m*