### PR TITLE
🔒 Security: Sanitize validation error details to prevent sensitive data leakage

### DIFF
--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { enhanceError } from './errors'
+
+describe('NotionMCPError Security', () => {
+  it('should not leak sensitive details in validation_error', () => {
+    const sensitiveBody = {
+      message: 'Validation failed',
+      object: 'error',
+      status: 400,
+      code: 'validation_error',
+      // Simulate sensitive data in the error body
+      request_payload: {
+        authorization: 'Bearer secret-token-123',
+        password: 'my-secret-password',
+        user_email: 'admin@example.com'
+      }
+    }
+
+    const error = {
+      code: 'validation_error',
+      message: 'Request body validation failed',
+      body: sensitiveBody
+    }
+
+    const enhanced = enhanceError(error)
+
+    expect(enhanced.details).toBeDefined()
+
+    const detailsStr = JSON.stringify(enhanced.details)
+
+    // Verify sensitive data is STRIPPED
+    expect(detailsStr).not.toContain('secret-token-123')
+    expect(detailsStr).not.toContain('my-secret-password')
+    expect(detailsStr).not.toContain('admin@example.com')
+
+    // Verify safe fields ARE present
+    expect(enhanced.details.message).toBe('Validation failed')
+    expect(enhanced.details.code).toBe('validation_error')
+    expect(enhanced.details.status).toBe(400)
+
+    // Verify unsafe fields are GONE
+    expect(enhanced.details.request_payload).toBeUndefined()
+  })
+})

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -31,12 +31,13 @@ export class NotionMCPError extends Error {
 function sanitizeErrorDetails(error: any): any {
   if (!error || typeof error !== 'object') return error
 
-  // whitelist safe properties
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
-  }
+  const safe: any = {}
+
+  // Whitelist safe properties
+  if (error.message) safe.message = error.message
+  if (error.name) safe.name = error.name
+  if (error.code) safe.code = error.code
+  if (error.path) safe.path = error.path // Common in validation errors
 
   // Add status if available (common in HTTP errors)
   if (error.status) safe.status = error.status
@@ -117,10 +118,10 @@ function handleNotionError(error: any): NotionMCPError {
 
     case 'validation_error':
       return new NotionMCPError(
-        error.body?.message || 'Invalid request parameters',
+        sanitizeErrorDetails(error.body)?.message || 'Invalid request parameters',
         'VALIDATION_ERROR',
         'Check the API documentation for valid parameter formats',
-        error.body
+        sanitizeErrorDetails(error.body)
       )
 
     case 'rate_limited':


### PR DESCRIPTION
* 🎯 **What:** Fixed a vulnerability where sensitive request data (like tokens or PII) in Notion API validation errors was echoed back in the error details.
* ⚠️ **Risk:** If an attacker can trigger a validation error with a crafted payload containing sensitive data, that data could be exposed in logs or error responses.
* 🛡️ **Solution:** Wrapped `error.body` with `sanitizeErrorDetails` in the `validation_error` handler to ensure only safe properties (message, code, name, status, path) are returned. Added a regression test to verify the fix.

---
*PR created automatically by Jules for task [2427920869930355875](https://jules.google.com/task/2427920869930355875) started by @n24q02m*