### PR TITLE
🧹 Refactor page property extraction to helper function

### DIFF
--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -12,9 +12,13 @@ vi.mock('../helpers/markdown.js', () => ({
   })
 }))
 
-vi.mock('../helpers/properties.js', () => ({
-  convertToNotionProperties: vi.fn((props: any) => props)
-}))
+vi.mock('../helpers/properties.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../helpers/properties.js')>()
+  return {
+    ...actual,
+    convertToNotionProperties: vi.fn((props: any) => props)
+  }
+})
 
 function createMockNotion() {
   return {

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -7,7 +7,7 @@ import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, processBatches } from '../helpers/pagination.js'
-import { convertToNotionProperties } from '../helpers/properties.js'
+import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
 import * as RichText from '../helpers/richtext.js'
 
 export interface PagesInput {
@@ -157,54 +157,7 @@ async function getPage(notion: Client, input: PagesInput): Promise<any> {
   const markdown = blocksToMarkdown(blocks as any)
 
   // Extract properties
-  const properties: any = {}
-  for (const [key, prop] of Object.entries(page.properties)) {
-    const p = prop as any
-    if (p.type === 'title' && p.title) {
-      properties[key] = p.title.map((t: any) => t.plain_text).join('')
-    } else if (p.type === 'rich_text' && p.rich_text) {
-      properties[key] = p.rich_text.map((t: any) => t.plain_text).join('')
-    } else if (p.type === 'select' && p.select) {
-      properties[key] = p.select.name
-    } else if (p.type === 'multi_select' && p.multi_select) {
-      properties[key] = p.multi_select.map((s: any) => s.name)
-    } else if (p.type === 'number') {
-      properties[key] = p.number
-    } else if (p.type === 'checkbox') {
-      properties[key] = p.checkbox
-    } else if (p.type === 'url') {
-      properties[key] = p.url
-    } else if (p.type === 'email') {
-      properties[key] = p.email
-    } else if (p.type === 'phone_number') {
-      properties[key] = p.phone_number
-    } else if (p.type === 'date' && p.date) {
-      properties[key] = p.date.start + (p.date.end ? ` to ${p.date.end}` : '')
-    } else if (p.type === 'relation' && p.relation) {
-      properties[key] = p.relation.map((r: any) => r.id)
-    } else if (p.type === 'rollup' && p.rollup) {
-      properties[key] = p.rollup
-    } else if (p.type === 'people' && p.people) {
-      properties[key] = p.people.map((person: any) => person.name || person.id)
-    } else if (p.type === 'files' && p.files) {
-      properties[key] = p.files.map((f: any) => f.file?.url || f.external?.url || f.name)
-    } else if (p.type === 'formula' && p.formula) {
-      const formula = p.formula
-      properties[key] = formula[formula.type]
-    } else if (p.type === 'created_time') {
-      properties[key] = p.created_time
-    } else if (p.type === 'last_edited_time') {
-      properties[key] = p.last_edited_time
-    } else if (p.type === 'created_by' && p.created_by) {
-      properties[key] = p.created_by.name || p.created_by.id
-    } else if (p.type === 'last_edited_by' && p.last_edited_by) {
-      properties[key] = p.last_edited_by.name || p.last_edited_by.id
-    } else if (p.type === 'status' && p.status) {
-      properties[key] = p.status.name
-    } else if (p.type === 'unique_id' && p.unique_id) {
-      properties[key] = p.unique_id.prefix ? `${p.unique_id.prefix}-${p.unique_id.number}` : p.unique_id.number
-    }
-  }
+  const properties = extractPageProperties(page.properties)
 
   return {
     action: 'get',

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { convertToNotionProperties } from './properties'
+import { convertToNotionProperties, extractPageProperties } from './properties'
 
 const richText = (content: string) => ({
   type: 'text',
@@ -221,5 +221,145 @@ describe('convertToNotionProperties', () => {
         Notes: null
       })
     })
+  })
+})
+
+describe('extractPageProperties', () => {
+  it('returns empty object for empty properties', () => {
+    expect(extractPageProperties({})).toEqual({})
+  })
+
+  it('extracts title', () => {
+    const props = {
+      Name: { type: 'title', title: [{ plain_text: 'Hello' }, { plain_text: ' World' }] }
+    }
+    expect(extractPageProperties(props)).toEqual({ Name: 'Hello World' })
+  })
+
+  it('extracts rich_text', () => {
+    const props = {
+      Desc: { type: 'rich_text', rich_text: [{ plain_text: 'A ' }, { plain_text: 'description' }] }
+    }
+    expect(extractPageProperties(props)).toEqual({ Desc: 'A description' })
+  })
+
+  it('extracts select', () => {
+    const props = {
+      Status: { type: 'select', select: { name: 'Done' } }
+    }
+    expect(extractPageProperties(props)).toEqual({ Status: 'Done' })
+  })
+
+  it('extracts multi_select', () => {
+    const props = {
+      Tags: { type: 'multi_select', multi_select: [{ name: 'A' }, { name: 'B' }] }
+    }
+    expect(extractPageProperties(props)).toEqual({ Tags: ['A', 'B'] })
+  })
+
+  it('extracts number', () => {
+    const props = { Count: { type: 'number', number: 42 } }
+    expect(extractPageProperties(props)).toEqual({ Count: 42 })
+  })
+
+  it('extracts checkbox', () => {
+    const props = { Active: { type: 'checkbox', checkbox: true } }
+    expect(extractPageProperties(props)).toEqual({ Active: true })
+  })
+
+  it('extracts url', () => {
+    const props = { Link: { type: 'url', url: 'https://example.com' } }
+    expect(extractPageProperties(props)).toEqual({ Link: 'https://example.com' })
+  })
+
+  it('extracts email', () => {
+    const props = { Mail: { type: 'email', email: 'test@example.com' } }
+    expect(extractPageProperties(props)).toEqual({ Mail: 'test@example.com' })
+  })
+
+  it('extracts phone_number', () => {
+    const props = { Phone: { type: 'phone_number', phone_number: '+123' } }
+    expect(extractPageProperties(props)).toEqual({ Phone: '+123' })
+  })
+
+  it('extracts date with start only', () => {
+    const props = { Due: { type: 'date', date: { start: '2025-01-01', end: null } } }
+    expect(extractPageProperties(props)).toEqual({ Due: '2025-01-01' })
+  })
+
+  it('extracts date with start and end', () => {
+    const props = { Range: { type: 'date', date: { start: '2025-01-01', end: '2025-01-05' } } }
+    expect(extractPageProperties(props)).toEqual({ Range: '2025-01-01 to 2025-01-05' })
+  })
+
+  it('extracts relation', () => {
+    const props = { Rel: { type: 'relation', relation: [{ id: 'r1' }, { id: 'r2' }] } }
+    expect(extractPageProperties(props)).toEqual({ Rel: ['r1', 'r2'] })
+  })
+
+  it('extracts rollup', () => {
+    const props = { Roll: { type: 'rollup', rollup: { type: 'number', number: 10 } } }
+    expect(extractPageProperties(props)).toEqual({ Roll: { type: 'number', number: 10 } })
+  })
+
+  it('extracts people', () => {
+    const props = {
+      Team: { type: 'people', people: [{ name: 'Alice', id: 'u1' }, { id: 'u2' }] }
+    }
+    expect(extractPageProperties(props)).toEqual({ Team: ['Alice', 'u2'] })
+  })
+
+  it('extracts files', () => {
+    const props = {
+      Docs: {
+        type: 'files',
+        files: [
+          { name: 'A.txt', file: { url: 'https://a.com' } },
+          { name: 'B.txt', external: { url: 'https://b.com' } },
+          { name: 'C.txt' }
+        ]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Docs: ['https://a.com', 'https://b.com', 'C.txt'] })
+  })
+
+  it('extracts formula', () => {
+    const props = { Calc: { type: 'formula', formula: { type: 'number', number: 123 } } }
+    expect(extractPageProperties(props)).toEqual({ Calc: 123 })
+  })
+
+  it('extracts created_time', () => {
+    const props = { Created: { type: 'created_time', created_time: '2025-01-01T00:00:00Z' } }
+    expect(extractPageProperties(props)).toEqual({ Created: '2025-01-01T00:00:00Z' })
+  })
+
+  it('extracts last_edited_time', () => {
+    const props = { Edited: { type: 'last_edited_time', last_edited_time: '2025-01-02T00:00:00Z' } }
+    expect(extractPageProperties(props)).toEqual({ Edited: '2025-01-02T00:00:00Z' })
+  })
+
+  it('extracts created_by', () => {
+    const props = { Author: { type: 'created_by', created_by: { name: 'Bob', id: 'u3' } } }
+    expect(extractPageProperties(props)).toEqual({ Author: 'Bob' })
+  })
+
+  it('extracts last_edited_by', () => {
+    const props = { Editor: { type: 'last_edited_by', last_edited_by: { id: 'u4' } } }
+    expect(extractPageProperties(props)).toEqual({ Editor: 'u4' })
+  })
+
+  it('extracts status', () => {
+    const props = { State: { type: 'status', status: { name: 'In Progress' } } }
+    expect(extractPageProperties(props)).toEqual({ State: 'In Progress' })
+  })
+
+  it('extracts unique_id with prefix', () => {
+    const props = { ID: { type: 'unique_id', unique_id: { prefix: 'TASK', number: 101 } } }
+    expect(extractPageProperties(props)).toEqual({ ID: 'TASK-101' })
+  })
+
+  it('extracts unique_id without prefix', () => {
+    const props = { ID: { type: 'unique_id', unique_id: { prefix: null, number: 102 } } }
+    expect(extractPageProperties(props)).toEqual({ ID: 102 })
   })
 })

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -69,3 +69,59 @@ export function convertToNotionProperties(
 
   return converted
 }
+
+/**
+ * Extract simplified values from Notion page properties
+ * Converts complex Notion property objects into simple JSON values
+ */
+export function extractPageProperties(properties: Record<string, any>): Record<string, any> {
+  const extracted: Record<string, any> = {}
+  for (const [key, prop] of Object.entries(properties)) {
+    const p = prop as any
+    if (p.type === 'title' && p.title) {
+      extracted[key] = p.title.map((t: any) => t.plain_text).join('')
+    } else if (p.type === 'rich_text' && p.rich_text) {
+      extracted[key] = p.rich_text.map((t: any) => t.plain_text).join('')
+    } else if (p.type === 'select' && p.select) {
+      extracted[key] = p.select.name
+    } else if (p.type === 'multi_select' && p.multi_select) {
+      extracted[key] = p.multi_select.map((s: any) => s.name)
+    } else if (p.type === 'number') {
+      extracted[key] = p.number
+    } else if (p.type === 'checkbox') {
+      extracted[key] = p.checkbox
+    } else if (p.type === 'url') {
+      extracted[key] = p.url
+    } else if (p.type === 'email') {
+      extracted[key] = p.email
+    } else if (p.type === 'phone_number') {
+      extracted[key] = p.phone_number
+    } else if (p.type === 'date' && p.date) {
+      extracted[key] = p.date.start + (p.date.end ? ` to ${p.date.end}` : '')
+    } else if (p.type === 'relation' && p.relation) {
+      extracted[key] = p.relation.map((r: any) => r.id)
+    } else if (p.type === 'rollup' && p.rollup) {
+      extracted[key] = p.rollup
+    } else if (p.type === 'people' && p.people) {
+      extracted[key] = p.people.map((person: any) => person.name || person.id)
+    } else if (p.type === 'files' && p.files) {
+      extracted[key] = p.files.map((f: any) => f.file?.url || f.external?.url || f.name)
+    } else if (p.type === 'formula' && p.formula) {
+      const formula = p.formula
+      extracted[key] = formula[formula.type]
+    } else if (p.type === 'created_time') {
+      extracted[key] = p.created_time
+    } else if (p.type === 'last_edited_time') {
+      extracted[key] = p.last_edited_time
+    } else if (p.type === 'created_by' && p.created_by) {
+      extracted[key] = p.created_by.name || p.created_by.id
+    } else if (p.type === 'last_edited_by' && p.last_edited_by) {
+      extracted[key] = p.last_edited_by.name || p.last_edited_by.id
+    } else if (p.type === 'status' && p.status) {
+      extracted[key] = p.status.name
+    } else if (p.type === 'unique_id' && p.unique_id) {
+      extracted[key] = p.unique_id.prefix ? `${p.unique_id.prefix}-${p.unique_id.number}` : p.unique_id.number
+    }
+  }
+  return extracted
+}


### PR DESCRIPTION
Refactored duplicated property extraction logic from src/tools/composite/pages.ts to a new helper function extractPageProperties in src/tools/helpers/properties.ts.

🎯 **What:** Extracted the property extraction loop from `getPage` in `src/tools/composite/pages.ts` into a reusable function `extractPageProperties`.
💡 **Why:** Reduces code duplication, improves readability of the `pages` tool, and allows for isolated testing of property extraction logic.
✅ **Verification:** Added comprehensive unit tests for `extractPageProperties` covering all Notion property types. Updated `pages.test.ts` to use the real implementation of the helper and verified all tests pass.
✨ **Result:** Cleaner `pages.ts` and robust property extraction utility.


---
*PR created automatically by Jules for task [3895721429405698043](https://jules.google.com/task/3895721429405698043) started by @n24q02m*