### PR TITLE
🧪 Improve testing for mixed-type arrays in properties helper

### DIFF
--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -168,6 +168,24 @@ describe('convertToNotionProperties', () => {
         Items: []
       })
     })
+
+    describe('mixed type arrays', () => {
+      it('passes mixed array starting with string through as-is', () => {
+        const mixed = ['tag', 123]
+        const result = convertToNotionProperties({ Mixed: mixed })
+        expect(result).toEqual({
+          Mixed: mixed
+        })
+      })
+
+      it('passes mixed array starting with number through as-is', () => {
+        const mixed = [123, 'tag']
+        const result = convertToNotionProperties({ Mixed: mixed })
+        expect(result).toEqual({
+          Mixed: mixed
+        })
+      })
+    })
   })
 
   describe('object values', () => {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -51,8 +51,8 @@ export function convertToNotionProperties(
       converted[key] = { checkbox: value }
     } else if (Array.isArray(value)) {
       // Could be multi_select, relation, people, files
-      if (value.length > 0 && typeof value[0] === 'string') {
-        // Assume multi_select
+      // Only assume multi_select if all elements are strings
+      if (value.length > 0 && value.every((v) => typeof v === 'string')) {
         converted[key] = {
           multi_select: value.map((v) => ({ name: v }))
         }


### PR DESCRIPTION
**What:** Addressed a testing gap where mixed-type arrays were incorrectly handled due to simplistic logic that only checked the first element.
**Coverage:** Added a specific test case for arrays containing both strings and numbers (e.g., `['tag', 123]`).
**Result:** Improved reliability of `convertToNotionProperties` by ensuring arrays are only treated as `multi_select` if *all* elements are strings. This prevents runtime errors or incorrect data formatting when mixed types are present.

---
*PR created automatically by Jules for task [4745140639576876240](https://jules.google.com/task/4745140639576876240) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of arrays containing mixed data types. Arrays with mixed element types are now properly preserved instead of being incorrectly converted.

* **Tests**
  * Added test coverage for mixed-type array scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->