### PR TITLE
🔒 Prevent DoS via large file uploads

### DIFF
--- a/src/tools/composite/file-uploads.security.test.ts
+++ b/src/tools/composite/file-uploads.security.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fileUploads } from './file-uploads.js'
+
+describe('fileUploads Security', () => {
+  const mockNotion = {
+    fileUploads: {
+      send: vi.fn(),
+      retrieve: vi.fn()
+    }
+  }
+
+  it('should reject file content exceeding the size limit', async () => {
+    // 10MB limit in bytes
+    const limit = 10 * 1024 * 1024
+    // Base64 length for 10MB + 1 byte
+    // Length = ceil((bytes * 4) / 3)
+    // We want to be safely above.
+    // 10.1 MB
+    const targetBytes = limit + 1024 * 100 // 10MB + 100KB
+    const base64Length = Math.ceil((targetBytes * 4) / 3)
+
+    // Create a "fake" base64 string of sufficient length
+    // 'a' is a valid base64 char
+    const largeContent = 'a'.repeat(base64Length)
+
+    await expect(
+      fileUploads(mockNotion as any, {
+        action: 'send',
+        file_upload_id: 'upload-123',
+        file_content: largeContent,
+        filename: 'large.txt',
+        content_type: 'text/plain'
+      })
+    ).rejects.toThrow(/exceeds maximum size/)
+  })
+})

--- a/src/tools/composite/file-uploads.ts
+++ b/src/tools/composite/file-uploads.ts
@@ -8,6 +8,10 @@ import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { autoPaginate } from '../helpers/pagination.js'
 
+// Maximum file size per request (10MB) to prevent OOM
+const MAX_FILE_SIZE_MB = 10
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024
+
 export interface FileUploadsInput {
   action: 'create' | 'send' | 'complete' | 'retrieve' | 'list'
 
@@ -118,6 +122,16 @@ async function sendFileUpload(notion: Client, input: FileUploadsInput): Promise<
       'file_content is required for send action',
       'VALIDATION_ERROR',
       'Provide base64-encoded file content'
+    )
+  }
+
+  // Check file size before processing to prevent OOM
+  const approximateSize = (input.file_content.length * 3) / 4
+  if (approximateSize > MAX_FILE_SIZE_BYTES) {
+    throw new NotionMCPError(
+      `File content exceeds maximum size of ${MAX_FILE_SIZE_MB}MB per request.`,
+      'VALIDATION_ERROR',
+      "Split the file into smaller parts and use the 'part_number' parameter for multi-part upload."
     )
   }
 


### PR DESCRIPTION
🔒 Prevent DoS via large file uploads

This PR introduces a maximum file size limit for the `fileUploads` tool to prevent Potential Denial of Service (DoS) attacks or Out of Memory (OOM) errors caused by processing extremely large base64 strings.

**What:**
- Added a `MAX_FILE_SIZE_MB` constant set to 10MB.
- Implemented a check in `sendFileUpload` to validate the approximate size of the file content (derived from base64 length) before creating a Buffer.
- Throws a `NotionMCPError` with code `VALIDATION_ERROR` if the size exceeds the limit.
- Added a security test file `src/tools/composite/file-uploads.security.test.ts` to verify the fix.

**Risk:**
- Previously, the tool would attempt to create a Buffer from any provided base64 string, potentially leading to OOM crashes if a malicious actor or buggy client sent a massive payload.

**Solution:**
- Enforce a strict 10MB limit per request, encouraging the use of multi-part uploads for larger files (as suggested in the error message).

---
*PR created automatically by Jules for task [4495203454134644292](https://jules.google.com/task/4495203454134644292) started by @n24q02m*