### PR TITLE
🧪 Fix truncate edge case for small lengths

### DIFF
--- a/src/tools/helpers/richtext.test.ts
+++ b/src/tools/helpers/richtext.test.ts
@@ -402,3 +402,14 @@ describe('truncate', () => {
     expect(result[0].text.content).toBe('a...')
   })
 })
+
+it('should handle maxLength smaller than ellipsis length', () => {
+  const items = [RichText.text('abcdef')]
+  const result1 = RichText.truncate(items, 1)
+  expect(result1[0].text.content).toBe('a')
+  expect(result1[0].text.content.length).toBe(1)
+
+  const result2 = RichText.truncate(items, 2)
+  expect(result2[0].text.content).toBe('ab')
+  expect(result2[0].text.content.length).toBe(2)
+})

--- a/src/tools/helpers/richtext.ts
+++ b/src/tools/helpers/richtext.ts
@@ -188,6 +188,10 @@ export function truncate(richText: RichTextItem[], maxLength: number): RichTextI
     return richText
   }
 
+  if (maxLength < 3) {
+    return [text(plainText.slice(0, maxLength))]
+  }
+
   const truncated = `${plainText.slice(0, maxLength - 3)}...`
   return [text(truncated)]
 }


### PR DESCRIPTION
This PR addresses a bug in the `truncate` helper function where `maxLength` values smaller than the ellipsis length (3) would cause a negative slice index, resulting in incorrect behavior.

**Changes:**
- Modified `src/tools/helpers/richtext.ts`: Added a check `if (maxLength < 3)` to return the truncated plain text without an ellipsis for very short limits.
- Added a regression test in `src/tools/helpers/richtext.test.ts`: `should handle maxLength smaller than ellipsis length` to verify the fix works for lengths of 1 and 2.

**Coverage:**
- The new test case covers the scenario where `maxLength` is 1 and 2.
- Existing tests ensure no regressions for normal usage.

**Result:**
- `truncate` now safely handles all positive integer `maxLength` values.

---
*PR created automatically by Jules for task [7664854800002694668](https://jules.google.com/task/7664854800002694668) started by @n24q02m*