### PR TITLE
🧹 Refactor: Add strong typing to databases tool response

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -1,5 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { databases } from './databases'
+import {
+  type CreateDatabasePageResponse,
+  type CreateDatabaseResponse,
+  type CreateDataSourceResponse,
+  type DeleteDatabasePageResponse,
+  databases,
+  type GetDatabaseResponse,
+  type ListDataSourceTemplatesResponse,
+  type QueryDatabaseResponse,
+  type UpdateDatabasePageResponse,
+  type UpdateDatabaseResponse,
+  type UpdateDataSourceResponse
+} from './databases.js'
 
 const mockNotion = {
   databases: {
@@ -66,12 +78,12 @@ describe('databases', () => {
         data_sources: [{ id: 'ds-new' }]
       })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'create',
         parent_id: 'page-1',
         title: 'My DB',
         properties: { Name: { title: {} } }
-      })
+      })) as CreateDatabaseResponse
 
       expect(result).toEqual({
         action: 'create',
@@ -125,7 +137,7 @@ describe('databases', () => {
       mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse())
       mockNotion.dataSources.retrieve.mockResolvedValueOnce(makeDataSourceResponse())
 
-      const result = await databases(notion, { action: 'get', database_id: 'db-1' })
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
 
       expect(result).toEqual({
         action: 'get',
@@ -163,7 +175,7 @@ describe('databases', () => {
         })
       )
 
-      const result = await databases(notion, { action: 'get', database_id: 'db-1' })
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
 
       expect(result.schema.Tags.options).toEqual(['A', 'B'])
       expect(result.schema.Total.expression).toBe('prop("Price") * prop("Qty")')
@@ -172,7 +184,7 @@ describe('databases', () => {
     it('should handle empty data_sources array', async () => {
       mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse({ data_sources: [] }))
 
-      const result = await databases(notion, { action: 'get', database_id: 'db-1' })
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
 
       expect(result.data_source).toBeNull()
       expect(result.schema).toEqual({})
@@ -202,7 +214,7 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = await databases(notion, { action: 'query', database_id: 'db-1' })
+      const result = (await databases(notion, { action: 'query', database_id: 'db-1' })) as QueryDatabaseResponse
 
       expect(result.action).toBe('query')
       expect(result.database_id).toBe('db-1')
@@ -291,11 +303,11 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'query',
         database_id: 'db-1',
         limit: 2
-      })
+      })) as QueryDatabaseResponse
 
       expect(result.total).toBe(2)
       expect(result.results).toHaveLength(2)
@@ -325,7 +337,7 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = await databases(notion, { action: 'query', database_id: 'db-1' })
+      const result = (await databases(notion, { action: 'query', database_id: 'db-1' })) as QueryDatabaseResponse
       const page = result.results[0]
 
       expect(page.Name).toBe('Test')
@@ -362,11 +374,11 @@ describe('databases', () => {
         url: 'https://notion.so/new-page-1'
       })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'create_page',
         database_id: 'db-1',
         page_properties: { Name: 'New Item', Status: 'Active' }
-      })
+      })) as CreateDatabasePageResponse
 
       expect(result.action).toBe('create_page')
       expect(result.database_id).toBe('db-1')
@@ -390,11 +402,11 @@ describe('databases', () => {
         .mockResolvedValueOnce({ id: 'p-1', url: 'https://notion.so/p-1' })
         .mockResolvedValueOnce({ id: 'p-2', url: 'https://notion.so/p-2' })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'create_page',
         database_id: 'db-1',
         pages: [{ properties: { Name: 'Item 1' } }, { properties: { Name: 'Item 2' } }]
-      })
+      })) as CreateDatabasePageResponse
 
       expect(result.processed).toBe(2)
       expect(result.results).toHaveLength(2)
@@ -418,11 +430,11 @@ describe('databases', () => {
     it('should update a single page with page_id and page_properties', async () => {
       mockNotion.pages.update.mockResolvedValueOnce({ id: 'page-1' })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'update_page',
         page_id: 'page-1',
         page_properties: { Status: 'Done' }
-      })
+      })) as UpdateDatabasePageResponse
 
       expect(result.action).toBe('update_page')
       expect(result.processed).toBe(1)
@@ -433,13 +445,13 @@ describe('databases', () => {
     it('should update multiple pages with pages array', async () => {
       mockNotion.pages.update.mockResolvedValueOnce({ id: 'page-1' }).mockResolvedValueOnce({ id: 'page-2' })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'update_page',
         pages: [
           { page_id: 'page-1', properties: { Status: 'Done' } },
           { page_id: 'page-2', properties: { Status: 'Active' } }
         ]
-      })
+      })) as UpdateDatabasePageResponse
 
       expect(result.processed).toBe(2)
       expect(result.results).toEqual([
@@ -459,10 +471,10 @@ describe('databases', () => {
     it('should delete pages by page_ids', async () => {
       mockNotion.pages.update.mockResolvedValueOnce({}).mockResolvedValueOnce({})
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'delete_page',
         page_ids: ['page-1', 'page-2']
-      })
+      })) as DeleteDatabasePageResponse
 
       expect(result.action).toBe('delete_page')
       expect(result.processed).toBe(2)
@@ -479,10 +491,10 @@ describe('databases', () => {
     it('should delete a single page by page_id', async () => {
       mockNotion.pages.update.mockResolvedValueOnce({})
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'delete_page',
         page_id: 'page-solo'
-      })
+      })) as DeleteDatabasePageResponse
 
       expect(result.processed).toBe(1)
       expect(result.results[0]).toEqual({ page_id: 'page-solo', deleted: true })
@@ -501,12 +513,12 @@ describe('databases', () => {
     it('should create a data source with required params', async () => {
       mockNotion.dataSources.create.mockResolvedValueOnce({ id: 'ds-new' })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'create_data_source',
         database_id: 'db-1',
         title: 'New Source',
         properties: { Name: { title: {} } }
-      })
+      })) as CreateDataSourceResponse
 
       expect(result).toEqual({
         action: 'create_data_source',
@@ -554,11 +566,11 @@ describe('databases', () => {
     it('should update data source title', async () => {
       mockNotion.dataSources.update.mockResolvedValueOnce({})
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'update_data_source',
         data_source_id: 'ds-1',
         title: 'Renamed'
-      })
+      })) as UpdateDataSourceResponse
 
       expect(result).toEqual({
         action: 'update_data_source',
@@ -603,11 +615,11 @@ describe('databases', () => {
     it('should update database title', async () => {
       mockNotion.databases.update.mockResolvedValueOnce({})
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'update_database',
         database_id: 'db-1',
         title: 'New Title'
-      })
+      })) as UpdateDatabaseResponse
 
       expect(result).toEqual({
         action: 'update_database',
@@ -688,10 +700,10 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'list_templates',
         database_id: 'db-1'
-      })
+      })) as ListDataSourceTemplatesResponse
 
       expect(result.action).toBe('list_templates')
       expect(result.database_id).toBe('db-1')
@@ -709,11 +721,11 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = await databases(notion, {
+      const result = (await databases(notion, {
         action: 'list_templates',
         database_id: 'db-1',
         data_source_id: 'ds-custom'
-      })
+      })) as ListDataSourceTemplatesResponse
 
       expect(result.data_source_id).toBe('ds-custom')
       expect(mockNotion.dataSources.listTemplates).toHaveBeenCalledWith(

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -53,10 +53,115 @@ export interface DatabasesInput {
   }>
 }
 
+export interface CreateDatabaseResponse {
+  action: 'create'
+  database_id: string
+  data_source_id?: string
+  url: string
+  created: boolean
+}
+
+export interface GetDatabaseResponse {
+  action: 'get'
+  database_id: string
+  title: string
+  description: string
+  url: string
+  is_inline: boolean
+  created_time: string
+  last_edited_time: string
+  data_source: {
+    id: string
+    name: string
+  } | null
+  schema: Record<string, any>
+}
+
+export interface QueryDatabaseResponse {
+  action: 'query'
+  database_id: string
+  data_source_id: string
+  total: number
+  results: Record<string, any>[]
+}
+
+export interface CreateDatabasePageResponse {
+  action: 'create_page'
+  database_id: string
+  data_source_id: string
+  processed: number
+  results: {
+    page_id: string
+    url: string
+    created: boolean
+  }[]
+}
+
+export interface UpdateDatabasePageResponse {
+  action: 'update_page'
+  processed: number
+  results: {
+    page_id: string
+    updated: boolean
+  }[]
+}
+
+export interface DeleteDatabasePageResponse {
+  action: 'delete_page'
+  processed: number
+  results: {
+    page_id: string
+    deleted: boolean
+  }[]
+}
+
+export interface CreateDataSourceResponse {
+  action: 'create_data_source'
+  data_source_id: string
+  database_id: string
+  created: boolean
+}
+
+export interface UpdateDataSourceResponse {
+  action: 'update_data_source'
+  data_source_id: string
+  updated: boolean
+}
+
+export interface UpdateDatabaseResponse {
+  action: 'update_database'
+  database_id: string
+  updated: boolean
+}
+
+export interface ListDataSourceTemplatesResponse {
+  action: 'list_templates'
+  database_id: string
+  data_source_id: string
+  total: number
+  templates: {
+    template_id: string
+    title: string
+    properties: any
+  }[]
+}
+
+export type DatabasesResponse =
+  | CreateDatabaseResponse
+  | GetDatabaseResponse
+  | QueryDatabaseResponse
+  | CreateDatabasePageResponse
+  | UpdateDatabasePageResponse
+  | DeleteDatabasePageResponse
+  | CreateDataSourceResponse
+  | UpdateDataSourceResponse
+  | UpdateDatabaseResponse
+  | ListDataSourceTemplatesResponse
+
 /**
  * Unified databases tool - handles all database operations
  */
-export async function databases(notion: Client, input: DatabasesInput): Promise<any> {
+export async function databases(notion: Client, input: DatabasesInput): Promise<DatabasesResponse> {
   return withErrorHandling(async () => {
     switch (input.action) {
       case 'create':
@@ -103,7 +208,7 @@ export async function databases(notion: Client, input: DatabasesInput): Promise<
  * Create database with initial data source
  * Maps to: POST /v1/databases (API 2025-09-03)
  */
-async function createDatabase(notion: Client, input: DatabasesInput): Promise<any> {
+async function createDatabase(notion: Client, input: DatabasesInput): Promise<CreateDatabaseResponse> {
   if (!input.parent_id || !input.title || !input.properties) {
     throw new NotionMCPError(
       'parent_id, title, and properties required for create action',
@@ -144,7 +249,7 @@ async function createDatabase(notion: Client, input: DatabasesInput): Promise<an
  * Get database info including all data sources
  * Maps to: GET /v1/databases/{id} (API 2025-09-03)
  */
-async function getDatabase(notion: Client, input: DatabasesInput): Promise<any> {
+async function getDatabase(notion: Client, input: DatabasesInput): Promise<GetDatabaseResponse> {
   if (!input.database_id) {
     throw new NotionMCPError('database_id required for get action', 'VALIDATION_ERROR', 'Provide database_id')
   }
@@ -206,7 +311,7 @@ async function getDatabase(notion: Client, input: DatabasesInput): Promise<any> 
  * Query database (via data source)
  * Maps to: POST /v1/data_sources/{id}/query (API 2025-09-03)
  */
-async function queryDatabase(notion: Client, input: DatabasesInput): Promise<any> {
+async function queryDatabase(notion: Client, input: DatabasesInput): Promise<QueryDatabaseResponse> {
   if (!input.database_id) {
     throw new NotionMCPError('database_id required for query action', 'VALIDATION_ERROR', 'Provide database_id')
   }
@@ -310,7 +415,7 @@ async function queryDatabase(notion: Client, input: DatabasesInput): Promise<any
  * Create pages in database (via data source)
  * Maps to: Multiple POST /v1/pages with data_source_id parent (API 2025-09-03)
  */
-async function createDatabasePages(notion: Client, input: DatabasesInput): Promise<any> {
+async function createDatabasePages(notion: Client, input: DatabasesInput): Promise<CreateDatabasePageResponse> {
   if (!input.database_id) {
     throw new NotionMCPError('database_id required', 'VALIDATION_ERROR', 'Provide database_id')
   }
@@ -371,7 +476,7 @@ async function createDatabasePages(notion: Client, input: DatabasesInput): Promi
  * Update pages in database (bulk)
  * Maps to: Multiple PATCH /v1/pages/{id}
  */
-async function updateDatabasePages(notion: Client, input: DatabasesInput): Promise<any> {
+async function updateDatabasePages(notion: Client, input: DatabasesInput): Promise<UpdateDatabasePageResponse> {
   const items =
     input.pages ||
     (input.page_id && input.page_properties ? [{ page_id: input.page_id, properties: input.page_properties }] : [])
@@ -409,7 +514,7 @@ async function updateDatabasePages(notion: Client, input: DatabasesInput): Promi
  * Delete pages in database (bulk archive)
  * Maps to: Multiple PATCH /v1/pages/{id} with archived: true
  */
-async function deleteDatabasePages(notion: Client, input: DatabasesInput): Promise<any> {
+async function deleteDatabasePages(notion: Client, input: DatabasesInput): Promise<DeleteDatabasePageResponse> {
   const pageIds =
     input.page_ids ||
     (input.page_id ? [input.page_id] : []) ||
@@ -446,7 +551,7 @@ async function deleteDatabasePages(notion: Client, input: DatabasesInput): Promi
  * Create additional data source for existing database
  * Maps to: POST /v1/data_sources (API 2025-09-03)
  */
-async function createDataSource(notion: Client, input: DatabasesInput): Promise<any> {
+async function createDataSource(notion: Client, input: DatabasesInput): Promise<CreateDataSourceResponse> {
   if (!input.database_id || !input.title || !input.properties) {
     throw new NotionMCPError(
       'database_id, title, and properties required',
@@ -479,7 +584,7 @@ async function createDataSource(notion: Client, input: DatabasesInput): Promise<
  * Update data source (title, description, properties/schema)
  * Maps to: PATCH /v1/data_sources/{id} (API 2025-09-03)
  */
-async function updateDataSource(notion: Client, input: DatabasesInput): Promise<any> {
+async function updateDataSource(notion: Client, input: DatabasesInput): Promise<UpdateDataSourceResponse> {
   if (!input.data_source_id) {
     throw new NotionMCPError('data_source_id required', 'VALIDATION_ERROR', 'Provide data_source_id')
   }
@@ -522,7 +627,7 @@ async function updateDataSource(notion: Client, input: DatabasesInput): Promise<
  * Update database container (parent, title, is_inline, icon, cover)
  * Maps to: PATCH /v1/databases/{id} (API 2025-09-03)
  */
-async function updateDatabaseContainer(notion: Client, input: DatabasesInput): Promise<any> {
+async function updateDatabaseContainer(notion: Client, input: DatabasesInput): Promise<UpdateDatabaseResponse> {
   if (!input.database_id) {
     throw new NotionMCPError('database_id required', 'VALIDATION_ERROR', 'Provide database_id')
   }
@@ -577,7 +682,10 @@ async function updateDatabaseContainer(notion: Client, input: DatabasesInput): P
  * List data source templates
  * Maps to: GET /v1/data_sources/{id}/templates (API 2025-09-03)
  */
-async function listDataSourceTemplates(notion: Client, input: DatabasesInput): Promise<any> {
+async function listDataSourceTemplates(
+  notion: Client,
+  input: DatabasesInput
+): Promise<ListDataSourceTemplatesResponse> {
   if (!input.database_id) {
     throw new NotionMCPError(
       'database_id required for list_templates action',

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -34,7 +34,7 @@ import { pages } from './composite/pages.js'
 import { users } from './composite/users.js'
 import { workspace } from './composite/workspace.js'
 import { NotionMCPError } from './helpers/errors.js'
-import { registerTools } from './registry'
+import { registerTools } from './registry.js'
 
 const EXPECTED_TOOL_NAMES = [
   'pages',
@@ -286,8 +286,9 @@ describe('registerTools', () => {
 
     it('should route databases tool correctly', async () => {
       const handler = server.getHandler(3)
-      const mockResult = { action: 'query', results: [] }
-      vi.mocked(databases).mockResolvedValue(mockResult)
+      // Fix: updated mockResult to satisfy QueryDatabaseResponse type (must have total)
+      const mockResult = { action: 'query', database_id: 'db-1', data_source_id: 'ds-1', total: 0, results: [] }
+      vi.mocked(databases).mockResolvedValue(mockResult as any)
 
       const result = await handler({
         params: { name: 'databases', arguments: { action: 'query', database_id: 'db-1' } }


### PR DESCRIPTION
🎯 **What:**
Defined specific TypeScript interfaces for all database tool actions in `src/tools/composite/databases.ts` and updated the `databases` function and its helpers to return these typed responses instead of `Promise<any>`.

💡 **Why:**
Using explicit return types improves type safety, maintainability, and developer experience by catching errors at compile time and providing better IDE support. This addresses the weak type safety issue identified in the code health task.

✅ **Verification:**
- Ran `npx vitest src/tools/composite/databases.test.ts` to ensure no regressions.
- Ran `pnpm check` (Biome linting + TypeScript type checking) to verify type correctness.
- Fixed type errors in `src/tools/composite/databases.test.ts` and `src/tools/registry.test.ts` that were exposed by the stricter types.

✨ **Result:**
The `databases` tool now has a strongly typed API contract, making it robust and easier to work with.

---
*PR created automatically by Jules for task [18241875276831184489](https://jules.google.com/task/18241875276831184489) started by @n24q02m*