### PR TITLE
Refactor pages tool to use strict return types

### DIFF
--- a/fix_registry_test.py
+++ b/fix_registry_test.py
@@ -1,0 +1,40 @@
+import re
+
+file_path = 'src/tools/registry.test.ts'
+
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Fix the first error: `should route pages tool correctly`
+# We need to construct a valid GetPageResult object or cast to any
+mock_result_replacement = """
+      const mockResult = {
+        action: 'get',
+        page_id: 'page-123',
+        title: 'Test',
+        url: 'https://notion.so/page-123',
+        created_time: '2023-01-01T00:00:00.000Z',
+        last_edited_time: '2023-01-02T00:00:00.000Z',
+        archived: false,
+        properties: {},
+        content: '# Test Content',
+        block_count: 5
+      } as any
+"""
+
+content = re.sub(
+    r"const mockResult = \{ action: 'get', page_id: 'page-123', title: 'Test' \}",
+    mock_result_replacement.strip(),
+    content
+)
+
+# Fix the second error: `should return well-formed success response structure`
+# The mockResolvedValue({ ok: true }) is invalid because PagesResult doesn't have `ok`.
+# We can cast it to any for the purpose of this test which just checks JSON output structure.
+content = content.replace(
+    "vi.mocked(pages).mockResolvedValue({ ok: true })",
+    "vi.mocked(pages).mockResolvedValue({ ok: true } as any)"
+)
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/fix_test_types.py
+++ b/fix_test_types.py
@@ -1,0 +1,84 @@
+import re
+
+file_path = 'src/tools/composite/pages.test.ts'
+
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Import the new result types
+content = content.replace(
+    "import { pages } from './pages'",
+    "import { pages, CreatePageResult, GetPageResult, GetPagePropertyResult, UpdatePageResult, MovePageResult, ArchivePageResult, DuplicatePageResult } from './pages'"
+)
+
+# Fix create tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'create'.*?\}\))",
+    r"\1 as CreatePageResult",
+    content, flags=re.DOTALL
+)
+
+# Fix get tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'get'.*?\}\))",
+    r"\1 as GetPageResult",
+    content, flags=re.DOTALL
+)
+
+# Fix get_property tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'get_property'.*?\}\))",
+    r"\1 as GetPagePropertyResult",
+    content, flags=re.DOTALL
+)
+
+# Fix update tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'update'.*?\}\))",
+    r"\1 as UpdatePageResult",
+    content, flags=re.DOTALL
+)
+
+# Fix move tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'move'.*?\}\))",
+    r"\1 as MovePageResult",
+    content, flags=re.DOTALL
+)
+
+# Fix archive/restore tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'archive'.*?\}\))",
+    r"\1 as ArchivePageResult",
+    content, flags=re.DOTALL
+)
+
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'restore'.*?\}\))",
+    r"\1 as ArchivePageResult",
+    content, flags=re.DOTALL
+)
+
+# Fix duplicate tests
+content = re.sub(
+    r"(const result = await pages\(.*?, \{\s*action: 'duplicate'.*?\}\))",
+    r"\1 as DuplicatePageResult",
+    content, flags=re.DOTALL
+)
+
+with open(file_path, 'w') as f:
+    f.write(content)
+
+# Fix src/tools/composite/pages.ts
+pages_path = 'src/tools/composite/pages.ts'
+with open(pages_path, 'r') as f:
+    pages_content = f.read()
+
+# Fix the archivePage return type issue
+pages_content = pages_content.replace(
+    "action: input.action,",
+    "action: input.action as 'archive' | 'restore',"
+)
+
+with open(pages_path, 'w') as f:
+    f.write(pages_content)

--- a/refactor_pages.py
+++ b/refactor_pages.py
@@ -1,0 +1,123 @@
+import re
+
+file_path = 'src/tools/composite/pages.ts'
+
+with open(file_path, 'r') as f:
+    content = f.read()
+
+# Define interfaces
+interfaces = """
+export interface CreatePageResult {
+  action: 'create'
+  page_id: string
+  url: string
+  created: true
+}
+
+export interface GetPageResult {
+  action: 'get'
+  page_id: string
+  url: string
+  created_time: string
+  last_edited_time: string
+  archived: boolean
+  properties: Record<string, any>
+  content: string
+  block_count: number
+}
+
+export interface GetPagePropertyResult {
+  action: 'get_property'
+  page_id: string
+  property_id: string
+  type: string
+  value: any
+}
+
+export interface UpdatePageResult {
+  action: 'update'
+  page_id: string
+  updated: true
+}
+
+export interface MovePageResult {
+  action: 'move'
+  page_id: string
+  new_parent_id: string
+  moved: true
+}
+
+export interface ArchivePageResult {
+  action: 'archive' | 'restore'
+  processed: number
+  results: Array<{ page_id: string; archived: boolean }>
+}
+
+export interface DuplicatePageResult {
+  action: 'duplicate'
+  processed: number
+  results: Array<{ original_id: string; duplicate_id: string; url: string }>
+}
+
+export type PagesResult =
+  | CreatePageResult
+  | GetPageResult
+  | GetPagePropertyResult
+  | UpdatePageResult
+  | MovePageResult
+  | ArchivePageResult
+  | DuplicatePageResult
+"""
+
+# Insert interfaces after imports
+# Find the last import
+import_end = 0
+for match in re.finditer(r'^import .*', content, re.MULTILINE):
+    import_end = match.end()
+
+content = content[:import_end+1] + "\n" + interfaces + content[import_end+1:]
+
+# Update pages function signature
+content = content.replace(
+    "export async function pages(notion: Client, input: PagesInput): Promise<any> {",
+    "export async function pages(notion: Client, input: PagesInput): Promise<PagesResult> {"
+)
+
+# Update helper function signatures
+content = content.replace(
+    "async function createPage(notion: Client, input: PagesInput): Promise<any> {",
+    "async function createPage(notion: Client, input: PagesInput): Promise<CreatePageResult> {"
+)
+
+content = content.replace(
+    "async function getPage(notion: Client, input: PagesInput): Promise<any> {",
+    "async function getPage(notion: Client, input: PagesInput): Promise<GetPageResult> {"
+)
+
+content = content.replace(
+    "async function getPageProperty(notion: Client, input: PagesInput): Promise<any> {",
+    "async function getPageProperty(notion: Client, input: PagesInput): Promise<GetPagePropertyResult> {"
+)
+
+content = content.replace(
+    "async function updatePage(notion: Client, input: PagesInput): Promise<any> {",
+    "async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePageResult> {"
+)
+
+content = content.replace(
+    "async function movePage(notion: Client, input: PagesInput): Promise<any> {",
+    "async function movePage(notion: Client, input: PagesInput): Promise<MovePageResult> {"
+)
+
+content = content.replace(
+    "async function archivePage(notion: Client, input: PagesInput): Promise<any> {",
+    "async function archivePage(notion: Client, input: PagesInput): Promise<ArchivePageResult> {"
+)
+
+content = content.replace(
+    "async function duplicatePage(notion: Client, input: PagesInput): Promise<any> {",
+    "async function duplicatePage(notion: Client, input: PagesInput): Promise<DuplicatePageResult> {"
+)
+
+with open(file_path, 'w') as f:
+    f.write(content)

--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { pages } from './pages'
+import {
+  type ArchivePageResult,
+  type CreatePageResult,
+  type DuplicatePageResult,
+  type GetPagePropertyResult,
+  type GetPageResult,
+  type MovePageResult,
+  pages,
+  type UpdatePageResult
+} from './pages'
 
 vi.mock('../helpers/markdown.js', () => ({
   markdownToBlocks: vi.fn((md: string) => {
@@ -52,11 +61,11 @@ describe('pages', () => {
     it('creates page with title and page parent', async () => {
       mockNotion.pages.create.mockResolvedValue({ id: 'page-1', url: 'https://notion.so/page-1' })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'create',
         title: 'Test Page',
         parent_id: 'parent-1'
-      })
+      })) as CreatePageResult
 
       expect(result).toEqual({
         action: 'create',
@@ -75,12 +84,12 @@ describe('pages', () => {
     it('creates page with database parent when properties provided', async () => {
       mockNotion.pages.create.mockResolvedValue({ id: 'page-2', url: 'https://notion.so/page-2' })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'create',
         title: 'DB Page',
         parent_id: 'db-123',
         properties: { Status: { select: { name: 'Active' } } }
-      })
+      })) as CreatePageResult
 
       expect(result.page_id).toBe('page-2')
       expect(mockNotion.pages.create).toHaveBeenCalledWith(
@@ -186,7 +195,7 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, { action: 'get', page_id: 'page-1' })
+      const result = (await pages(mockNotion as any, { action: 'get', page_id: 'page-1' })) as GetPageResult
 
       expect(result).toEqual({
         action: 'get',
@@ -216,7 +225,7 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, { action: 'get', page_id: 'page-2' })
+      const result = (await pages(mockNotion as any, { action: 'get', page_id: 'page-2' })) as GetPageResult
 
       expect(result.block_count).toBe(0)
       expect(result.properties).toEqual({})
@@ -268,7 +277,7 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, { action: 'get', page_id: 'page-3' })
+      const result = (await pages(mockNotion as any, { action: 'get', page_id: 'page-3' })) as GetPageResult
       const p = result.properties
 
       expect(p.Name).toBe('Hello World')
@@ -317,7 +326,7 @@ describe('pages', () => {
           has_more: false
         })
 
-      const result = await pages(mockNotion as any, { action: 'get', page_id: 'page-4' })
+      const result = (await pages(mockNotion as any, { action: 'get', page_id: 'page-4' })) as GetPageResult
 
       expect(result.block_count).toBe(2)
       expect(mockNotion.blocks.children.list).toHaveBeenCalledTimes(2)
@@ -342,11 +351,11 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'title'
-      })
+      })) as GetPagePropertyResult
 
       expect(result).toEqual({
         action: 'get_property',
@@ -367,11 +376,11 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'desc'
-      })
+      })) as GetPagePropertyResult
 
       expect(result.type).toBe('rich_text')
       expect(result.value).toBe('First Second')
@@ -387,11 +396,11 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'related'
-      })
+      })) as GetPagePropertyResult
 
       expect(result.type).toBe('relation')
       expect(result.value).toEqual(['rel-a', 'rel-b'])
@@ -407,11 +416,11 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'assignees'
-      })
+      })) as GetPagePropertyResult
 
       expect(result.type).toBe('people')
       expect(result.value).toEqual([
@@ -427,11 +436,11 @@ describe('pages', () => {
         has_more: false
       })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'total'
-      })
+      })) as GetPagePropertyResult
 
       expect(result.type).toBe('rollup')
       expect(result.value).toEqual({ type: 'number', number: 99, function: 'sum' })
@@ -444,11 +453,11 @@ describe('pages', () => {
         number: 42
       })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'count'
-      })
+      })) as GetPagePropertyResult
 
       expect(result.type).toBe('number')
       expect(result.value).toBe(42)
@@ -467,11 +476,11 @@ describe('pages', () => {
           has_more: false
         })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'get_property',
         page_id: 'page-1',
         property_id: 'refs'
-      })
+      })) as GetPagePropertyResult
 
       expect(result.value).toEqual(['r-1', 'r-2'])
       expect(mockNotion.pages.properties.retrieve).toHaveBeenCalledTimes(2)
@@ -497,12 +506,12 @@ describe('pages', () => {
     it('updates metadata with icon and cover', async () => {
       mockNotion.pages.update.mockResolvedValue({ id: 'page-1' })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'update',
         page_id: 'page-1',
         icon: '📝',
         cover: 'https://example.com/banner.jpg'
-      })
+      })) as UpdatePageResult
 
       expect(result).toEqual({ action: 'update', page_id: 'page-1', updated: true })
       expect(mockNotion.pages.update).toHaveBeenCalledWith({
@@ -621,11 +630,11 @@ describe('pages', () => {
     it('moves page to new parent', async () => {
       mockNotion.pages.update.mockResolvedValue({})
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'move',
         page_id: 'page-1',
         parent_id: 'newparent123'
-      })
+      })) as MovePageResult
 
       expect(result).toEqual({
         action: 'move',
@@ -642,11 +651,11 @@ describe('pages', () => {
     it('normalizes parent_id by removing dashes', async () => {
       mockNotion.pages.update.mockResolvedValue({})
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'move',
         page_id: 'page-1',
         parent_id: 'abc-def-123-456'
-      })
+      })) as MovePageResult
 
       expect(result.new_parent_id).toBe('abcdef123456')
       expect(mockNotion.pages.update).toHaveBeenCalledWith({
@@ -675,10 +684,10 @@ describe('pages', () => {
     it('archives multiple pages', async () => {
       mockNotion.pages.update.mockResolvedValue({})
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'archive',
         page_ids: ['page-1', 'page-2', 'page-3']
-      })
+      })) as ArchivePageResult
 
       expect(result.action).toBe('archive')
       expect(result.processed).toBe(3)
@@ -694,10 +703,10 @@ describe('pages', () => {
     it('archives single page via page_id', async () => {
       mockNotion.pages.update.mockResolvedValue({})
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'archive',
         page_id: 'page-solo'
-      })
+      })) as ArchivePageResult
 
       expect(result.processed).toBe(1)
       expect(result.results).toEqual([{ page_id: 'page-solo', archived: true }])
@@ -712,10 +721,10 @@ describe('pages', () => {
     it('restores single page', async () => {
       mockNotion.pages.update.mockResolvedValue({})
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'restore',
         page_id: 'page-archived'
-      })
+      })) as ArchivePageResult
 
       expect(result.action).toBe('restore')
       expect(result.processed).toBe(1)
@@ -726,10 +735,10 @@ describe('pages', () => {
     it('restores multiple pages via page_ids', async () => {
       mockNotion.pages.update.mockResolvedValue({})
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'restore',
         page_ids: ['page-a', 'page-b']
-      })
+      })) as ArchivePageResult
 
       expect(result.processed).toBe(2)
       for (const r of result.results) {
@@ -765,10 +774,10 @@ describe('pages', () => {
       })
       mockNotion.blocks.children.append.mockResolvedValue({ results: [] })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'duplicate',
         page_id: 'orig-1'
-      })
+      })) as DuplicatePageResult
 
       expect(result).toEqual({
         action: 'duplicate',
@@ -887,10 +896,10 @@ describe('pages', () => {
         .mockResolvedValueOnce({ id: 'dup-a', url: 'https://notion.so/dup-a' })
         .mockResolvedValueOnce({ id: 'dup-b', url: 'https://notion.so/dup-b' })
 
-      const result = await pages(mockNotion as any, {
+      const result = (await pages(mockNotion as any, {
         action: 'duplicate',
         page_ids: ['orig-a', 'orig-b']
-      })
+      })) as DuplicatePageResult
 
       expect(result.processed).toBe(2)
       expect(result.results).toHaveLength(2)

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -10,6 +10,67 @@ import { autoPaginate, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties } from '../helpers/properties.js'
 import * as RichText from '../helpers/richtext.js'
 
+export interface CreatePageResult {
+  action: 'create'
+  page_id: string
+  url: string
+  created: true
+}
+
+export interface GetPageResult {
+  action: 'get'
+  page_id: string
+  url: string
+  created_time: string
+  last_edited_time: string
+  archived: boolean
+  properties: Record<string, any>
+  content: string
+  block_count: number
+}
+
+export interface GetPagePropertyResult {
+  action: 'get_property'
+  page_id: string
+  property_id: string
+  type: string
+  value: any
+}
+
+export interface UpdatePageResult {
+  action: 'update'
+  page_id: string
+  updated: true
+}
+
+export interface MovePageResult {
+  action: 'move'
+  page_id: string
+  new_parent_id: string
+  moved: true
+}
+
+export interface ArchivePageResult {
+  action: 'archive' | 'restore'
+  processed: number
+  results: Array<{ page_id: string; archived: boolean }>
+}
+
+export interface DuplicatePageResult {
+  action: 'duplicate'
+  processed: number
+  results: Array<{ original_id: string; duplicate_id: string; url: string }>
+}
+
+export type PagesResult =
+  | CreatePageResult
+  | GetPageResult
+  | GetPagePropertyResult
+  | UpdatePageResult
+  | MovePageResult
+  | ArchivePageResult
+  | DuplicatePageResult
+
 export interface PagesInput {
   action: 'create' | 'get' | 'get_property' | 'update' | 'move' | 'archive' | 'restore' | 'duplicate'
 
@@ -36,7 +97,7 @@ export interface PagesInput {
 /**
  * Unified pages tool - handles all page operations
  */
-export async function pages(notion: Client, input: PagesInput): Promise<any> {
+export async function pages(notion: Client, input: PagesInput): Promise<PagesResult> {
   return withErrorHandling(async () => {
     switch (input.action) {
       case 'create':
@@ -75,7 +136,7 @@ export async function pages(notion: Client, input: PagesInput): Promise<any> {
  * Create page with title and content
  * Maps to: POST /v1/pages + PATCH /v1/blocks/{id}/children
  */
-async function createPage(notion: Client, input: PagesInput): Promise<any> {
+async function createPage(notion: Client, input: PagesInput): Promise<CreatePageResult> {
   if (!input.title) {
     throw new NotionMCPError('title is required for create action', 'VALIDATION_ERROR', 'Provide page title')
   }
@@ -138,7 +199,7 @@ async function createPage(notion: Client, input: PagesInput): Promise<any> {
  * Get page with full content as markdown
  * Maps to: GET /v1/pages/{id} + GET /v1/blocks/{id}/children
  */
-async function getPage(notion: Client, input: PagesInput): Promise<any> {
+async function getPage(notion: Client, input: PagesInput): Promise<GetPageResult> {
   if (!input.page_id) {
     throw new NotionMCPError('page_id is required for get action', 'VALIDATION_ERROR', 'Provide page_id')
   }
@@ -223,7 +284,7 @@ async function getPage(notion: Client, input: PagesInput): Promise<any> {
  * Retrieve a page property item (supports paginated properties like relation, rollup, rich_text)
  * Maps to: GET /v1/pages/{id}/properties/{property_id}
  */
-async function getPageProperty(notion: Client, input: PagesInput): Promise<any> {
+async function getPageProperty(notion: Client, input: PagesInput): Promise<GetPagePropertyResult> {
   if (!input.page_id) {
     throw new NotionMCPError('page_id is required for get_property action', 'VALIDATION_ERROR', 'Provide page_id')
   }
@@ -302,7 +363,7 @@ async function getPageProperty(notion: Client, input: PagesInput): Promise<any> 
  * Update page content/properties
  * Maps to: PATCH /v1/pages/{id} + PATCH /v1/blocks/{id}/children
  */
-async function updatePage(notion: Client, input: PagesInput): Promise<any> {
+async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePageResult> {
   if (!input.page_id) {
     throw new NotionMCPError('page_id is required for update action', 'VALIDATION_ERROR', 'Provide page_id')
   }
@@ -381,7 +442,7 @@ async function updatePage(notion: Client, input: PagesInput): Promise<any> {
  * Move page to a new parent
  * Maps to: POST /v1/pages/{id}/move
  */
-async function movePage(notion: Client, input: PagesInput): Promise<any> {
+async function movePage(notion: Client, input: PagesInput): Promise<MovePageResult> {
   if (!input.page_id) {
     throw new NotionMCPError('page_id is required for move action', 'VALIDATION_ERROR', 'Provide page_id')
   }
@@ -414,7 +475,7 @@ async function movePage(notion: Client, input: PagesInput): Promise<any> {
  * Archive or restore page
  * Maps to: PATCH /v1/pages/{id}
  */
-async function archivePage(notion: Client, input: PagesInput): Promise<any> {
+async function archivePage(notion: Client, input: PagesInput): Promise<ArchivePageResult> {
   const pageIds = input.page_ids || (input.page_id ? [input.page_id] : [])
 
   if (pageIds.length === 0) {
@@ -435,7 +496,7 @@ async function archivePage(notion: Client, input: PagesInput): Promise<any> {
   )
 
   return {
-    action: input.action,
+    action: input.action as 'archive' | 'restore',
     processed: results.length,
     results
   }
@@ -445,7 +506,7 @@ async function archivePage(notion: Client, input: PagesInput): Promise<any> {
  * Duplicate page
  * Maps to: GET /v1/pages/{id} + POST /v1/pages + GET/PATCH /v1/blocks
  */
-async function duplicatePage(notion: Client, input: PagesInput): Promise<any> {
+async function duplicatePage(notion: Client, input: PagesInput): Promise<DuplicatePageResult> {
   const pageIds = input.page_ids || (input.page_id ? [input.page_id] : [])
 
   if (pageIds.length === 0) {

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -271,7 +271,18 @@ describe('registerTools', () => {
 
     it('should route pages tool correctly', async () => {
       const handler = server.getHandler(3)
-      const mockResult = { action: 'get', page_id: 'page-123', title: 'Test' }
+      const mockResult = {
+        action: 'get',
+        page_id: 'page-123',
+        title: 'Test',
+        url: 'https://notion.so/page-123',
+        created_time: '2023-01-01T00:00:00.000Z',
+        last_edited_time: '2023-01-02T00:00:00.000Z',
+        archived: false,
+        properties: {},
+        content: '# Test Content',
+        block_count: 5
+      } as any
       vi.mocked(pages).mockResolvedValue(mockResult)
 
       const result = await handler({
@@ -453,7 +464,7 @@ describe('registerTools', () => {
 
     it('should return well-formed success response structure', async () => {
       const handler = server.getHandler(3)
-      vi.mocked(pages).mockResolvedValue({ ok: true })
+      vi.mocked(pages).mockResolvedValue({ ok: true } as any)
 
       const result = await handler({
         params: { name: 'pages', arguments: { action: 'get', page_id: 'p-1' } }


### PR DESCRIPTION
Refactored `src/tools/composite/pages.ts` to replace `Promise<any>` with a discriminated union `PagesResult` and specific return types for each action (`CreatePageResult`, `GetPageResult`, etc.). This improves type safety and developer experience. Updated tests to handle the new strict types.

---
*PR created automatically by Jules for task [17897507945948413262](https://jules.google.com/task/17897507945948413262) started by @n24q02m*