### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive data leakage in validation error responses

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@n24q02m/better-notion-mcp",
@@ -10,7 +9,7 @@
         "zod": "^4.1.13",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.8",
+        "@biomejs/biome": "^2.4.4",
         "@types/node": "^24.10.1",
         "@vitest/coverage-v8": "^4.0.15",
         "esbuild": "^0.25.12",

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -101,6 +101,25 @@ describe('enhanceError', () => {
       expect(result.message).toBe('Invalid request parameters')
     })
 
+    it('should sanitize validation_error body to remove sensitive fields', () => {
+      const result = enhanceError({
+        code: 'validation_error',
+        message: 'validation failed',
+        body: {
+          message: 'title is required',
+          path: '/properties/title',
+          secret_token: 'sk-12345',
+          internal_state: { some: 'data' }
+        }
+      })
+
+      expect(result.code).toBe('VALIDATION_ERROR')
+      expect(result.message).toBe('title is required')
+      expect(result.details).toEqual({ message: 'title is required', path: '/properties/title' })
+      expect(JSON.stringify(result.details)).not.toContain('secret_token')
+      expect(JSON.stringify(result.details)).not.toContain('sk-12345')
+    })
+
     it('should handle rate_limited error', () => {
       const result = enhanceError({ code: 'rate_limited', message: 'rate limited' })
 

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -26,6 +26,25 @@ export class NotionMCPError extends Error {
 }
 
 /**
+ * Sanitize validation error body to remove sensitive information
+ */
+function sanitizeValidationBody(body: any): any {
+  if (!body || typeof body !== 'object') return body
+
+  // whitelist safe properties from Notion API validation_error responses
+  const safe: any = {}
+  const safeFields = ['message', 'object', 'code', 'status', 'request_id', 'path']
+
+  for (const field of safeFields) {
+    if (field in body) {
+      safe[field] = body[field]
+    }
+  }
+
+  return safe
+}
+
+/**
  * Sanitize error object to remove sensitive information
  */
 function sanitizeErrorDetails(error: any): any {
@@ -120,7 +139,7 @@ function handleNotionError(error: any): NotionMCPError {
         error.body?.message || 'Invalid request parameters',
         'VALIDATION_ERROR',
         'Check the API documentation for valid parameter formats',
-        error.body
+        sanitizeValidationBody(error.body)
       )
 
     case 'rate_limited':


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Notion API `validation_error` bodies were being passed through directly to the client without sanitization, potentially leaking sensitive information via the error response object.
🎯 **Impact:** Exposing internal error fields or unexpected API payload parameters could leak confidential tokens, internal state, or server path logic to end users.
🔧 **Fix:** Added a `sanitizeValidationBody` function that enforces a strict allowlist (whitelist) of safe fields (`message`, `object`, `code`, `status`, `request_id`, `path`) before including the body in the `NotionMCPError` details.
✅ **Verification:** Added a specific unit test in `src/tools/helpers/errors.test.ts` to assert that secret tokens injected into a mock `validation_error` body are stripped out and not leaked in the resulting `details` object. All existing tests pass.

---
*PR created automatically by Jules for task [14595768351904931462](https://jules.google.com/task/14595768351904931462) started by @n24q02m*