### PR TITLE
docs: use `bun run test` instead of `bun test` in contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ bun install                 # Install dependencies
 bun run build               # tsc --build && esbuild CLI bundle
 bun run check               # Biome check + tsc --noEmit (CI command)
 bun run check:fix           # Auto-fix Biome + type check
-bun test                    # vitest --passWithNoTests
+bun run test                # vitest --passWithNoTests (NEVER use bare "bun test")
 bun run test:watch          # vitest watch
 bun run test:coverage       # vitest --coverage
 bun run lint                # biome lint src
@@ -26,7 +26,7 @@ bun x vitest run -t "test name pattern"
 # Mise shortcuts
 mise run setup              # Full dev environment setup
 mise run lint               # bun run check
-mise run test               # bun test
+mise run test               # bun run test
 mise run fix                # bun run check:fix
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,10 @@ bun run build
 4. **Run tests**
 
 ```bash
-bun test
+bun run test
 ```
+
+> **Note:** Always use `bun run test` (which runs vitest), not `bun test` (which uses bun's built-in test runner). The test suite uses vitest-specific APIs like `vi.hoisted()` and `importOriginal` that are not available in bun's runner.
 
 ## Development Workflow
 
@@ -65,7 +67,7 @@ bun run dev
 1. Create a new branch: `git checkout -b feature/your-feature-name`
 2. Make your changes
 3. Run checks: `bun run check`
-4. Run tests: `bun test`
+4. Run tests: `bun run test`
 5. Build the project: `bun run build`
 6. Commit your changes (see [Commit Convention](#commit-convention))
 7. Push to your fork: `git push origin feature/your-feature-name`
@@ -151,7 +153,7 @@ You do **not** need to create manual tags or changelog entries.
 Before submitting your PR, ensure:
 
 - [ ] Code follows TypeScript best practices
-- [ ] All tests pass (`bun test`)
+- [ ] All tests pass (`bun run test`)
 - [ ] Linting passes (`bun run lint`)
 - [ ] Formatting is correct (`bun run format:check`)
 - [ ] Type checking passes (`bun run type-check`)
@@ -183,7 +185,7 @@ bun run check:fix     # Auto-fix issues
 
 ```bash
 # Run all tests
-bun test
+bun run test
 
 # Run tests in watch mode
 bun run test:watch


### PR DESCRIPTION
## Summary

While setting up a development environment for this project (without mise), I ran into test failures when following the CONTRIBUTING.md instructions to run `bun test`. On my machine (bun 1.3.10, macOS), this invokes bun's built-in test runner rather than vitest, which causes errors like:

```
TypeError: vi.hoisted is not a function
TypeError: importOriginal is not a function
```

Switching to `bun run test` resolves this since it delegates to the `vitest` script defined in package.json, and all 944 tests pass.

I noticed that `.mise.toml` already uses `bun run test` for its test task, so this may just be a documentation fix. It's possible that `bun test` behaves differently on other bun versions or with mise managing the environment - if so, happy to adjust the PR.

### Changes

- CONTRIBUTING.md: `bun test` -> `bun run test` in setup, workflow, PR checklist, and testing sections
- CONTRIBUTING.md: added a note explaining the difference between the two commands
- AGENTS.md: same fix in the command reference

## Test plan

- [x] Verified `bun run test` passes all 944 tests
- [x] Verified `bun run check` passes