### PR TITLE
feat: page mention syntax @[Title](id) (#1)

### DIFF
--- a/src/docs/blocks.md
+++ b/src/docs/blocks.md
@@ -39,6 +39,7 @@ Inline formatting within any text content:
 - `Code`: `` `text` ``
 - ~~Strikethrough~~: `~~text~~`
 - Links: `[text](url)`
+- Page mentions: `@[Page Title](page-id)` - creates an inline @mention, not a hyperlink
 
 ## Actions
 

--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -1031,6 +1031,177 @@ describe('parseRichText', () => {
     const result = parseRichText('plain')
     expect(result[0].text.link).toBeNull()
   })
+
+  describe('page mentions', () => {
+    it('should parse @[Title](page-id) as mention rich text', () => {
+      const result = parseRichText('@[My Page](abc123def456)')
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe('mention')
+      expect((result[0] as any).mention).toEqual({ page: { id: 'abc123def456' } })
+      expect(result[0].plain_text).toBe('My Page')
+    })
+
+    it('should parse mention with UUID page id', () => {
+      const result = parseRichText('@[Test](a1b2c3d4-e5f6-7890-abcd-ef1234567890)')
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe('mention')
+      expect((result[0] as any).mention).toEqual({ page: { id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' } })
+    })
+
+    it('should parse mention with Notion URL and extract page id', () => {
+      const result = parseRichText('@[My Page](https://www.notion.so/My-Page-abc123def456abc123def456abc123de)')
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe('mention')
+      expect((result[0] as any).mention).toEqual({ page: { id: 'abc123def456abc123def456abc123de' } })
+    })
+
+    it('should parse mention mixed with plain text', () => {
+      const result = parseRichText('See @[My Page](abc123) for details')
+      expect(result).toHaveLength(3)
+      expect(result[0].type).toBe('text')
+      expect(result[0].text.content).toBe('See ')
+      expect(result[1].type).toBe('mention')
+      expect((result[1] as any).mention).toEqual({ page: { id: 'abc123' } })
+      expect(result[1].plain_text).toBe('My Page')
+      expect(result[2].type).toBe('text')
+      expect(result[2].text.content).toBe(' for details')
+    })
+
+    it('should not confuse regular links with mentions', () => {
+      const result = parseRichText('[click](https://example.com)')
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe('text')
+      expect(result[0].text.link!.url).toBe('https://example.com')
+    })
+  })
+})
+
+// ============================================================
+// richTextToMarkdown (via blocksToMarkdown)
+// ============================================================
+
+describe('richTextToMarkdown mention handling', () => {
+  it('should serialize page mention to @[Title](id)', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'abc123' } },
+              plain_text: 'My Page',
+              href: 'https://www.notion.so/abc123',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('@[My Page](abc123)')
+  })
+
+  it('should serialize mention alongside plain text', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            plainRichText('See '),
+            {
+              type: 'mention',
+              mention: { page: { id: 'abc123' } },
+              plain_text: 'My Page',
+              href: 'https://www.notion.so/abc123',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            },
+            plainRichText(' for details')
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    expect(blocksToMarkdown(blocks)).toBe('See @[My Page](abc123) for details')
+  })
+
+  it('should not drop mention elements silently', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { page: { id: 'xyz789' } },
+              plain_text: 'Referenced Page',
+              href: null,
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    const result = blocksToMarkdown(blocks)
+    expect(result).not.toBe('')
+    expect(result).toContain('Referenced Page')
+    expect(result).toContain('xyz789')
+  })
+
+  it('should handle database mention gracefully', () => {
+    const blocks: NotionBlock[] = [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'mention',
+              mention: { database: { id: 'db123' } },
+              plain_text: 'My Database',
+              href: 'https://www.notion.so/db123',
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default'
+              }
+            }
+          ],
+          color: 'default'
+        }
+      }
+    ]
+    const result = blocksToMarkdown(blocks)
+    expect(result).toContain('My Database')
+  })
 })
 
 // ============================================================

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -15,10 +15,15 @@ export interface NotionBlock {
 }
 
 export interface RichText {
-  type: 'text'
+  type: 'text' | 'mention'
   text: {
     content: string
     link?: { url: string } | null
+  }
+  mention?: {
+    page?: { id: string }
+    database?: { id: string }
+    [key: string]: any
   }
   annotations: {
     bold: boolean
@@ -365,6 +370,45 @@ export function parseRichText(text: string): RichText[] {
     const char = text[i]
     const next = text[i + 1]
 
+    // Page mention @[Title](page-id-or-url) — must come before link handling
+    if (char === '@' && next === '[') {
+      const closeBracket = text.indexOf(']', i + 2)
+      if (closeBracket !== -1 && closeBracket + 1 < text.length && text[closeBracket + 1] === '(') {
+        const closeParen = text.indexOf(')', closeBracket + 2)
+        if (closeParen !== -1) {
+          if (current) {
+            richText.push(createRichText(current, { bold, italic, code, strikethrough }))
+            current = ''
+          }
+
+          const mentionTitle = text.slice(i + 2, closeBracket)
+          const mentionTarget = text.slice(closeBracket + 2, closeParen)
+
+          // Extract 32-char hex page ID from Notion URL or use as-is
+          const idMatch = mentionTarget.match(/([a-f0-9]{32})/)
+          const pageId = idMatch ? idMatch[1] : mentionTarget
+
+          richText.push({
+            type: 'mention',
+            mention: { page: { id: pageId } },
+            text: { content: mentionTitle, link: null },
+            plain_text: mentionTitle,
+            annotations: {
+              bold,
+              italic,
+              strikethrough,
+              underline: false,
+              code,
+              color: 'default'
+            }
+          })
+
+          i = closeParen
+          continue
+        }
+      }
+    }
+
     // Link [text](url) — optimized to avoid O(N²) on pathological inputs
     if (char === '[' && !noMoreCloseBrackets) {
       const closeBracket = text.indexOf(']', i + 1)
@@ -460,7 +504,18 @@ function richTextToMarkdown(richText: RichText[]): string {
 
   return richText
     .map((rt) => {
-      if (!rt || !rt.text) return ''
+      if (!rt) return ''
+
+      // Handle mention elements
+      if (rt.type === 'mention' && rt.mention) {
+        const title = rt.plain_text || rt.text?.content || 'Untitled'
+        const id = rt.mention.page?.id || rt.mention.database?.id || ''
+        if (id) return `@[${title}](${id})`
+        // Fallback for other mention types (user, date, etc.)
+        return title
+      }
+
+      if (!rt.text) return ''
 
       let text = rt.text.content || ''
       const annotations = rt.annotations || {}

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -37,6 +37,27 @@ export interface RichText {
   href?: string | null
 }
 
+/** Create a mention rich text element (no text property - Notion API rejects it on mentions) */
+function createMention(
+  mentionData: RichText['mention'],
+  title: string,
+  formatting: { bold: boolean; italic: boolean; code: boolean; strikethrough: boolean }
+): RichText {
+  return {
+    type: 'mention',
+    mention: mentionData,
+    plain_text: title,
+    annotations: {
+      bold: formatting.bold,
+      italic: formatting.italic,
+      strikethrough: formatting.strikethrough,
+      underline: false,
+      code: formatting.code,
+      color: 'default'
+    }
+  } as RichText
+}
+
 // Regular expressions for block parsing
 const CALLOUT_REGEX = /^>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|INFO|SUCCESS|ERROR)\]\s*(.*)/i
 const IMAGE_REGEX = /^!\[([^\]]*)\]\(([^)]+)\)$/
@@ -388,20 +409,7 @@ export function parseRichText(text: string): RichText[] {
           const idMatch = mentionTarget.match(/([a-f0-9]{32})/)
           const pageId = idMatch ? idMatch[1] : mentionTarget
 
-          richText.push({
-            type: 'mention',
-            mention: { page: { id: pageId } },
-            text: { content: mentionTitle, link: null },
-            plain_text: mentionTitle,
-            annotations: {
-              bold,
-              italic,
-              strikethrough,
-              underline: false,
-              code,
-              color: 'default'
-            }
-          })
+          richText.push(createMention({ page: { id: pageId } }, mentionTitle, { bold, italic, code, strikethrough }))
 
           i = closeParen
           continue
@@ -534,7 +542,7 @@ function richTextToMarkdown(richText: RichText[]): string {
  * Extract plain text from rich text
  */
 export function extractPlainText(richText: RichText[]): string {
-  return richText.map((rt) => rt.text.content).join('')
+  return richText.map((rt) => rt.plain_text || rt.text?.content || '').join('')
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

Adds two-directional support for Notion page mentions in markdown:

- **Markdown -> Blocks**: `@[Page Title](page-id)` syntax parsed by `parseRichText()` into proper Notion mention rich text elements
- **Blocks -> Markdown**: Mention rich text from Notion API serialized back to `@[Title](id)` by `richTextToMarkdown()`
- Supports page IDs (hex, UUID, Notion URL with auto-extraction of 32-char ID)
- Database mentions also serialized on readback
- Previously, mention elements were silently dropped (returned empty string)

Fixes #1

## Test plan

- [x] 8 unit tests (5 parseRichText + 4 blocksToMarkdown mention tests)
- [x] All 962 existing tests pass
- [x] Integration tested: created page with mention via Notion API, confirmed mention appears in Notion UI, readback produces correct `@[Title](id)` markdown
- [x] Verified `text` property is NOT included on mention elements (Notion API rejects it with "Invalid URL for link")

🤖 Generated with [Claude Code](https://claude.com/claude-code)