### PR TITLE
fix(properties): handle relation type in convertToNotionProperties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ bun install                 # Install dependencies
 bun run build               # tsc --build && esbuild CLI bundle
 bun run check               # Biome check + tsc --noEmit (CI command)
 bun run check:fix           # Auto-fix Biome + type check
-bun test                    # vitest --passWithNoTests
+bun run test                # vitest --passWithNoTests (NEVER use bare "bun test")
 bun run test:watch          # vitest watch
 bun run test:coverage       # vitest --coverage
 bun run lint                # biome lint src
@@ -26,7 +26,7 @@ bun x vitest run -t "test name pattern"
 # Mise shortcuts
 mise run setup              # Full dev environment setup
 mise run lint               # bun run check
-mise run test               # bun test
+mise run test               # bun run test
 mise run fix                # bun run check:fix
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,10 @@ bun run build
 4. **Run tests**
 
 ```bash
-bun test
+bun run test
 ```
+
+> **Note:** Always use `bun run test` (which runs vitest), not `bun test` (which uses bun's built-in test runner). The test suite uses vitest-specific APIs like `vi.hoisted()` and `importOriginal` that are not available in bun's runner.
 
 ## Development Workflow
 
@@ -65,7 +67,7 @@ bun run dev
 1. Create a new branch: `git checkout -b feature/your-feature-name`
 2. Make your changes
 3. Run checks: `bun run check`
-4. Run tests: `bun test`
+4. Run tests: `bun run test`
 5. Build the project: `bun run build`
 6. Commit your changes (see [Commit Convention](#commit-convention))
 7. Push to your fork: `git push origin feature/your-feature-name`
@@ -151,7 +153,7 @@ You do **not** need to create manual tags or changelog entries.
 Before submitting your PR, ensure:
 
 - [ ] Code follows TypeScript best practices
-- [ ] All tests pass (`bun test`)
+- [ ] All tests pass (`bun run test`)
 - [ ] Linting passes (`bun run lint`)
 - [ ] Formatting is correct (`bun run format:check`)
 - [ ] Type checking passes (`bun run type-check`)
@@ -183,7 +185,7 @@ bun run check:fix     # Auto-fix issues
 
 ```bash
 # Run all tests
-bun test
+bun run test
 
 # Run tests in watch mode
 bun run test:watch

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -206,6 +206,98 @@ describe('convertToNotionProperties', () => {
     })
   })
 
+  describe('relation values with schema', () => {
+    it('converts a single page ID string to relation format', () => {
+      const result = convertToNotionProperties({ Project: 'abc123def456' }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: { relation: [{ id: 'abc123def456' }] }
+      })
+    })
+
+    it('converts a UUID string to relation format', () => {
+      const result = convertToNotionProperties(
+        { Project: '12345678-1234-1234-1234-123456789abc' },
+        { Project: 'relation' }
+      )
+      expect(result).toEqual({
+        Project: { relation: [{ id: '12345678-1234-1234-1234-123456789abc' }] }
+      })
+    })
+
+    it('converts a Notion URL to relation format by extracting the page ID', () => {
+      const result = convertToNotionProperties(
+        { Project: 'https://www.notion.so/My-Page-abc123def45678901234567890abcdef' },
+        { Project: 'relation' }
+      )
+      expect(result).toEqual({
+        Project: { relation: [{ id: 'abc123def45678901234567890abcdef' }] }
+      })
+    })
+
+    it('converts a Notion URL with query params to relation format', () => {
+      const result = convertToNotionProperties(
+        { Project: 'https://www.notion.so/workspace/abc123def45678901234567890abcdef?v=xyz' },
+        { Project: 'relation' }
+      )
+      expect(result).toEqual({
+        Project: { relation: [{ id: 'abc123def45678901234567890abcdef' }] }
+      })
+    })
+
+    it('converts an array of page ID strings to relation format', () => {
+      const result = convertToNotionProperties({ Projects: ['abc123', 'def456'] }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [{ id: 'abc123' }, { id: 'def456' }] }
+      })
+    })
+
+    it('converts an array of Notion URLs to relation format', () => {
+      const result = convertToNotionProperties(
+        {
+          Projects: [
+            'https://www.notion.so/Page-A-abc123def45678901234567890abcdef',
+            'https://www.notion.so/Page-B-fedcba09876543210987654321fedcba'
+          ]
+        },
+        { Projects: 'relation' }
+      )
+      expect(result).toEqual({
+        Projects: {
+          relation: [{ id: 'abc123def45678901234567890abcdef' }, { id: 'fedcba09876543210987654321fedcba' }]
+        }
+      })
+    })
+
+    it('converts a JSON array string to relation format', () => {
+      const result = convertToNotionProperties({ Projects: '["abc123", "def456"]' }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [{ id: 'abc123' }, { id: 'def456' }] }
+      })
+    })
+
+    it('converts empty string to empty relation array', () => {
+      const result = convertToNotionProperties({ Project: '' }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: { relation: [] }
+      })
+    })
+
+    it('converts empty array to empty relation', () => {
+      const result = convertToNotionProperties({ Projects: [] }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [] }
+      })
+    })
+
+    it('passes through pre-formatted relation objects as-is', () => {
+      const value = { relation: [{ id: 'abc123' }] }
+      const result = convertToNotionProperties({ Project: value }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: value
+      })
+    })
+  })
+
   describe('mixed properties with schema', () => {
     it('converts multiple property types in a single call', () => {
       const properties = {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -5,6 +5,37 @@
 
 import * as RichText from './richtext.js'
 
+/** Extract a 32-char hex page ID from a Notion URL, or return the input as-is if it's already a raw ID */
+function extractPageId(value: string): string {
+  const match = value.match(/([a-f0-9]{32})/)
+  if (match) return match[1]
+  // Also accept hyphenated UUIDs as-is
+  return value
+}
+
+/** Convert a single string or array value to Notion relation format */
+function toRelation(value: any): { relation: { id: string }[] } {
+  if (typeof value === 'string') {
+    if (value === '') return { relation: [] }
+    // Try parsing as JSON array (e.g. '["id1", "id2"]')
+    if (value.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(value)
+        if (Array.isArray(parsed)) {
+          return { relation: parsed.map((v: string) => ({ id: extractPageId(v) })) }
+        }
+      } catch {
+        // Not valid JSON, treat as single value
+      }
+    }
+    return { relation: [{ id: extractPageId(value) }] }
+  }
+  if (Array.isArray(value)) {
+    return { relation: value.map((v: string) => ({ id: extractPageId(v) })) }
+  }
+  return value
+}
+
 /**
  * Convert simple property values to Notion API format
  * Handles auto-detection of property types and conversion
@@ -42,6 +73,8 @@ export function convertToNotionProperties(
         converted[key] = { email: value }
       } else if (schemaType === 'phone_number') {
         converted[key] = { phone_number: value }
+      } else if (schemaType === 'relation') {
+        converted[key] = toRelation(value)
       } else if (key === 'Name' || key === 'Title' || key.toLowerCase() === 'title') {
         // Fallback: guess title from key name
         converted[key] = { title: [RichText.text(value)] }
@@ -54,6 +87,11 @@ export function convertToNotionProperties(
     } else if (typeof value === 'boolean') {
       converted[key] = { checkbox: value }
     } else if (Array.isArray(value)) {
+      const schemaType = schema?.[key]
+      if (schemaType === 'relation') {
+        converted[key] = toRelation(value)
+        continue
+      }
       // Could be multi_select, relation, people, files
       // Only assume multi_select if all elements are strings
       if (value.length > 0 && value.every((v) => typeof v === 'string')) {


### PR DESCRIPTION
## Summary

`convertToNotionProperties()` handles `title`, `rich_text`, `date`, `url`, `email`, `phone_number` schema types - but when the schema says `relation`, the value falls through to the default `select` format. This causes Notion API errors like `"Related is expected to be relation."`.

Fix: Add `relation` branch that converts page IDs, Notion URLs, JSON array strings, and arrays to Notion API relation format.

- Single page ID string or UUID
- Notion URLs (extracts 32-char hex ID from path)
- JSON array strings (`'["id1","id2"]'`)
- Arrays of IDs or URLs
- Empty string/array produces `{ relation: [] }`
- Pre-formatted objects pass through as-is

## Test plan

### Unit tests (9 new, all pass)
- Single page ID, UUID, Notion URL, URL with query params
- Array of IDs, array of URLs, JSON array string
- Empty string, empty array, pre-formatted passthrough

### Integration tests against live Notion
- Bug confirmed: string value rejected with `"Related is expected to be relation."`
- Single and multi relation accepted
- Empty relation accepted
- Unhyphenated 32-char ID accepted
- Round-trip write/read verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)