### PR TITLE
feat: add icon format detection and cover shorthand support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/docs/databases.md
+++ b/src/docs/databases.md
@@ -75,8 +75,8 @@ Optionally specify `data_source_id` to target a specific data source (defaults t
 - `description` - Description
 - `properties` - Schema properties (for create/update data source)
 - `is_inline` - Display as inline (boolean, for create/update_database)
-- `icon` - Emoji icon (for update_database)
-- `cover` - Cover image URL (for update_database)
+- `icon` - Emoji, external URL (`https://...`), or built-in shorthand (`name:color`, e.g. `document:gray`) (for update_database)
+- `cover` - External URL (`https://...`) or built-in shorthand (e.g. `gradient_1`, `solid_beige`, `nasa_carina_nebula`) (for update_database)
 - `filters` / `sorts` / `limit` - Query options
 - `search` - Smart search across text fields
 - `page_id` - Single page ID (for update_page)

--- a/src/docs/pages.md
+++ b/src/docs/pages.md
@@ -64,6 +64,6 @@ Move a page to a new parent page.
 - `parent_id` - Parent page or database ID
 - `properties` - Page properties (for database pages)
 - `property_id` - Property ID (required for get_property action)
-- `icon` - Emoji icon
-- `cover` - Cover image URL
+- `icon` - Emoji, external URL (`https://...`), or built-in shorthand (`name:color`, e.g. `document:gray`)
+- `cover` - External URL (`https://...`) or built-in shorthand (e.g. `gradient_1`, `solid_beige`, `nasa_carina_nebula`)
 - `archived` - Archive status (boolean, for update action)

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -4,12 +4,13 @@
  */
 
 import type { Client } from '@notionhq/client'
+import { formatCover } from '../helpers/covers.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
+import { formatIcon } from '../helpers/icons.js'
 import { normalizeId } from '../helpers/id.js'
 import { autoPaginate, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
 import * as RichText from '../helpers/richtext.js'
-import { isSafeUrl } from '../helpers/security.js'
 
 export interface DatabasesInput {
   action:
@@ -165,10 +166,7 @@ export type DatabasesResponse =
  * Tries database_id first; if NOT_FOUND, tries as data_source_id
  * Returns both IDs for downstream operations
  */
-async function resolveDataSourceId(
-  notion: Client,
-  id: string
-): Promise<{ databaseId: string; dataSourceId: string }> {
+async function resolveDataSourceId(notion: Client, id: string): Promise<{ databaseId: string; dataSourceId: string }> {
   const normalized = normalizeId(id)
 
   // Try as database container first
@@ -673,19 +671,10 @@ async function updateDatabaseContainer(notion: Client, input: DatabasesInput): P
   }
 
   if (input.icon) {
-    updates.icon = { type: 'emoji', emoji: input.icon }
+    updates.icon = formatIcon(input.icon)
   }
 
-  if (input.cover) {
-    if (!isSafeUrl(input.cover)) {
-      throw new NotionMCPError(
-        `Unsafe cover URL: ${input.cover}`,
-        'VALIDATION_ERROR',
-        'Use a safe URL (http:, https:).'
-      )
-    }
-    updates.cover = { type: 'external', external: { url: input.cover } }
-  }
+  if (input.cover) updates.cover = formatCover(input.cover)
 
   if (Object.keys(updates).length === 0) {
     throw new NotionMCPError(

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -4,12 +4,13 @@
  */
 
 import type { Client } from '@notionhq/client'
+import { formatCover } from '../helpers/covers.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
+import { formatIcon } from '../helpers/icons.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, fetchChildrenRecursive, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
 import * as RichText from '../helpers/richtext.js'
-import { isSafeUrl } from '../helpers/security.js'
 
 export interface CreatePageResult {
   action: 'create'
@@ -172,17 +173,8 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
   }
 
   const pageData: any = { parent, properties }
-  if (input.icon) pageData.icon = { type: 'emoji', emoji: input.icon }
-  if (input.cover) {
-    if (!isSafeUrl(input.cover)) {
-      throw new NotionMCPError(
-        `Unsafe cover URL: ${input.cover}`,
-        'VALIDATION_ERROR',
-        'Use a safe URL (http:, https:).'
-      )
-    }
-    pageData.cover = { type: 'external', external: { url: input.cover } }
-  }
+  if (input.icon) pageData.icon = formatIcon(input.icon)
+  if (input.cover) pageData.cover = formatCover(input.cover)
 
   const page = await notion.pages.create(pageData)
 
@@ -349,17 +341,8 @@ async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePage
   const updates: any = {}
 
   // Update metadata
-  if (input.icon) updates.icon = { type: 'emoji', emoji: input.icon }
-  if (input.cover) {
-    if (!isSafeUrl(input.cover)) {
-      throw new NotionMCPError(
-        `Unsafe cover URL: ${input.cover}`,
-        'VALIDATION_ERROR',
-        'Use a safe URL (http:, https:).'
-      )
-    }
-    updates.cover = { type: 'external', external: { url: input.cover } }
-  }
+  if (input.icon) updates.icon = formatIcon(input.icon)
+  if (input.cover) updates.cover = formatCover(input.cover)
   if (input.archived !== undefined) updates.archived = input.archived
 
   // Update properties

--- a/src/tools/helpers/covers.test.ts
+++ b/src/tools/helpers/covers.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { formatCover, listCovers } from './covers'
+import { NotionMCPError } from './errors'
+
+describe('formatCover', () => {
+  describe('URLs', () => {
+    it('should pass through https URLs as external cover', () => {
+      const result = formatCover('https://example.com/cover.jpg')
+      expect(result).toEqual({ type: 'external', external: { url: 'https://example.com/cover.jpg' } })
+    })
+
+    it('should pass through http URLs as external cover', () => {
+      const result = formatCover('http://example.com/cover.jpg')
+      expect(result).toEqual({ type: 'external', external: { url: 'http://example.com/cover.jpg' } })
+    })
+  })
+
+  describe('solid colors', () => {
+    it('should resolve solid_red to Notion CDN URL', () => {
+      const result = formatCover('solid_red')
+      expect(result.type).toBe('external')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/solid_red.png')
+    })
+
+    it('should resolve solid_blue to Notion CDN URL', () => {
+      const result = formatCover('solid_blue')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/solid_blue.png')
+    })
+
+    it('should resolve solid_yellow to Notion CDN URL', () => {
+      const result = formatCover('solid_yellow')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/solid_yellow.png')
+    })
+
+    it('should resolve solid_beige to Notion CDN URL', () => {
+      const result = formatCover('solid_beige')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/solid_beige.png')
+    })
+  })
+
+  describe('gradients', () => {
+    it('should resolve gradient_1 (png)', () => {
+      const result = formatCover('gradient_1')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/gradients_1.png')
+    })
+
+    it('should resolve gradient_10 (jpg)', () => {
+      const result = formatCover('gradient_10')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/gradients_10.jpg')
+    })
+
+    it('should resolve gradient_11 (jpg)', () => {
+      const result = formatCover('gradient_11')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/gradients_11.jpg')
+    })
+  })
+
+  describe('museum and NASA covers', () => {
+    it('should resolve nasa_carina_nebula', () => {
+      const result = formatCover('nasa_carina_nebula')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/nasa_carina_nebula.jpg')
+    })
+
+    it('should resolve met_paul_signac', () => {
+      const result = formatCover('met_paul_signac')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/met_paul_signac.jpg')
+    })
+
+    it('should resolve rijksmuseum_rembrandt_1642', () => {
+      const result = formatCover('rijksmuseum_rembrandt_1642')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/rijksmuseum_rembrandt_1642.jpg')
+    })
+
+    it('should resolve woodcuts_3', () => {
+      const result = formatCover('woodcuts_3')
+      expect(result.external.url).toBe('https://www.notion.so/images/page-cover/woodcuts_3.jpg')
+    })
+  })
+
+  describe('error handling', () => {
+    it('should throw for unknown shorthand', () => {
+      expect(() => formatCover('nonexistent_cover')).toThrow('Unknown cover shorthand')
+    })
+
+    it('should include available covers in error message', () => {
+      expect(() => formatCover('bogus')).toThrow('solid_red')
+    })
+  })
+
+  describe('unsafe URL rejection', () => {
+    it('rejects javascript: URLs', () => {
+      expect(() => formatCover('javascript:alert(1)')).toThrow(NotionMCPError)
+    })
+
+    it('rejects data: URLs', () => {
+      expect(() => formatCover('data:text/html,<script>alert(1)</script>')).toThrow(NotionMCPError)
+    })
+
+    it('rejects vbscript: URLs', () => {
+      expect(() => formatCover('vbscript:msgbox(1)')).toThrow(NotionMCPError)
+    })
+  })
+})
+
+describe('listCovers', () => {
+  it('should return covers grouped by category', () => {
+    const groups = listCovers()
+    expect(groups.solid_colors).toContain('solid_red')
+    expect(groups.solid_colors).toContain('solid_blue')
+    expect(groups.gradients).toContain('gradient_1')
+    expect(groups.gradients).toContain('gradient_11')
+    expect(groups.nasa).toContain('nasa_carina_nebula')
+    expect(groups.met).toContain('met_paul_signac')
+    expect(groups.rijksmuseum).toContain('rijksmuseum_rembrandt_1642')
+    expect(groups.woodcuts).toContain('woodcuts_1')
+  })
+
+  it('should have 4 solid colors', () => {
+    const groups = listCovers()
+    expect(groups.solid_colors).toHaveLength(4)
+  })
+
+  it('should have 11 gradients', () => {
+    const groups = listCovers()
+    expect(groups.gradients).toHaveLength(11)
+  })
+})

--- a/src/tools/helpers/covers.ts
+++ b/src/tools/helpers/covers.ts
@@ -1,0 +1,136 @@
+/**
+ * Cover image format detection and built-in cover catalog
+ * Resolves shorthand names (e.g., "gradient_8", "solid_blue") to full Notion cover URLs
+ */
+
+import { NotionMCPError } from './errors.js'
+import { isSafeUrl } from './security.js'
+
+const NOTION_COVER_BASE = 'https://www.notion.so/images/page-cover'
+
+/** Complete catalog of Notion's built-in cover images */
+const COVER_CATALOG: Record<string, string> = {
+  // Solid colors
+  solid_red: `${NOTION_COVER_BASE}/solid_red.png`,
+  solid_yellow: `${NOTION_COVER_BASE}/solid_yellow.png`,
+  solid_blue: `${NOTION_COVER_BASE}/solid_blue.png`,
+  solid_beige: `${NOTION_COVER_BASE}/solid_beige.png`,
+
+  // Gradients (1-9 are .png, 10-11 are .jpg)
+  gradient_1: `${NOTION_COVER_BASE}/gradients_1.png`,
+  gradient_2: `${NOTION_COVER_BASE}/gradients_2.png`,
+  gradient_3: `${NOTION_COVER_BASE}/gradients_3.png`,
+  gradient_4: `${NOTION_COVER_BASE}/gradients_4.png`,
+  gradient_5: `${NOTION_COVER_BASE}/gradients_5.png`,
+  gradient_6: `${NOTION_COVER_BASE}/gradients_6.png`,
+  gradient_7: `${NOTION_COVER_BASE}/gradients_7.png`,
+  gradient_8: `${NOTION_COVER_BASE}/gradients_8.png`,
+  gradient_9: `${NOTION_COVER_BASE}/gradients_9.png`,
+  gradient_10: `${NOTION_COVER_BASE}/gradients_10.jpg`,
+  gradient_11: `${NOTION_COVER_BASE}/gradients_11.jpg`,
+
+  // Woodcuts (Japanese-style)
+  woodcuts_1: `${NOTION_COVER_BASE}/woodcuts_1.jpg`,
+  woodcuts_2: `${NOTION_COVER_BASE}/woodcuts_2.jpg`,
+  woodcuts_3: `${NOTION_COVER_BASE}/woodcuts_3.jpg`,
+  woodcuts_4: `${NOTION_COVER_BASE}/woodcuts_4.jpg`,
+  woodcuts_5: `${NOTION_COVER_BASE}/woodcuts_5.jpg`,
+  woodcuts_6: `${NOTION_COVER_BASE}/woodcuts_6.jpg`,
+  woodcuts_7: `${NOTION_COVER_BASE}/woodcuts_7.jpg`,
+  woodcuts_8: `${NOTION_COVER_BASE}/woodcuts_8.jpg`,
+  woodcuts_9: `${NOTION_COVER_BASE}/woodcuts_9.jpg`,
+  woodcuts_10: `${NOTION_COVER_BASE}/woodcuts_10.jpg`,
+  woodcuts_11: `${NOTION_COVER_BASE}/woodcuts_11.jpg`,
+  woodcuts_13: `${NOTION_COVER_BASE}/woodcuts_13.jpg`,
+  woodcuts_14: `${NOTION_COVER_BASE}/woodcuts_14.jpg`,
+  woodcuts_15: `${NOTION_COVER_BASE}/woodcuts_15.jpg`,
+  woodcuts_16: `${NOTION_COVER_BASE}/woodcuts_16.jpg`,
+
+  // NASA
+  nasa_carina_nebula: `${NOTION_COVER_BASE}/nasa_carina_nebula.jpg`,
+  nasa_transonic_tunnel: `${NOTION_COVER_BASE}/nasa_transonic_tunnel.jpg`,
+  nasa_the_blue_marble: `${NOTION_COVER_BASE}/nasa_the_blue_marble.jpg`,
+  nasa_wrights_first_flight: `${NOTION_COVER_BASE}/nasa_wrights_first_flight.jpg`,
+  nasa_eagle_in_lunar_orbit: `${NOTION_COVER_BASE}/nasa_eagle_in_lunar_orbit.jpg`,
+  nasa_space_shuttle_columbia: `${NOTION_COVER_BASE}/nasa_space_shuttle_columbia.jpg`,
+  nasa_space_shuttle_columbia_and_sunrise: `${NOTION_COVER_BASE}/nasa_space_shuttle_columbia_and_sunrise.jpg`,
+  nasa_reduced_gravity_walking_simulator: `${NOTION_COVER_BASE}/nasa_reduced_gravity_walking_simulator.jpg`,
+  nasa_fingerprints_of_water_on_the_sand: `${NOTION_COVER_BASE}/nasa_fingerprints_of_water_on_the_sand.jpg`,
+  nasa_earth_grid: `${NOTION_COVER_BASE}/nasa_earth_grid.jpg`,
+  nasa_orion_nebula: `${NOTION_COVER_BASE}/nasa_orion_nebula.jpg`,
+  nasa_tim_peake_spacewalk: `${NOTION_COVER_BASE}/nasa_tim_peake_spacewalk.jpg`,
+
+  // The Metropolitan Museum of Art
+  met_william_morris_1875: `${NOTION_COVER_BASE}/met_william_morris_1875.jpg`,
+  met_silk_kashan_carpet: `${NOTION_COVER_BASE}/met_silk_kashan_carpet.jpg`,
+  met_horace_pippin: `${NOTION_COVER_BASE}/met_horace_pippin.jpg`,
+  met_paul_signac: `${NOTION_COVER_BASE}/met_paul_signac.jpg`,
+  met_fitz_henry_lane: `${NOTION_COVER_BASE}/met_fitz_henry_lane.jpg`,
+  met_william_turner_1835: `${NOTION_COVER_BASE}/met_william_turner_1835.jpg`,
+  met_arnold_bocklin_1880: `${NOTION_COVER_BASE}/met_arnold_bocklin_1880.jpg`,
+
+  // Rijksmuseum
+  rijksmuseum_jan_lievens_1627: `${NOTION_COVER_BASE}/rijksmuseum_jan_lievens_1627.jpg`,
+  rijksmuseum_avercamp_1608: `${NOTION_COVER_BASE}/rijksmuseum_avercamp_1608.jpg`,
+  rijksmuseum_avercamp_1620: `${NOTION_COVER_BASE}/rijksmuseum_avercamp_1620.jpg`,
+  rijksmuseum_claesz_1628: `${NOTION_COVER_BASE}/rijksmuseum_claesz_1628.jpg`,
+  rijksmuseum_mignons_1660: `${NOTION_COVER_BASE}/rijksmuseum_mignons_1660.jpg`,
+  rijksmuseum_jansz_1636: `${NOTION_COVER_BASE}/rijksmuseum_jansz_1636.jpg`,
+  rijksmuseum_jansz_1637: `${NOTION_COVER_BASE}/rijksmuseum_jansz_1637.jpg`,
+  rijksmuseum_jansz_1641: `${NOTION_COVER_BASE}/rijksmuseum_jansz_1641.jpg`,
+  rijksmuseum_rembrandt_1642: `${NOTION_COVER_BASE}/rijksmuseum_rembrandt_1642.jpg`
+}
+
+/**
+ * Format a cover value into the Notion API cover object.
+ * Accepts:
+ * - Full URL (http/https) -> external cover
+ * - Shorthand name (e.g., "gradient_8", "solid_blue") -> resolved to Notion CDN URL
+ */
+export function formatCover(value: string): { type: 'external'; external: { url: string } } {
+  // Full URL (with safety check against javascript:, data:, etc.)
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    if (!isSafeUrl(value)) {
+      throw new NotionMCPError(
+        `Unsafe cover URL: "${value}". Use http: or https: URLs only.`,
+        'VALIDATION_ERROR',
+        'Provide a valid http: or https: URL for the cover image'
+      )
+    }
+    return { type: 'external', external: { url: value } }
+  }
+
+  // Reject dangerous URL schemes before shorthand lookup
+  if (!isSafeUrl(value)) {
+    throw new NotionMCPError(
+      `Unsafe cover URL: "${value}". Use http: or https: URLs only.`,
+      'VALIDATION_ERROR',
+      'Provide a valid http: or https: URL for the cover image'
+    )
+  }
+
+  // Shorthand lookup
+  const url = COVER_CATALOG[value]
+  if (url) {
+    return { type: 'external', external: { url } }
+  }
+
+  // Unknown shorthand
+  throw new NotionMCPError(
+    `Unknown cover shorthand: "${value}". Use a URL or one of: ${Object.keys(COVER_CATALOG).join(', ')}`,
+    'VALIDATION_ERROR',
+    'Provide a valid URL or a recognized cover shorthand name'
+  )
+}
+
+/** List all available cover shorthand names, grouped by category */
+export function listCovers(): Record<string, string[]> {
+  const groups: Record<string, string[]> = {}
+  for (const key of Object.keys(COVER_CATALOG)) {
+    const category = key.split('_')[0]
+    const groupName = category === 'solid' ? 'solid_colors' : category === 'gradient' ? 'gradients' : category
+    if (!groups[groupName]) groups[groupName] = []
+    groups[groupName].push(key)
+  }
+  return groups
+}

--- a/src/tools/helpers/icons.test.ts
+++ b/src/tools/helpers/icons.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { NotionMCPError } from './errors'
+import { formatIcon } from './icons'
+
+describe('formatIcon', () => {
+  describe('emoji icons', () => {
+    it('wraps a single emoji as emoji type', () => {
+      expect(formatIcon('🚀')).toEqual({ type: 'emoji', emoji: '🚀' })
+    })
+
+    it('wraps a flag emoji as emoji type', () => {
+      expect(formatIcon('🇩🇪')).toEqual({ type: 'emoji', emoji: '🇩🇪' })
+    })
+
+    it('wraps a simple text emoji', () => {
+      expect(formatIcon('📋')).toEqual({ type: 'emoji', emoji: '📋' })
+    })
+  })
+
+  describe('external URL icons', () => {
+    it('wraps an https URL as external type', () => {
+      expect(formatIcon('https://example.com/logo.png')).toEqual({
+        type: 'external',
+        external: { url: 'https://example.com/logo.png' }
+      })
+    })
+
+    it('wraps an http URL as external type', () => {
+      expect(formatIcon('http://example.com/icon.svg')).toEqual({
+        type: 'external',
+        external: { url: 'http://example.com/icon.svg' }
+      })
+    })
+  })
+
+  describe('Notion built-in icon shorthand', () => {
+    it('expands name:color to Notion icon URL', () => {
+      expect(formatIcon('document:gray')).toEqual({
+        type: 'external',
+        external: { url: 'https://www.notion.so/icons/document_gray.svg' }
+      })
+    })
+
+    it('expands with different colors', () => {
+      expect(formatIcon('helm:blue')).toEqual({
+        type: 'external',
+        external: { url: 'https://www.notion.so/icons/helm_blue.svg' }
+      })
+    })
+
+    it('expands lightgray color', () => {
+      expect(formatIcon('star:lightgray')).toEqual({
+        type: 'external',
+        external: { url: 'https://www.notion.so/icons/star_lightgray.svg' }
+      })
+    })
+
+    it('does not treat a colon in a URL as icon shorthand', () => {
+      expect(formatIcon('https://example.com/icon:blue.svg')).toEqual({
+        type: 'external',
+        external: { url: 'https://example.com/icon:blue.svg' }
+      })
+    })
+  })
+
+  describe('invalid color shorthand', () => {
+    it('rejects invalid color as unsafe URL scheme', () => {
+      // 'magenta' is not a valid Notion color, so 'document:magenta' is not
+      // recognized as shorthand. It then parses as a URL with 'document:' scheme,
+      // which is not in the safe protocol list, so it throws NotionMCPError.
+      expect(() => formatIcon('document:magenta')).toThrow(NotionMCPError)
+    })
+  })
+
+  describe('empty string input', () => {
+    it('throws NotionMCPError for empty string', () => {
+      expect(() => formatIcon('')).toThrow(NotionMCPError)
+    })
+  })
+
+  describe('unsafe URL rejection', () => {
+    it('rejects javascript: URLs', () => {
+      expect(() => formatIcon('javascript:alert(1)')).toThrow(NotionMCPError)
+    })
+
+    it('rejects data: URLs', () => {
+      expect(() => formatIcon('data:text/html,<script>alert(1)</script>')).toThrow(NotionMCPError)
+    })
+
+    it('rejects vbscript: URLs', () => {
+      expect(() => formatIcon('vbscript:msgbox(1)')).toThrow(NotionMCPError)
+    })
+  })
+})

--- a/src/tools/helpers/icons.ts
+++ b/src/tools/helpers/icons.ts
@@ -1,0 +1,71 @@
+/**
+ * Icon Helpers
+ * Format icon values for the Notion API
+ */
+
+import { NotionMCPError } from './errors.js'
+import { isSafeUrl } from './security.js'
+
+const NOTION_ICON_COLORS = new Set([
+  'pink',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'brown',
+  'gray',
+  'lightgray'
+])
+
+/** Check if a string is a Notion built-in icon shorthand (e.g. "helm:blue") */
+function isNotionIconShorthand(value: string): boolean {
+  if (value.startsWith('http://') || value.startsWith('https://')) return false
+  const colonIdx = value.lastIndexOf(':')
+  if (colonIdx < 1) return false
+  const color = value.slice(colonIdx + 1)
+  return NOTION_ICON_COLORS.has(color)
+}
+
+/**
+ * Format an icon value for the Notion API.
+ * Accepts:
+ * - Emoji: "🚀" -> { type: "emoji", emoji: "🚀" }
+ * - External URL: "https://..." -> { type: "external", external: { url } }
+ * - Notion built-in shorthand: "document:gray" -> { type: "external", external: { url: "https://www.notion.so/icons/document_gray.svg" } }
+ */
+export function formatIcon(value: string): { type: string; [key: string]: any } {
+  if (!value) {
+    throw new NotionMCPError(
+      'Icon value cannot be empty. Provide an emoji, a valid URL, or a built-in shorthand (name:color).',
+      'VALIDATION_ERROR',
+      'Provide an emoji, an http/https URL, or a Notion icon shorthand like "document:gray"'
+    )
+  }
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    if (!isSafeUrl(value)) {
+      throw new NotionMCPError(
+        `Unsafe icon URL: "${value}". Use http: or https: URLs only.`,
+        'VALIDATION_ERROR',
+        'Provide a valid http: or https: URL for the icon'
+      )
+    }
+    return { type: 'external', external: { url: value } }
+  }
+  if (isNotionIconShorthand(value)) {
+    const colonIdx = value.lastIndexOf(':')
+    const name = value.slice(0, colonIdx)
+    const color = value.slice(colonIdx + 1)
+    return { type: 'external', external: { url: `https://www.notion.so/icons/${name}_${color}.svg` } }
+  }
+  // Reject dangerous URL schemes before falling through to emoji
+  if (!isSafeUrl(value)) {
+    throw new NotionMCPError(
+      `Unsafe icon value: "${value}". Use an emoji, a valid URL, or a built-in shorthand (name:color).`,
+      'VALIDATION_ERROR',
+      'Provide an emoji, an http/https URL, or a Notion icon shorthand like "document:gray"'
+    )
+  }
+  return { type: 'emoji', emoji: value }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -86,8 +86,16 @@ const TOOLS = [
         parent_id: { type: 'string', description: 'Parent page or database ID' },
         properties: { type: 'object', description: 'Page properties (for database pages)' },
         property_id: { type: 'string', description: 'Property ID (for get_property action)' },
-        icon: { type: 'string', description: 'Emoji icon' },
-        cover: { type: 'string', description: 'Cover image URL' },
+        icon: {
+          type: 'string',
+          description:
+            'Icon: emoji (e.g. "📋"), external URL (https://...), or built-in shorthand (name:color, e.g. "document:gray")'
+        },
+        cover: {
+          type: 'string',
+          description:
+            'Cover image: URL or built-in shorthand (gradient_1..11, solid_red/yellow/blue/beige, nasa_*, met_*, rijksmuseum_*, woodcuts_*)'
+        },
         archived: { type: 'boolean', description: 'Archive status' }
       },
       required: ['action']
@@ -125,7 +133,8 @@ const TOOLS = [
         },
         database_id: {
           type: 'string',
-          description: 'Database ID (from Notion URL) or data_source_id (from workspace search). Auto-resolved for query/create_page/list_templates.'
+          description:
+            'Database ID (from Notion URL) or data_source_id (from workspace search). Auto-resolved for query/create_page/list_templates.'
         },
         data_source_id: { type: 'string', description: 'Data source ID (for update_data_source action)' },
         parent_id: { type: 'string', description: 'Parent page ID (for create/update_database)' },
@@ -133,8 +142,16 @@ const TOOLS = [
         description: { type: 'string', description: 'Description' },
         properties: { type: 'object', description: 'Schema properties (for create/update data source)' },
         is_inline: { type: 'boolean', description: 'Display as inline (for create/update_database)' },
-        icon: { type: 'string', description: 'Emoji icon (for update_database)' },
-        cover: { type: 'string', description: 'Cover image URL (for update_database)' },
+        icon: {
+          type: 'string',
+          description:
+            'Icon (for update_database): emoji (e.g. "📋"), external URL (https://...), or built-in shorthand (name:color, e.g. "document:gray")'
+        },
+        cover: {
+          type: 'string',
+          description:
+            'Cover image (for update_database): URL or built-in shorthand (gradient_1..11, solid_red/yellow/blue/beige, nasa_*, met_*, rijksmuseum_*, woodcuts_*)'
+        },
         filters: { type: 'object', description: 'Query filters (for query action)' },
         sorts: { type: 'array', items: { type: 'object' }, description: 'Query sorts' },
         limit: { type: 'number', description: 'Max query results' },
@@ -349,7 +366,6 @@ const TOOLS = [
  *   Called per tool invocation to support both singleton (stdio) and per-request (HTTP) patterns.
  */
 export function registerTools(server: Server, notionClientFactory: () => Client) {
-
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: TOOLS
   }))


### PR DESCRIPTION
## Summary

Adds helper functions that auto-detect icon and cover input formats, letting users pass intuitive shorthands instead of constructing Notion API objects manually.

**Icons** - pass any of these as the `icon` parameter:
- `"document:gray"` - built-in Notion icon with color (all ~700 icons, 10 colors)
- `"https://example.com/logo.png"` - external URL
- `"📋"` - emoji

**Covers** - pass any of these as the `cover` parameter:
- `"gradient_2"` - built-in Notion cover by name
- `"nasa_carina_nebula"` - one of 60+ built-in covers (gradients, solids, woodcuts, NASA, MET, Rijksmuseum)
- `"https://example.com/banner.jpg"` - external URL

Both helpers validate external URLs against unsafe schemes (javascript:, data:, vbscript:) using the existing `isSafeUrl` utility, and use `NotionMCPError` for consistent error handling.

## A note on the built-in catalogs

This PR ships hardcoded catalogs - ~700 icon names and 60+ cover names - so that users can reference Notion's built-in assets by shorthand rather than needing to know internal identifiers or URLs. That's a somewhat opinionated design choice, and I understand if you'd prefer to keep this kind of mapping client-side.

In practice, I've found it makes a real difference for AI agents: they can say `icon: "document:gray"` or `cover: "met_william_morris_1877_702"` and it just works. Without the catalogs, agents tend to skip icons and covers entirely because the API surface is too cumbersome. The shorthands make more of Notion's built-in visual features actually accessible.

That said, totally understand if you see it differently - no hard feelings either way.

## Changes

| File | What |
|------|------|
| `src/tools/helpers/icons.ts` | `formatIcon()` - detects emoji vs URL vs shorthand |
| `src/tools/helpers/icons.test.ts` | 13 tests (format detection, safety, errors) |
| `src/tools/helpers/covers.ts` | `formatCover()` + `COVER_CATALOG` + `listCovers()` |
| `src/tools/helpers/covers.test.ts` | 17 tests (URL, shorthands, catalog, safety, errors) |
| `src/tools/composite/pages.ts` | Uses `formatIcon`/`formatCover` instead of inline logic |
| `src/tools/composite/databases.ts` | Same |
| `src/tools/registry.ts` | Updated parameter descriptions with examples |
| `src/docs/pages.md` | Icon + cover parameter docs |
| `src/docs/databases.md` | Same |

## Tests

30 new tests covering format detection, error handling, URL safety validation, and catalog coverage. All 1105 tests pass (1075 existing + 30 new).