### PR TITLE
feat: ci: improve PR checks and Qodo filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,21 +30,63 @@ jobs:
       && github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
 
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Validate and auto-fix PR title
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title -q .title)
+          if [[ "$title" =~ ^(feat|fix)(\(.+\))?:.+ ]] || [[ "$title" =~ ^chore\(release\):.+ ]]; then
+            echo "Title is valid: $title"
+            exit 0
+          fi
+          clean=$(echo "$title" | sed -E 's/^[^a-zA-Z]*//; s/^(Bolt|Sentinel|Guard|Shield): *(\[.*\] *)?//')
+          if echo "$clean" | grep -qiE 'fix|bug|vulnerability|security|patch|resolve|crash|error'; then
+            new_title="fix: $(echo "$clean" | sed 's/^./\L&/')"
+          else
+            new_title="feat: $(echo "$clean" | sed 's/^./\L&/')"
+          fi
+          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --title "$new_title"
+          echo "Auto-fixed: $title -> $new_title"
+
+  commit-message-check:
+    name: Commit Message Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
         with:
-          types: |
-            feat
-            fix
-          requireScope: false
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit messages
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          invalid=0
+          while IFS= read -r msg; do
+            if [[ ! "$msg" =~ ^(feat|fix)(\(.+\))?:.+ ]] && [[ ! "$msg" =~ ^chore\(release\):.+ ]]; then
+              echo "INVALID: $msg"
+              invalid=$((invalid + 1))
+            fi
+          done < <(git log --format=%s "$base".."$head")
+          if [ "$invalid" -gt 0 ]; then
+            echo "::error::$invalid commit(s) do not follow Conventional Commits (feat/fix only)."
+            exit 1
+          fi
 
   lint-and-test:
     name: Lint, Test & Build
@@ -110,8 +152,14 @@ jobs:
   ai_pr_review:
     name: Qodo AI Code Review
     if: >-
-      (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
-      && github.event.sender.type != 'Bot'
+      (
+        github.event_name == 'issue_comment'
+        && github.event.sender.type != 'Bot'
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.sender.type != 'Bot'
+        && github.event.pull_request.user.login != 'n24q02m'
+      )
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,4 +1,3 @@
 [config]
 model = "gemini/gemini-3-flash-preview"
 fallback_models = ["gemini/gemini-2.5-flash"]
-ignore_pr_authors = ["n24q02m", "[bot]"]


### PR DESCRIPTION
## Summary
- Replace `amannn/action-semantic-pull-request` with custom script that auto-fixes non-conventional PR titles to `feat:`/`fix:` format
- Add `commit-message-check` job to enforce Conventional Commits at CI level (not just pre-commit)
- Update Qodo AI review to only auto-review PRs from external contributors
- Remove `ignore_pr_authors` from `.pr_agent.toml` (filtering now handled at workflow level)

## Test plan
- [ ] Create a PR with non-conventional title (e.g. emoji prefix) and verify auto-fix
- [ ] Create a PR with invalid commit messages and verify CI fails
- [ ] Verify Qodo does not auto-review owner's PRs
- [ ] Verify manual `/review` command still works on any PR

Generated with [Claude Code](https://claude.com/claude-code)