### PR TITLE
fix: fix XSS/Open Redirect in OAuth Callback

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-    "workspaceId": "eb2a1274-f333-4f5f-b3b9-42c525cec134",
-    "defaultEnvironment": "dev",
-    "gitBranchToEnvironmentMapping": null
+  "workspaceId": "eb2a1274-f333-4f5f-b3b9-42c525cec134",
+  "defaultEnvironment": "dev",
+  "gitBranchToEnvironmentMapping": null
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,94 +1,61 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits"
-  ],
-  "schedule": [
-    "before 5am"
-  ],
+  "extends": ["config:recommended", ":semanticCommits"],
+  "schedule": ["before 5am"],
   "timezone": "Asia/Ho_Chi_Minh",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 3,
-  "labels": [
-    "dependencies"
-  ],
+  "labels": ["dependencies"],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": [
-      "before 5am"
-    ]
+    "schedule": ["before 5am"]
   },
   "packageRules": [
     {
       "description": "Auto-merge non-major devDependencies",
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr"
     },
     {
       "description": "Auto-merge patch production dependencies",
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "pr"
     },
     {
       "description": "Group all non-major updates",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "non-major dependencies",
       "groupSlug": "non-major"
     },
     {
       "description": "Pin GitHub Actions to SHA for security",
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "pinDigests": true
     },
     {
       "description": "Pin PSR to v10 — block Renovate downgrades",
-      "matchPackagePatterns": [
-        "^python-semantic-release/"
-      ],
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchPackagePatterns": ["^python-semantic-release/"],
+      "matchManagers": ["github-actions"],
       "allowedVersions": ">=10.0.0"
     },
     {
       "description": "Disable Python runtime upgrades (pinned to 3.13)",
-      "matchPackageNames": [
-        "python"
-      ],
+      "matchPackageNames": ["python"],
       "enabled": false
     },
     {
       "description": "Disable Node.js runtime upgrades (pinned to 24)",
-      "matchPackageNames": [
-        "node"
-      ],
+      "matchPackageNames": ["node"],
       "enabled": false
     },
     {
       "description": "Disable Java runtime upgrades (pinned to 21 LTS)",
-      "matchPackageNames": [
-        "java"
-      ],
+      "matchPackageNames": ["java"],
       "enabled": false
     }
   ]

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -248,6 +248,45 @@ describe('startHttp', () => {
         error_description: 'Unknown or expired state'
       })
     })
+
+    it('should block unsafe redirect URIs to prevent XSS', async () => {
+      // Mock global fetch
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'notion-token',
+          token_type: 'bearer'
+        })
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const { createNotionOAuthProvider } = await import('../auth/notion-oauth-provider.js')
+      const handlers = await startAndGetHandlers()
+      const handler = handlers['GET:/callback']?.at(-1) as Fn
+
+      // Get the mock instance returned by createNotionOAuthProvider
+      const providerInfo = vi.mocked(createNotionOAuthProvider).mock.results[0].value
+      const pendingAuths: Map<string, any> = providerInfo.pendingAuths
+
+      // Insert a pending auth with an unsafe redirectURI
+      pendingAuths.set('unsafe-state', {
+        clientId: 'c1',
+        clientRedirectUri: 'javascript:alert(1)',
+        codeChallenge: 'c',
+        codeChallengeMethod: 'S256',
+        createdAt: Date.now()
+      })
+
+      const req = { query: { code: 'some-code', state: 'unsafe-state' } }
+      const res = mockRes()
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'invalid_request',
+        error_description: 'Unsafe redirect URI'
+      })
+    })
   })
 
   describe('POST /mcp', () => {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -155,6 +155,14 @@ export async function startHttp() {
 
       // Redirect back to the MCP client's original redirect_uri
       const clientRedirect = new URL(pending.clientRedirectUri)
+
+      // Prevent XSS and Open Redirect vulnerabilities via unsafe protocols
+      const protocol = clientRedirect.protocol.toLowerCase()
+      if (['javascript:', 'data:', 'vbscript:', 'file:'].includes(protocol)) {
+        res.status(400).json({ error: 'invalid_request', error_description: 'Unsafe redirect URI' })
+        return
+      }
+
       clientRedirect.searchParams.set('code', ourAuthCode)
       if (pending.clientState) {
         clientRedirect.searchParams.set('state', pending.clientState)


### PR DESCRIPTION
🚨 Sentinel: [HIGH] Fix XSS/Open Redirect in OAuth Callback

🚨 **Severity:** HIGH
💡 **Vulnerability:** The OAuth callback handler (`src/transports/http.ts`) redirected clients back to their `redirect_uri` using `res.redirect()` directly after a successful OAuth exchange. However, it did not validate the protocol of the URI. A malicious actor could specify an unsafe URI such as `javascript:alert(1)`, enabling Cross-Site Scripting (XSS) or Open Redirect attacks upon successful authorization.
🎯 **Impact:** If exploited, this could execute malicious JavaScript within the context of the user's session and browser, potentially compromising session tokens, or it could redirect the user to malicious external sites.
🔧 **Fix:** Added a protocol validation check before the redirect. It safely parses the `clientRedirectUri` with `new URL()` and explicitly blocks `['javascript:', 'data:', 'vbscript:', 'file:']` protocols, responding with a 400 Bad Request error if an unsafe protocol is used.
✅ **Verification:** Unit tests have been added in `src/transports/http.test.ts` to assert that unsafe URIs like `javascript:alert(1)` are properly rejected with a `400 Bad Request` and `Unsafe redirect URI` error. Tested locally via `bun run test` and `bun run check`.

---
*PR created automatically by Jules for task [6273918968420960704](https://jules.google.com/task/6273918968420960704) started by @n24q02m*