### PR TITLE
fix: fix timing vulnerability in PKCE validation

### DIFF
--- a/src/auth/notion-oauth-provider.ts
+++ b/src/auth/notion-oauth-provider.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { createHash, randomBytes } from 'node:crypto'
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js'
 import { Client } from '@notionhq/client'
@@ -234,7 +234,9 @@ export function createNotionOAuthProvider(config: NotionOAuthConfig) {
         throw new InvalidTokenError('code_verifier is required')
       }
       const expectedChallenge = createHash('sha256').update(codeVerifier).digest('base64url')
-      if (expectedChallenge !== stored.codeChallenge) {
+      const expectedBuffer = Buffer.from(expectedChallenge)
+      const storedBuffer = Buffer.from(stored.codeChallenge)
+      if (expectedBuffer.byteLength !== storedBuffer.byteLength || !timingSafeEqual(expectedBuffer, storedBuffer)) {
         throw new InvalidTokenError('code_verifier does not match the challenge')
       }
     }


### PR DESCRIPTION
This PR implements a security enhancement to mitigate timing attacks against the OAuth authorization flow.

🛡️ Sentinel: [MEDIUM] Enhance PKCE verifier security against timing attacks

🚨 Severity: MEDIUM
💡 Vulnerability: The PKCE `code_verifier` check used a standard string equality operator `!==`. Standard equality checks in JavaScript exit on the first non-matching character, theoretically allowing an attacker to deduce the expected challenge byte-by-byte via timing measurements. While difficult in practice over a network, constant-time comparison is a cryptographic best practice for secrets.
🎯 Impact: Mitigates theoretical timing side-channel attacks during the token exchange step.
🔧 Fix: Replaced `!==` with `node:crypto.timingSafeEqual`. To handle the possibility of multi-byte UTF-8 character length mismatches causing unhandled `500 Internal Server Errors`, the string lengths are no longer compared directly. Instead, `Buffer` objects are created first, their `byteLength`s are compared, and then `timingSafeEqual` is applied.
✅ Verification: `bun run test src/auth/notion-oauth-provider.test.ts` passes, confirming no valid OAuth flows are broken. Tests also confirm that the API continues to return `400 InvalidTokenError` correctly.

---
*PR created automatically by Jules for task [1214548549090984870](https://jules.google.com/task/1214548549090984870) started by @n24q02m*