### PR TITLE
fix: remove console.error from handleNotionError

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -103,20 +103,6 @@ function handleNotionError(error: any): NotionMCPError {
   const code = error.code
   const message = error.message || 'Unknown Notion API error'
 
-  // Log error code and message only to avoid leaking sensitive data
-  console.error(
-    'Notion API Error:',
-    JSON.stringify(
-      {
-        code,
-        message,
-        status: error.status
-      },
-      null,
-      2
-    )
-  )
-
   switch (code) {
     case 'unauthorized':
       return new NotionMCPError(


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the `console.error` block from `handleNotionError`.

💡 **Why:** How this improves maintainability
The `console.error` block inside `handleNotionError` produced noisy internal server logs and was redundant, especially considering that the error itself is wrapped into a well-structured `NotionMCPError` and propagated safely. Its removal streamlines the codebase and prevents potential clutter without sacrificing the existing security or error context returned to clients. 

✅ **Verification:** How you confirmed the change is safe
- Ran `bun run check:fix` and `bun run check` to verify formatting and linting.
- Executed the full test suite via `bun run test` – all 660 tests passed.
- Performed a code review which concluded there were no regressions, functionality changes, or side-effects.

✨ **Result:** The improvement achieved
A cleaner and slightly more maintainable error handler with no loss of functional or security capability.

---
*PR created automatically by Jules for task [5674178088735472839](https://jules.google.com/task/5674178088735472839) started by @n24q02m*