### PR TITLE
fix: fix: Remove console.error from handleNotionError

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -103,20 +103,6 @@ function handleNotionError(error: any): NotionMCPError {
   const code = error.code
   const message = error.message || 'Unknown Notion API error'
 
-  // Log error code and message only to avoid leaking sensitive data
-  console.error(
-    'Notion API Error:',
-    JSON.stringify(
-      {
-        code,
-        message,
-        status: error.status
-      },
-      null,
-      2
-    )
-  )
-
   switch (code) {
     case 'unauthorized':
       return new NotionMCPError(


### PR DESCRIPTION
🎯 **What:** Removed the `console.error` call from the `handleNotionError` function in `src/tools/helpers/errors.ts`.

💡 **Why:** `handleNotionError` is designed to be a pure function that returns a `NotionMCPError` instance. Logging directly within this function is an unintended side effect that clutters the terminal output and is inconsistent with the rest of the error handling utilities, which return the errors to be handled (and optionally logged) by the caller. Removing this side effect improves readability and maintainability.

✅ **Verification:** Verified by running the test suite (`bun run test`) which passes successfully. The changes were also formatted and checked via `bun run check`.

✨ **Result:** A cleaner, more predictable `handleNotionError` function that no longer emits side effects, ensuring error reporting is consistently managed by the caller.

---
*PR created automatically by Jules for task [3217562322021766873](https://jules.google.com/task/3217562322021766873) started by @n24q02m*