### PR TITLE
fix: update mockResult to satisfy QueryDatabaseResponse type in registry tests

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -287,9 +287,15 @@ describe('registerTools', () => {
 
     it('should route databases tool correctly', async () => {
       const handler = server.getHandler(3)
-      // Fix: updated mockResult to satisfy QueryDatabaseResponse type (must have total)
-      const mockResult = { action: 'query', database_id: 'db-1', data_source_id: 'ds-1', total: 0, results: [] }
-      vi.mocked(databases).mockResolvedValue(mockResult as any)
+
+      const mockResult = {
+        action: 'query' as const,
+        database_id: 'db-1',
+        data_source_id: 'ds-1',
+        total: 0,
+        results: []
+      }
+      vi.mocked(databases).mockResolvedValue(mockResult)
 
       const result = await handler({
         params: { name: 'databases', arguments: { action: 'query', database_id: 'db-1' } }


### PR DESCRIPTION
- Removed obsolete 'Fix: updated mockResult...' comment.
- Re-formatted mockResult in databases tool route test for clarity.
- Explicitly typed 'action' as const ('query' as const) to satisfy the expected action string literal of QueryDatabaseResponse.
- Removed unsafe `as any` cast from `vi.mocked(databases).mockResolvedValue()`.

---
*PR created automatically by Jules for task [7197900813898570362](https://jules.google.com/task/7197900813898570362) started by @n24q02m*