### PR TITLE
feat: refactor: reduce markdownToBlocks complexity by introducing MarkdownParser

### DIFF
--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -70,20 +70,39 @@ const DIVIDER_REGEX = /^[-*]{3,}$/
 /**
  * Convert markdown string to Notion blocks
  */
-export function markdownToBlocks(markdown: string): NotionBlock[] {
-  const lines = markdown.split('\n')
-  const blocks: NotionBlock[] = []
-  let currentList: NotionBlock[] = []
-  let currentListType: 'bulleted' | 'numbered' | null = null
+class MarkdownParser {
+  private lines: string[]
+  private blocks: NotionBlock[] = []
+  private currentList: NotionBlock[] = []
+  private currentListType: 'bulleted' | 'numbered' | null = null
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
+  constructor(markdown: string) {
+    this.lines = markdown.split('\n')
+  }
+
+  public parse(): NotionBlock[] {
+    for (let i = 0; i < this.lines.length; i++) {
+      i = this.parseBlock(i)
+    }
+
+    this.flushList()
+    return this.blocks
+  }
+
+  private flushList() {
+    if (this.currentList.length > 0) {
+      this.blocks.push(...this.currentList)
+      this.currentList = []
+      this.currentListType = null
+    }
+  }
+
+  private parseBlock(i: number): number {
+    const line = this.lines[i]
 
     // Flush list if we're not in a list anymore
-    if (currentListType && !isListItem(line)) {
-      blocks.push(...currentList)
-      currentList = []
-      currentListType = null
+    if (this.currentListType && !isListItem(line)) {
+      this.flushList()
     }
 
     // Cache trimmed line for performance to avoid repeated string allocations
@@ -91,19 +110,19 @@ export function markdownToBlocks(markdown: string): NotionBlock[] {
 
     // Skip empty lines
     if (!trimmedLine) {
-      continue
+      return i
     }
 
     // Table of Contents [toc]
     if (trimmedLine === '[toc]' || trimmedLine === '[TOC]') {
-      blocks.push(createTableOfContents())
-      continue
+      this.blocks.push(createTableOfContents())
+      return i
     }
 
     // Breadcrumb [breadcrumb]
     if (trimmedLine === '[breadcrumb]' || trimmedLine === '[BREADCRUMB]') {
-      blocks.push(createBreadcrumb())
-      continue
+      this.blocks.push(createBreadcrumb())
+      return i
     }
 
     // Equation block $$...$$
@@ -111,18 +130,18 @@ export function markdownToBlocks(markdown: string): NotionBlock[] {
       if (trimmedLine.endsWith('$$') && trimmedLine.length > 4) {
         // Single line equation: $$expression$$
         const expression = trimmedLine.slice(2, -2).trim()
-        blocks.push(createEquation(expression))
-        continue
+        this.blocks.push(createEquation(expression))
+        return i
       }
       // Multi-line equation
       const eqLines: string[] = []
       i++
-      while (i < lines.length && !lines[i].trim().startsWith('$$')) {
-        eqLines.push(lines[i])
+      while (i < this.lines.length && !this.lines[i].trim().startsWith('$$')) {
+        eqLines.push(this.lines[i])
         i++
       }
-      blocks.push(createEquation(eqLines.join('\n')))
-      continue
+      this.blocks.push(createEquation(eqLines.join('\n')))
+      return i
     }
 
     // Callout > [!TYPE] content or > [!TYPE]\n> content
@@ -132,15 +151,15 @@ export function markdownToBlocks(markdown: string): NotionBlock[] {
       let calloutContent = calloutMatch[2] || ''
 
       // Collect continuation lines (lines starting with >)
-      while (i + 1 < lines.length && lines[i + 1].startsWith('> ')) {
+      while (i + 1 < this.lines.length && this.lines[i + 1].startsWith('> ')) {
         i++
-        calloutContent += (calloutContent ? '\n' : '') + lines[i].slice(2)
+        calloutContent += (calloutContent ? '\n' : '') + this.lines[i].slice(2)
       }
 
       const icon = getCalloutIcon(calloutType)
       const color = getCalloutColor(calloutType)
-      blocks.push(createCallout(calloutContent || calloutType, icon, color))
-      continue
+      this.blocks.push(createCallout(calloutContent || calloutType, icon, color))
+      return i
     }
 
     // Image ![alt](url)
@@ -148,11 +167,11 @@ export function markdownToBlocks(markdown: string): NotionBlock[] {
     if (imageMatch) {
       const url = imageMatch[2]
       if (isSafeUrl(url)) {
-        blocks.push(createImage(url, imageMatch[1]))
+        this.blocks.push(createImage(url, imageMatch[1]))
       } else {
-        blocks.push(createParagraph(line))
+        this.blocks.push(createParagraph(line))
       }
-      continue
+      return i
     }
 
     // Bookmark/Embed [bookmark](url) or [embed](url)
@@ -162,100 +181,99 @@ export function markdownToBlocks(markdown: string): NotionBlock[] {
       const url = bookmarkMatch[2]
       if (isSafeUrl(url)) {
         if (type === 'embed') {
-          blocks.push(createEmbed(url))
+          this.blocks.push(createEmbed(url))
         } else {
-          blocks.push(createBookmark(url))
+          this.blocks.push(createBookmark(url))
         }
       } else {
-        blocks.push(createParagraph(line))
+        this.blocks.push(createParagraph(line))
       }
-      continue
+      return i
     }
 
     // Toggle <details><summary>Title</summary>
     if (trimmedLine === '<details>' || trimmedLine.startsWith('<details>')) {
-      const toggleData = parseToggle(lines, i)
-      blocks.push(createToggle(toggleData.title, toggleData.children))
-      i = toggleData.endIndex
-      continue
+      const toggleData = parseToggle(this.lines, i)
+      this.blocks.push(createToggle(toggleData.title, toggleData.children))
+      return toggleData.endIndex
     }
 
     // Column layout :::columns
     if (trimmedLine === ':::columns') {
-      const columnData = parseColumns(lines, i)
-      blocks.push(createColumnList(columnData.columns, columnData.widthRatios))
-      i = columnData.endIndex
-      continue
+      const columnData = parseColumns(this.lines, i)
+      this.blocks.push(createColumnList(columnData.columns, columnData.widthRatios))
+      return columnData.endIndex
     }
 
     // Table (pipe-delimited)
     if (line.includes('|') && trimmedLine.startsWith('|')) {
-      const tableData = parseTable(lines, i)
+      const tableData = parseTable(this.lines, i)
       if (tableData) {
-        blocks.push(createTable(tableData.headers, tableData.rows, tableData.hasHeader))
-        i = tableData.endIndex
-        continue
+        this.blocks.push(createTable(tableData.headers, tableData.rows, tableData.hasHeader))
+        return tableData.endIndex
       }
     }
 
     // Heading
     if (line.startsWith('# ')) {
-      blocks.push(createHeading(1, line.slice(2)))
+      this.blocks.push(createHeading(1, line.slice(2)))
     } else if (line.startsWith('## ')) {
-      blocks.push(createHeading(2, line.slice(3)))
+      this.blocks.push(createHeading(2, line.slice(3)))
     } else if (line.startsWith('### ')) {
-      blocks.push(createHeading(3, line.slice(4)))
+      this.blocks.push(createHeading(3, line.slice(4)))
     }
     // Code block
     else if (line.startsWith('```')) {
       const language = line.slice(3).trim()
       const codeLines: string[] = []
       i++
-      while (i < lines.length && !lines[i].startsWith('```')) {
-        codeLines.push(lines[i])
+      while (i < this.lines.length && !this.lines[i].startsWith('```')) {
+        codeLines.push(this.lines[i])
         i++
       }
-      blocks.push(createCodeBlock(codeLines.join('\n'), language))
+      this.blocks.push(createCodeBlock(codeLines.join('\n'), language))
     }
     // Task list / Checkbox list - [ ] or - [x]
     else if (CHECKED_LIST_REGEX.test(line)) {
       const checked = line[3] !== ' '
       const text = line.replace(CHECKED_LIST_REGEX, '')
-      currentListType = 'bulleted'
-      currentList.push(createTodoItem(text, checked))
+      this.currentListType = 'bulleted'
+      this.currentList.push(createTodoItem(text, checked))
     }
     // Bulleted list
     else if (BULLETED_LIST_REGEX.test(line)) {
       const text = line.replace(BULLETED_LIST_REGEX, '')
-      currentListType = 'bulleted'
-      currentList.push(createBulletedListItem(text))
+      this.currentListType = 'bulleted'
+      this.currentList.push(createBulletedListItem(text))
     }
     // Numbered list
     else if (NUMBERED_LIST_REGEX.test(line)) {
       const text = line.replace(NUMBERED_LIST_REGEX, '')
-      currentListType = 'numbered'
-      currentList.push(createNumberedListItem(text))
+      this.currentListType = 'numbered'
+      this.currentList.push(createNumberedListItem(text))
     }
     // Quote
     else if (line.startsWith('> ')) {
-      blocks.push(createQuote(line.slice(2)))
+      this.blocks.push(createQuote(line.slice(2)))
     }
     // Divider
     else if (DIVIDER_REGEX.test(line)) {
-      blocks.push(createDivider())
+      this.blocks.push(createDivider())
     }
     // Regular paragraph
     else {
-      blocks.push(createParagraph(line))
+      this.blocks.push(createParagraph(line))
     }
-  }
 
-  // Flush remaining list
-  if (currentList.length > 0) {
-    blocks.push(...currentList)
+    return i
   }
+}
 
-  return blocks
+/**
+ * Convert markdown string to Notion blocks
+ */
+export function markdownToBlocks(markdown: string): NotionBlock[] {
+  return new MarkdownParser(markdown).parse()
 }
 
 /**


### PR DESCRIPTION
🎯 **What:** The `markdownToBlocks` function in `src/tools/helpers/markdown.ts` was extremely complex, with a massive `for` loop that managed state related to parsing blocks, handling lists, and multi-line sequences (like equations, tables, code blocks). It has been refactored by moving the parsing loop and its state into a dedicated `MarkdownParser` class. The main loop body has been extracted into a `parseBlock(i)` method, reducing cognitive load significantly.
💡 **Why:** Refactoring monolithic, stateful parsing loops into classes prevents excessive passing of state arguments (`i`, `lines`, `blocks`, `currentList`, etc.) around, dramatically simplifying logic and making it easier to test or expand in the future.
✅ **Verification:** Verified that tests pass via `bun run test` (including 162 unit tests in `markdown.test.ts`), and that type-checking and linting succeed via `bun run check`. Temporary scripting files were cleaned up to leave no unused workspace artifacts behind.
✨ **Result:** A much cleaner `markdownToBlocks` entry point that just returns `new MarkdownParser(markdown).parse()`, paving the way for easier maintainability and code readability.

---
*PR created automatically by Jules for task [1003972895302474067](https://jules.google.com/task/1003972895302474067) started by @n24q02m*