### PR TITLE
fix: test: add missing error path test for documentation retrieval

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -231,6 +231,20 @@ describe('registerTools', () => {
       })
     })
 
+    it('should throw NotionMCPError with DOC_NOT_FOUND when readFileSync throws', async () => {
+      const handler = server.getHandler(2)
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory')
+      })
+
+      const promise = handler({ params: { uri: 'notion://docs/pages' } })
+      await expect(promise).rejects.toThrow(NotionMCPError)
+      await expect(promise).rejects.toMatchObject({
+        code: 'DOC_NOT_FOUND',
+        suggestion: expect.any(String)
+      })
+    })
+
     it('should include available resources in error message', async () => {
       const handler = server.getHandler(2)
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -391,9 +391,13 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
       )
     }
 
-    const content = readFileSync(join(DOCS_DIR, resource.file), 'utf-8')
-    return {
-      contents: [{ uri, mimeType: 'text/markdown', text: content }]
+    try {
+      const content = readFileSync(join(DOCS_DIR, resource.file), 'utf-8')
+      return {
+        contents: [{ uri, mimeType: 'text/markdown', text: content }]
+      }
+    } catch {
+      throw new NotionMCPError(`Documentation not found for: ${resource.name}`, 'DOC_NOT_FOUND', 'Check resource URI')
     }
   })
 


### PR DESCRIPTION
🎯 **What:** The `ReadResource handler` lacked a try/catch block for `fs.readFileSync` and a corresponding test for when documentation files are missing.
📊 **Coverage:** Added `try/catch` wrapping `fs.readFileSync` in the `ReadResource handler` to throw a `NotionMCPError` with `DOC_NOT_FOUND` code when encountering missing documentation files. Accompanied by a new test mimicking `fs.readFileSync` throwing `ENOENT` to ensure `ReadResource handler` rejects properly with the `DOC_NOT_FOUND` error.
✨ **Result:** Improved test coverage and aligned the documentation resource error path handling with the existing help tool fallback behavior. All error paths now gracefully handle missing files using the `NotionMCPError` pattern.

---
*PR created automatically by Jules for task [12566098351685844763](https://jules.google.com/task/12566098351685844763) started by @n24q02m*