### PR TITLE
feat: test: add comprehensive test suite for extractPageProperties

### DIFF
--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { convertToNotionProperties } from './properties'
+import { convertToNotionProperties, extractPageProperties } from './properties'
 
 const richText = (content: string) => ({
   type: 'text',
@@ -331,5 +331,314 @@ describe('convertToNotionProperties', () => {
         Notes: null
       })
     })
+  })
+})
+
+describe('extractPageProperties', () => {
+  it('extracts title', () => {
+    const props = {
+      Name: {
+        type: 'title',
+        title: [{ plain_text: 'Hello ' }, { plain_text: 'World' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Name: 'Hello World' })
+  })
+
+  it('handles empty title correctly', () => {
+    const props = {
+      Name: {
+        type: 'title',
+        title: []
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Name: '' })
+  })
+
+  it('extracts rich_text', () => {
+    const props = {
+      Desc: {
+        type: 'rich_text',
+        rich_text: [{ plain_text: 'Some ' }, { plain_text: 'text' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Desc: 'Some text' })
+  })
+
+  it('extracts select', () => {
+    const props = {
+      Status: {
+        type: 'select',
+        select: { name: 'Done' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Status: 'Done' })
+  })
+
+  it('extracts multi_select', () => {
+    const props = {
+      Tags: {
+        type: 'multi_select',
+        multi_select: [{ name: 'A' }, { name: 'B' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Tags: ['A', 'B'] })
+  })
+
+  it('extracts number', () => {
+    const props = {
+      Price: {
+        type: 'number',
+        number: 42
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Price: 42 })
+  })
+
+  it('extracts checkbox', () => {
+    const props = {
+      Done: {
+        type: 'checkbox',
+        checkbox: true
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Done: true })
+  })
+
+  it('extracts url', () => {
+    const props = {
+      Link: {
+        type: 'url',
+        url: 'https://example.com'
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Link: 'https://example.com' })
+  })
+
+  it('extracts email', () => {
+    const props = {
+      Email: {
+        type: 'email',
+        email: 'test@example.com'
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Email: 'test@example.com' })
+  })
+
+  it('extracts phone_number', () => {
+    const props = {
+      Phone: {
+        type: 'phone_number',
+        phone_number: '123-456-7890'
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Phone: '123-456-7890' })
+  })
+
+  it('extracts date with start and end', () => {
+    const props = {
+      Timeline: {
+        type: 'date',
+        date: { start: '2023-01-01', end: '2023-01-31' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Timeline: '2023-01-01 to 2023-01-31' })
+  })
+
+  it('extracts date with start only', () => {
+    const props = {
+      Date: {
+        type: 'date',
+        date: { start: '2023-01-01' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Date: '2023-01-01' })
+  })
+
+  it('extracts relation', () => {
+    const props = {
+      Related: {
+        type: 'relation',
+        relation: [{ id: 'id1' }, { id: 'id2' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Related: ['id1', 'id2'] })
+  })
+
+  it('extracts rollup', () => {
+    const rollupValue = { type: 'number', number: 100, function: 'sum' }
+    const props = {
+      Total: {
+        type: 'rollup',
+        rollup: rollupValue
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Total: rollupValue })
+  })
+
+  it('extracts people with name', () => {
+    const props = {
+      Assignee: {
+        type: 'people',
+        people: [
+          { name: 'Alice', id: 'a1' },
+          { name: 'Bob', id: 'b2' }
+        ]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Assignee: ['Alice', 'Bob'] })
+  })
+
+  it('extracts people falling back to id', () => {
+    const props = {
+      Assignee: {
+        type: 'people',
+        people: [{ id: 'a1' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Assignee: ['a1'] })
+  })
+
+  it('extracts files (url, external url, name fallback)', () => {
+    const props = {
+      Attachments: {
+        type: 'files',
+        files: [{ file: { url: 'internal.png' } }, { external: { url: 'external.png' } }, { name: 'fallback.txt' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Attachments: ['internal.png', 'external.png', 'fallback.txt'] })
+  })
+
+  it('extracts formula string', () => {
+    const props = {
+      Calc: {
+        type: 'formula',
+        formula: { type: 'string', string: 'result' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Calc: 'result' })
+  })
+
+  it('extracts formula returning null when type is unsupported', () => {
+    const props = {
+      Calc: {
+        type: 'formula',
+        formula: { type: 'unknown' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Calc: null })
+  })
+
+  it('extracts formula returning null when type is missing', () => {
+    const props = {
+      Calc: {
+        type: 'formula',
+        formula: {}
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Calc: null })
+  })
+
+  it('extracts created_time', () => {
+    const props = {
+      Created: {
+        type: 'created_time',
+        created_time: '2023-01-01T00:00:00Z'
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Created: '2023-01-01T00:00:00Z' })
+  })
+
+  it('extracts last_edited_time', () => {
+    const props = {
+      Edited: {
+        type: 'last_edited_time',
+        last_edited_time: '2023-01-02T00:00:00Z'
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Edited: '2023-01-02T00:00:00Z' })
+  })
+
+  it('extracts created_by name', () => {
+    const props = {
+      Author: {
+        type: 'created_by',
+        created_by: { name: 'Alice', id: 'a1' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Author: 'Alice' })
+  })
+
+  it('extracts created_by falling back to id', () => {
+    const props = {
+      Author: {
+        type: 'created_by',
+        created_by: { id: 'a1' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Author: 'a1' })
+  })
+
+  it('extracts last_edited_by name', () => {
+    const props = {
+      Editor: {
+        type: 'last_edited_by',
+        last_edited_by: { name: 'Bob', id: 'b1' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Editor: 'Bob' })
+  })
+
+  it('extracts last_edited_by falling back to id', () => {
+    const props = {
+      Editor: {
+        type: 'last_edited_by',
+        last_edited_by: { id: 'b1' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Editor: 'b1' })
+  })
+
+  it('extracts status', () => {
+    const props = {
+      Progress: {
+        type: 'status',
+        status: { name: 'In Progress' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Progress: 'In Progress' })
+  })
+
+  it('extracts unique_id with prefix', () => {
+    const props = {
+      ID: {
+        type: 'unique_id',
+        unique_id: { prefix: 'TASK', number: 123 }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ ID: 'TASK-123' })
+  })
+
+  it('extracts unique_id without prefix', () => {
+    const props = {
+      ID: {
+        type: 'unique_id',
+        unique_id: { number: 456 }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ ID: 456 })
+  })
+
+  it('ignores unsupported or malformed properties', () => {
+    const props = {
+      BadTitle: {
+        type: 'title'
+        // missing .title
+      },
+      UnknownType: {
+        type: 'magical_type'
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({})
   })
 })


### PR DESCRIPTION
🎯 **What:** The `extractPageProperties` function in `src/tools/helpers/properties.ts` lacked unit tests, creating a gap in testing coverage.
📊 **Coverage:** This PR adds a comprehensive suite of tests in `src/tools/helpers/properties.test.ts`. It covers happy paths, edge cases, and unsupported property fallbacks for all property types handled by the function (`title`, `rich_text`, `select`, `multi_select`, `number`, `checkbox`, `url`, `email`, `phone_number`, `date`, `relation`, `rollup`, `people`, `files`, `formula`, `created_time`, `last_edited_time`, `created_by`, `last_edited_by`, `status`, and `unique_id`).
✨ **Result:** Test coverage for this optimized property extraction utility is now thorough, increasing reliability and preventing future regressions.

---
*PR created automatically by Jules for task [15806020729336293602](https://jules.google.com/task/15806020729336293602) started by @n24q02m*