### PR TITLE
feat: refactor: reduce duplication in parseRichText

### DIFF
--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -392,6 +392,13 @@ export function parseRichText(text: string): RichText[] {
   let strikethrough = false
   let noMoreCloseBrackets = false
 
+  const flushCurrent = () => {
+    if (current) {
+      richText.push(createRichText(current, { bold, italic, code, strikethrough }))
+      current = ''
+    }
+  }
+
   for (let i = 0; i < text.length; i++) {
     const char = text[i]
     const next = text[i + 1]
@@ -402,10 +409,7 @@ export function parseRichText(text: string): RichText[] {
       if (closeBracket !== -1 && closeBracket + 1 < text.length && text[closeBracket + 1] === '(') {
         const closeParen = text.indexOf(')', closeBracket + 2)
         if (closeParen !== -1) {
-          if (current) {
-            richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-            current = ''
-          }
+          flushCurrent()
 
           const mentionTitle = text.slice(i + 2, closeBracket)
           const mentionTarget = text.slice(closeBracket + 2, closeParen)
@@ -432,10 +436,7 @@ export function parseRichText(text: string): RichText[] {
         const closeParen = text.indexOf(')', closeBracket + 2)
 
         if (closeParen !== -1) {
-          if (current) {
-            richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-            current = ''
-          }
+          flushCurrent()
 
           const linkText = text.slice(i + 1, closeBracket)
           const linkUrl = text.slice(closeBracket + 2, closeParen)
@@ -462,38 +463,26 @@ export function parseRichText(text: string): RichText[] {
 
     // Bold **text**
     if (char === '*' && next === '*') {
-      if (current) {
-        richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-        current = ''
-      }
+      flushCurrent()
       bold = !bold
       i++ // Skip next *
       continue
     }
     // Italic *text*
     else if (char === '*' && next !== '*') {
-      if (current) {
-        richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-        current = ''
-      }
+      flushCurrent()
       italic = !italic
       continue
     }
     // Code `text`
     else if (char === '`') {
-      if (current) {
-        richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-        current = ''
-      }
+      flushCurrent()
       code = !code
       continue
     }
     // Strikethrough ~~text~~
     else if (char === '~' && next === '~') {
-      if (current) {
-        richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-        current = ''
-      }
+      flushCurrent()
       strikethrough = !strikethrough
       i++ // Skip next ~
       continue
@@ -502,9 +491,7 @@ export function parseRichText(text: string): RichText[] {
     current += char
   }
 
-  if (current) {
-    richText.push(createRichText(current, { bold, italic, code, strikethrough }))
-  }
+  flushCurrent()
 
   return richText.length > 0 ? richText : [createRichText(text)]
 }


### PR DESCRIPTION
🎯 **What:** Extracted the repeated code block that checks `current` and pushes to `richText` into an inline closure helper `flushCurrent()`.

💡 **Why:** `parseRichText` was parsing characters one by one with a lot of duplicated code for handling various inline formatting elements (bold, italic, code, etc.). Replacing these with a concise closure improves maintainability, significantly reduces line count, and avoids repetitive code blocks.

✅ **Verification:** Ran `bun run test` on `src/tools/helpers/markdown.test.ts` and the full test suite. Verified formatting using `bun run check`.

✨ **Result:** A cleaner and much less repetitive `parseRichText` implementation that preserves all original logic exactly.

---
*PR created automatically by Jules for task [10263825276751286047](https://jules.google.com/task/10263825276751286047) started by @n24q02m*