### PR TITLE
fix: fix timing attack in PKCE validation

### DIFF
--- a/src/auth/notion-oauth-provider.ts
+++ b/src/auth/notion-oauth-provider.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { createHash, randomBytes } from 'node:crypto'
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js'
 import { Client } from '@notionhq/client'
@@ -234,7 +234,11 @@ export function createNotionOAuthProvider(config: NotionOAuthConfig) {
         throw new InvalidTokenError('code_verifier is required')
       }
       const expectedChallenge = createHash('sha256').update(codeVerifier).digest('base64url')
-      if (expectedChallenge !== stored.codeChallenge) {
+
+      const expectedBuffer = Buffer.from(expectedChallenge, 'utf8')
+      const storedBuffer = Buffer.from(stored.codeChallenge, 'utf8')
+
+      if (expectedBuffer.byteLength !== storedBuffer.byteLength || !timingSafeEqual(expectedBuffer, storedBuffer)) {
         throw new InvalidTokenError('code_verifier does not match the challenge')
       }
     }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The PKCE `code_challenge` verification in `src/auth/notion-oauth-provider.ts` used a basic string comparison (`expectedChallenge !== stored.codeChallenge`). This is vulnerable to timing attacks, where an attacker could theoretically guess the expected hash byte-by-byte by observing the response time of the server.
🎯 **Impact**: While extremely difficult to exploit on a SHA-256 hash, an attacker who successfully bypasses PKCE validation could potentially intercept and exchange authorization codes, gaining unauthorized access to the user's Notion integration.
🔧 **Fix**: Imported `timingSafeEqual` from `node:crypto`. Converted the `expectedChallenge` and `stored.codeChallenge` strings to `Buffer` objects, checked that their `byteLength` matches exactly, and then compared them securely using `timingSafeEqual`.
✅ **Verification**: Ran `bun run check` to ensure code is properly formatted and type-safe. Ran `bun run test` to verify no authentication flows were broken by the buffer conversion. All 660 tests pass.

---
*PR created automatically by Jules for task [2948533197689227505](https://jules.google.com/task/2948533197689227505) started by @n24q02m*