### PR TITLE
fix: fix XSS protocol obfuscation bypass in isSafeUrl

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -34,6 +34,13 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('vbscript&colon;msgbox(1)')).toBe(false)
       expect(isSafeUrl('javascript&#58;alert(1)')).toBe(false)
       expect(isSafeUrl('javascript&#0000058alert(1)')).toBe(false)
+      expect(isSafeUrl('jav&#x09;ascript:alert(1)')).toBe(false)
+      expect(isSafeUrl('javascript&#x3a;alert(1)')).toBe(false)
+    })
+
+    it('should reject URLs with URL encoding obfuscation', () => {
+      expect(isSafeUrl('javascript%3aalert(1)')).toBe(false)
+      expect(isSafeUrl('javascript%3Aalert(1)')).toBe(false)
     })
   })
 

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -29,17 +29,26 @@ export function isSafeUrl(url: string): boolean {
     // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security sanitization
     const lowerUrl = url.toLowerCase().replace(/[\s\x00-\x1F\x7F]+/g, '')
 
-    if (
-      lowerUrl.startsWith('javascript:') ||
-      lowerUrl.startsWith('data:') ||
-      lowerUrl.startsWith('vbscript:') ||
-      lowerUrl.startsWith('javascript&') ||
-      lowerUrl.startsWith('data&') ||
-      lowerUrl.startsWith('vbscript&')
-    ) {
+    try {
+      new URL(lowerUrl, 'http://relative-check.internal')
+
+      const delimiters = [lowerUrl.indexOf('/'), lowerUrl.indexOf('?'), lowerUrl.indexOf('#')].filter(
+        (idx) => idx !== -1
+      )
+      const firstDelimiter = delimiters.length > 0 ? Math.min(...delimiters) : -1
+
+      const prefix = firstDelimiter === -1 ? lowerUrl : lowerUrl.substring(0, firstDelimiter)
+
+      // Prevent obfuscated protocols (e.g., jav&#x09;ascript:, javascript%3a)
+      // Any colon or ampersand before the first delimiter is suspicious in a relative URL
+      if (prefix.includes(':') || prefix.includes('&') || prefix.includes('%3a')) {
+        return false
+      }
+
+      return true
+    } catch {
       return false
     }
-    return true
   }
 }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `isSafeUrl` function failed to block protocol obfuscation payloads like `jav&#x09;ascript:alert(1)` or `javascript%3aalert(1)`. Because these payloads throw exceptions when parsed as absolute URLs via `new URL()`, they fall into the relative path fallback. The fallback only checked for literal colons matching specific strings (`javascript:`, `data:`, etc.), allowing obfuscated strings to be evaluated as "safe relative URLs."
🎯 **Impact:** Potential Cross-Site Scripting (XSS) or Indirect Prompt Injection (XPIA) bypass if clients consume and execute markdown links containing obfuscated schemes, believing they have been sanitized by the MCP server.
🔧 **Fix:** Updated the relative fallback logic in `isSafeUrl` to strictly extract the string prefix *before* the first path delimiter (`/`, `?`, `#`). If this prefix contains a colon (`:`), URL-encoded colon (`%3a`, `%3A`), or ampersand (`&`, indicating the start of an HTML entity), the URL is rejected as potentially malicious.
✅ **Verification:** Verified locally via `bun test` passing on updated test cases covering HTML entity and URL-encoding obfuscation. Added a Sentinel journal entry documenting the vulnerability pattern.

---
*PR created automatically by Jules for task [17860564975971468442](https://jules.google.com/task/17860564975971468442) started by @n24q02m*