### PR TITLE
fix: code health improvement] Standardize Notion token refresh error

### DIFF
--- a/src/auth/notion-oauth-provider.ts
+++ b/src/auth/notion-oauth-provider.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js'
 import { Client } from '@notionhq/client'
+import { NotionMCPError } from '../tools/helpers/errors.js'
 import { StatelessClientStore } from './stateless-client-store.js'
 
 /** Request context propagated via AsyncLocalStorage for IP-scoped pending binds */
@@ -288,7 +289,11 @@ export function createNotionOAuthProvider(config: NotionOAuthConfig) {
     })
 
     if (!response.ok) {
-      throw new Error(`Token refresh failed: ${response.status}`)
+      throw new NotionMCPError(
+        `Token refresh failed: ${response.status}`,
+        'AUTHENTICATION_ERROR',
+        'Check OAuth token and scopes'
+      )
     }
 
     const data = (await response.json()) as { access_token: string; token_type: string; expires_in?: number }


### PR DESCRIPTION
🎯 **What:** Replaced the generic `new Error` for token refresh failures in `src/auth/notion-oauth-provider.ts` with the project's standardized `NotionMCPError`.

💡 **Why:** This improves maintainability and debugging by providing a structured payload with an error code (`AUTHENTICATION_ERROR`) and actionable suggestions, adhering to the established error-handling patterns across the codebase.

✅ **Verification:** Ran `bun run check` to verify formatting/linting and `bun run test` to confirm no regressions were introduced.

✨ **Result:** Token refresh errors now yield a consistently structured MCP error response.

---
*PR created automatically by Jules for task [7402030469494494774](https://jules.google.com/task/7402030469494494774) started by @n24q02m*