### PR TITLE
feat: replace console.log with console.info in http transport]

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -116,7 +116,7 @@ describe('startHttp', () => {
   })
 
   it('should register OAuth router, health, and MCP endpoints', async () => {
-    const mockLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const mockLog = vi.spyOn(console, 'info').mockImplementation(() => {})
     const { startHttp } = await import('./http.js')
     const express = (await import('express')).default
 
@@ -152,7 +152,7 @@ describe('startHttp', () => {
   })
 
   it('should use createNotionOAuthProvider with config', async () => {
-    const mockLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const mockLog = vi.spyOn(console, 'info').mockImplementation(() => {})
     const { createNotionOAuthProvider } = await import('../auth/notion-oauth-provider.js')
 
     const { startHttp } = await import('./http.js')
@@ -170,7 +170,7 @@ describe('startHttp', () => {
 
   // Helper: start the server and return the registered route handlers
   async function startAndGetHandlers() {
-    const mockLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const mockLog = vi.spyOn(console, 'info').mockImplementation(() => {})
     const { startHttp } = await import('./http.js')
     const express = (await import('express')).default
     await startHttp()

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -274,7 +274,7 @@ export async function startHttp() {
   })
 
   app.listen(config.port, '0.0.0.0', () => {
-    console.log(`Remote MCP server listening on port ${config.port}`)
-    console.log(`Public URL: ${config.publicUrl}`)
+    console.info(`Remote MCP server listening on port ${config.port}`)
+    console.info(`Public URL: ${config.publicUrl}`)
   })
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced direct `console.log` usage with `console.info` for server startup messages in `src/transports/http.ts`, and updated the corresponding test spies in `src/transports/http.test.ts`.

💡 **Why:** How this improves maintainability
Using `console.log` is often flagged by linters as it's typically used for temporary debugging. `console.info` provides a clear semantic meaning for standard informational messages like server startup notifications without triggering lint warnings.

✅ **Verification:** How you confirmed the change is safe
Ran `bun run check` and `bun run test`. All lint checks passed and the test suite remains fully green.

✨ **Result:** The improvement achieved
Cleaned up the production code by using appropriate logging levels while preserving test coverage and server functionality.

---
*PR created automatically by Jules for task [1625014790825325278](https://jules.google.com/task/1625014790825325278) started by @n24q02m*