### PR TITLE
feat: code health improvement] Remove unused listCovers function

### DIFF
--- a/src/tools/helpers/covers.test.ts
+++ b/src/tools/helpers/covers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatCover, listCovers } from './covers'
+import { formatCover } from './covers'
 import { NotionMCPError } from './errors'
 
 describe('formatCover', () => {
@@ -99,29 +99,5 @@ describe('formatCover', () => {
     it('rejects vbscript: URLs', () => {
       expect(() => formatCover('vbscript:msgbox(1)')).toThrow(NotionMCPError)
     })
-  })
-})
-
-describe('listCovers', () => {
-  it('should return covers grouped by category', () => {
-    const groups = listCovers()
-    expect(groups.solid_colors).toContain('solid_red')
-    expect(groups.solid_colors).toContain('solid_blue')
-    expect(groups.gradients).toContain('gradient_1')
-    expect(groups.gradients).toContain('gradient_11')
-    expect(groups.nasa).toContain('nasa_carina_nebula')
-    expect(groups.met).toContain('met_paul_signac')
-    expect(groups.rijksmuseum).toContain('rijksmuseum_rembrandt_1642')
-    expect(groups.woodcuts).toContain('woodcuts_1')
-  })
-
-  it('should have 4 solid colors', () => {
-    const groups = listCovers()
-    expect(groups.solid_colors).toHaveLength(4)
-  })
-
-  it('should have 11 gradients', () => {
-    const groups = listCovers()
-    expect(groups.gradients).toHaveLength(11)
   })
 })

--- a/src/tools/helpers/covers.ts
+++ b/src/tools/helpers/covers.ts
@@ -122,15 +122,3 @@ export function formatCover(value: string): { type: 'external'; external: { url:
     'Provide a valid URL or a recognized cover shorthand name'
   )
 }
-
-/** List all available cover shorthand names, grouped by category */
-export function listCovers(): Record<string, string[]> {
-  const groups: Record<string, string[]> = {}
-  for (const key of Object.keys(COVER_CATALOG)) {
-    const category = key.split('_')[0]
-    const groupName = category === 'solid' ? 'solid_colors' : category === 'gradient' ? 'gradients' : category
-    if (!groups[groupName]) groups[groupName] = []
-    groups[groupName].push(key)
-  }
-  return groups
-}


### PR DESCRIPTION
🎯 **What:** The `listCovers` function and its associated unit tests were removed.
💡 **Why:** It was identified as dead code and was only being utilized within its own tests. Removing it cleans up the codebase and improves general maintainability.
✅ **Verification:** Verified by checking functionality via `bun run check` and confirming that the full test suite (`bun run test`) passed properly without regressions.
✨ **Result:** A slightly cleaner and easier to maintain repository.

---
*PR created automatically by Jules for task [3676805125957197993](https://jules.google.com/task/3676805125957197993) started by @n24q02m*