### PR TITLE
fix: refactor: replace Error with NotionMCPError in contentConvert

### DIFF
--- a/src/tools/composite/content.ts
+++ b/src/tools/composite/content.ts
@@ -3,7 +3,7 @@
  * Convert between Markdown and Notion blocks
  */
 
-import { withErrorHandling } from '../helpers/errors.js'
+import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 
 export interface ContentConvertInput {
@@ -19,7 +19,11 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
     switch (input.direction) {
       case 'markdown-to-blocks': {
         if (typeof input.content !== 'string') {
-          throw new Error('Content must be a string for markdown-to-blocks')
+          throw new NotionMCPError(
+            'Content must be a string for markdown-to-blocks',
+            'VALIDATION_ERROR',
+            'Ensure content is a string'
+          )
         }
         const blocks = markdownToBlocks(input.content)
         return {
@@ -36,11 +40,19 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
           try {
             content = JSON.parse(content)
           } catch {
-            throw new Error('Content must be a valid JSON array or array object for blocks-to-markdown')
+            throw new NotionMCPError(
+              'Content must be a valid JSON array or array object for blocks-to-markdown',
+              'VALIDATION_ERROR',
+              'Ensure content is a valid JSON string representing an array'
+            )
           }
         }
         if (!Array.isArray(content)) {
-          throw new Error('Content must be an array for blocks-to-markdown')
+          throw new NotionMCPError(
+            'Content must be an array for blocks-to-markdown',
+            'VALIDATION_ERROR',
+            'Ensure content is an array'
+          )
         }
         const markdown = blocksToMarkdown(content as any)
         return {
@@ -51,7 +63,11 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
       }
 
       default:
-        throw new Error(`Unsupported direction: ${input.direction}`)
+        throw new NotionMCPError(
+          `Unsupported direction: ${input.direction}`,
+          'VALIDATION_ERROR',
+          'Use "markdown-to-blocks" or "blocks-to-markdown"'
+        )
     }
   })()
 }


### PR DESCRIPTION
🎯 **What:** Replaced generic `throw new Error(...)` instances with the project's standard `NotionMCPError` class in `src/tools/composite/content.ts`. Added specific `VALIDATION_ERROR` codes and helpful suggestion strings.

💡 **Why:** Using `NotionMCPError` instead of generic `Error` objects integrates better with the existing `withErrorHandling` wrapper and the broader MCP server architecture, allowing for more structured and AI-friendly error responses (including `code` and `suggestion` fields). This improves the maintainability and consistency of the codebase.

✅ **Verification:** 
* Confirmed the changes are localized to `src/tools/composite/content.ts`.
* Ran `bun run check:fix` to ensure formatting and linting rules are met.
* Ran the full test suite (`bun run test`) which passed successfully. 
* Ran the specific test suite (`bun run test src/tools/composite/content.test.ts`), which passed successfully.

✨ **Result:** The `contentConvert` tool now consistently throws structured `NotionMCPError` instances for validation failures, improving both code health and the quality of errors returned to the client.

---
*PR created automatically by Jules for task [4029420883598643935](https://jules.google.com/task/4029420883598643935) started by @n24q02m*