### PR TITLE
fix: fix: remove unused batchItems function

### DIFF
--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { autoPaginate, batchItems, fetchChildrenRecursive, processBatches } from './pagination'
+import { autoPaginate, fetchChildrenRecursive, processBatches } from './pagination'
 
 describe('autoPaginate', () => {
   it('should return results from a single page', async () => {
@@ -173,48 +173,6 @@ describe('fetchChildrenRecursive', () => {
     const fetchChildren = vi.fn()
     await fetchChildrenRecursive([], fetchChildren)
     expect(fetchChildren).not.toHaveBeenCalled()
-  })
-})
-
-describe('batchItems', () => {
-  it('should split items evenly into batches', () => {
-    const items = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-    const batches = batchItems(items, 3)
-
-    expect(batches).toEqual([
-      [1, 2, 3],
-      [4, 5, 6],
-      [7, 8, 9]
-    ])
-  })
-
-  it('should handle uneven splits with a smaller last batch', () => {
-    const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-    const batches = batchItems(items, 3)
-
-    expect(batches).toEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]])
-  })
-
-  it('should return empty array for empty input', () => {
-    const batches = batchItems([], 3)
-
-    expect(batches).toEqual([])
-  })
-
-  it('should handle a single item', () => {
-    const batches = batchItems(['only'], 3)
-
-    expect(batches).toEqual([['only']])
-  })
-
-  it('should put all items in one batch when batchSize exceeds length', () => {
-    const items = [1, 2, 3]
-
-    const batches = batchItems(items, 100)
-
-    expect(batches).toEqual([[1, 2, 3]])
   })
 })
 

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -96,17 +96,6 @@ export async function fetchChildrenRecursive(
 }
 
 /**
- * Batch items into chunks
- */
-export function batchItems<T>(items: T[], batchSize: number): T[][] {
-  const batches: T[][] = []
-  for (let i = 0; i < items.length; i += batchSize) {
-    batches.push(items.slice(i, i + batchSize))
-  }
-  return batches
-}
-
-/**
  * Process items in batches with concurrency limit using a rolling window
  */
 export async function processBatches<T, R>(


### PR DESCRIPTION
🎯 **What:** Removed the unused `batchItems` function from `src/tools/helpers/pagination.ts` and its associated tests and imports from `src/tools/helpers/pagination.test.ts`.

💡 **Why:** A simple regex check confirmed that the `batchItems` function was exclusively used within its own test suite and nowhere else in the codebase. Removing dead code improves maintainability, reduces noise, and ensures developers only spend time reviewing and understanding code that is actually in use. 

✅ **Verification:** 
1. Verified the function was unused via `grep` and source code inspection.
2. Ran `bun run check` to ensure no linting or type errors were introduced by the removal.
3. Ran `bun run test` to verify that all remaining functionality and test suites continue to pass correctly.

✨ **Result:** The codebase is cleaner and easier to maintain without any change to the existing runtime behavior.

---
*PR created automatically by Jules for task [6207312575876873462](https://jules.google.com/task/6207312575876873462) started by @n24q02m*