### PR TITLE
fix: replace generic Errors with NotionMCPError in content tool]

### DIFF
--- a/src/tools/composite/content.ts
+++ b/src/tools/composite/content.ts
@@ -3,7 +3,7 @@
  * Convert between Markdown and Notion blocks
  */
 
-import { withErrorHandling } from '../helpers/errors.js'
+import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 
 export interface ContentConvertInput {
@@ -19,7 +19,11 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
     switch (input.direction) {
       case 'markdown-to-blocks': {
         if (typeof input.content !== 'string') {
-          throw new Error('Content must be a string for markdown-to-blocks')
+          throw new NotionMCPError(
+            'Content must be a string for markdown-to-blocks',
+            'VALIDATION_ERROR',
+            'Provide a string content'
+          )
         }
         const blocks = markdownToBlocks(input.content)
         return {
@@ -36,11 +40,19 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
           try {
             content = JSON.parse(content)
           } catch {
-            throw new Error('Content must be a valid JSON array or array object for blocks-to-markdown')
+            throw new NotionMCPError(
+              'Content must be a valid JSON array or array object for blocks-to-markdown',
+              'VALIDATION_ERROR',
+              'Provide a valid JSON string'
+            )
           }
         }
         if (!Array.isArray(content)) {
-          throw new Error('Content must be an array for blocks-to-markdown')
+          throw new NotionMCPError(
+            'Content must be an array for blocks-to-markdown',
+            'VALIDATION_ERROR',
+            'Provide an array of blocks'
+          )
         }
         const markdown = blocksToMarkdown(content as any)
         return {
@@ -51,7 +63,11 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
       }
 
       default:
-        throw new Error(`Unsupported direction: ${input.direction}`)
+        throw new NotionMCPError(
+          `Unsupported direction: ${input.direction}`,
+          'VALIDATION_ERROR',
+          'Direction must be markdown-to-blocks or blocks-to-markdown'
+        )
     }
   })()
 }


### PR DESCRIPTION
🎯 **What:** Replaced instances of generic `new Error` with the project-standard `new NotionMCPError` in `src/tools/composite/content.ts`. Four total generic errors were replaced. All now throw a 'VALIDATION_ERROR' code and provide AI-friendly suggestions.

💡 **Why:** This improves the maintainability and readability of the codebase by using consistent error handling patterns. `NotionMCPError` provides richer details for the client compared to generic Error objects, aligning with the project's standards.

✅ **Verification:** Verified that existing integration tests in `content.test.ts` still pass without modifications. Ran `bun run check` and `bun run test` locally to ensure no functionality is broken and code passes linting/formatting.

✨ **Result:** The codebase now consistently utilizes `NotionMCPError` in `content.ts`, yielding more robust, actionable error traces without altering core application behavior.

---
*PR created automatically by Jules for task [7056237045567017007](https://jules.google.com/task/7056237045567017007) started by @n24q02m*