### PR TITLE
feat: code Health Improvement: Simplify createNotionOAuthProvider

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,3 @@
+1. **Extract `setupProviderOverrides`**: Move the logic that overrides the provider's `authorize`, `exchangeAuthorizationCode`, and `exchangeRefreshToken` methods into a separate helper function to simplify `createNotionOAuthProvider`.
+2. **Extract Cleanup Logic**: Extract the `setInterval` logic that cleans up expired tokens, binds, and caches into a separate function `startCleanupInterval`.
+3. **Verify and test**: Ensure `bun run check` and `bun run test` pass after refactoring.

--- a/src/auth/notion-oauth-provider.ts
+++ b/src/auth/notion-oauth-provider.ts
@@ -192,6 +192,39 @@ export function createNotionOAuthProvider(config: NotionOAuthConfig) {
     get: () => clientStore
   })
 
+  setupProviderOverrides(
+    provider,
+    config,
+    callbackUrl,
+    notionBasicAuth,
+    pendingAuths,
+    authCodes,
+    notionTokens,
+    pendingBinds
+  )
+
+  startCleanupInterval(pendingAuths, authCodes, notionTokens, pendingBinds, boundTokens, verifyCache)
+
+  return {
+    provider,
+    clientStore,
+    pendingAuths,
+    authCodes,
+    callbackUrl,
+    notionBasicAuth
+  }
+}
+
+function setupProviderOverrides(
+  provider: ProxyOAuthServerProvider,
+  config: NotionOAuthConfig,
+  callbackUrl: string,
+  notionBasicAuth: string,
+  pendingAuths: Map<string, PendingAuth>,
+  authCodes: Map<string, StoredAuthCode>,
+  notionTokens: Map<string, StoredNotionToken>,
+  pendingBinds: Map<string, { notionToken: StoredNotionToken; expiresAt: number; sourceIp?: string }>
+) {
   // Override authorize: redirect to Notion with OUR callback URL, not client's
   provider.authorize = async (client, params, res) => {
     const ourState = randomBytes(32).toString('hex')
@@ -312,9 +345,17 @@ export function createNotionOAuthProvider(config: NotionOAuthConfig) {
       expires_in: data.expires_in ?? 86400
     }
   }
+}
 
-  // Cleanup expired entries periodically
-  setInterval(() => {
+function startCleanupInterval(
+  pendingAuths: Map<string, PendingAuth>,
+  authCodes: Map<string, StoredAuthCode>,
+  notionTokens: Map<string, StoredNotionToken>,
+  pendingBinds: Map<string, { notionToken: StoredNotionToken; expiresAt: number; sourceIp?: string }>,
+  boundTokens: Map<string, StoredNotionToken>,
+  verifyCache: Map<string, { expiresAt: number; userId: string; userName: string | null }>
+) {
+  return setInterval(() => {
     const now = Date.now()
     for (const [key, val] of pendingAuths) {
       if (now - val.createdAt > PENDING_AUTH_TTL) pendingAuths.delete(key)
@@ -335,13 +376,4 @@ export function createNotionOAuthProvider(config: NotionOAuthConfig) {
       if (now > val.expiresAt) verifyCache.delete(key)
     }
   }, 60_000)
-
-  return {
-    provider,
-    clientStore,
-    pendingAuths,
-    authCodes,
-    callbackUrl,
-    notionBasicAuth
-  }
 }


### PR DESCRIPTION
🎯 **What:** Extracted `setupProviderOverrides` and `startCleanupInterval` from `createNotionOAuthProvider` to reduce the complexity of the main function.
💡 **Why:** `createNotionOAuthProvider` was previously over 200 lines long and highly complex. By modularizing the method overrides and the cache expiration interval, the main function is now highly focused on variable initialization and dependency management, significantly improving readability and maintainability.
✅ **Verification:** Verified by ensuring the `bun run check` and `bun run test` pipelines ran successfully, including the comprehensive unit test suite in `notion-oauth-provider.test.ts`. Types have been fully preserved by explicit arguments.
✨ **Result:** The `createNotionOAuthProvider` method is now easier to understand and safe against side effects without breaking existing code.

---
*PR created automatically by Jules for task [15474944516188826706](https://jules.google.com/task/15474944516188826706) started by @n24q02m*