### PR TITLE
fix: fix: Replace new Error with NotionMCPError in content conversion tool

### DIFF
--- a/src/tools/composite/content.ts
+++ b/src/tools/composite/content.ts
@@ -3,7 +3,7 @@
  * Convert between Markdown and Notion blocks
  */
 
-import { withErrorHandling } from '../helpers/errors.js'
+import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 
 export interface ContentConvertInput {
@@ -19,7 +19,11 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
     switch (input.direction) {
       case 'markdown-to-blocks': {
         if (typeof input.content !== 'string') {
-          throw new Error('Content must be a string for markdown-to-blocks')
+          throw new NotionMCPError(
+            'Content must be a string for markdown-to-blocks',
+            'VALIDATION_ERROR',
+            'Provide a string content'
+          )
         }
         const blocks = markdownToBlocks(input.content)
         return {
@@ -36,11 +40,19 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
           try {
             content = JSON.parse(content)
           } catch {
-            throw new Error('Content must be a valid JSON array or array object for blocks-to-markdown')
+            throw new NotionMCPError(
+              'Content must be a valid JSON array or array object for blocks-to-markdown',
+              'VALIDATION_ERROR',
+              'Provide a valid JSON array or object'
+            )
           }
         }
         if (!Array.isArray(content)) {
-          throw new Error('Content must be an array for blocks-to-markdown')
+          throw new NotionMCPError(
+            'Content must be an array for blocks-to-markdown',
+            'VALIDATION_ERROR',
+            'Provide an array content'
+          )
         }
         const markdown = blocksToMarkdown(content as any)
         return {
@@ -51,7 +63,11 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
       }
 
       default:
-        throw new Error(`Unsupported direction: ${input.direction}`)
+        throw new NotionMCPError(
+          `Unsupported direction: ${input.direction}`,
+          'VALIDATION_ERROR',
+          'Provide a valid direction'
+        )
     }
   })()
 }


### PR DESCRIPTION
🎯 **What:** 
Replaced standard `new Error()` throws with the project's robust `NotionMCPError` class in `src/tools/composite/content.ts`. I also updated three other identical cases within the file for consistency.

💡 **Why:** 
This improves code health and maintainability by ensuring that validation errors use a standard format containing an explicit error code (`VALIDATION_ERROR`) and helpful AI/user resolution suggestions. It avoids leaking generic JavaScript exceptions to the MCP client.

✅ **Verification:** 
- Ran `bun run check` locally; linting and formatting are successful.
- Ran `bun run test` locally; all tests passed. 
- Conducted an AI code review to ensure safety and completeness.

✨ **Result:** 
All content conversion errors are consistently wrapped as `NotionMCPError` providing better error details and consistency with the rest of the codebase.

---
*PR created automatically by Jules for task [9606046009199908337](https://jules.google.com/task/9606046009199908337) started by @n24q02m*