### PR TITLE
feat: refactor startHttp route definitions

### DIFF
--- a/src/routes/callback.ts
+++ b/src/routes/callback.ts
@@ -1,0 +1,102 @@
+import { randomBytes } from 'node:crypto'
+import type express from 'express'
+
+const NOTION_TOKEN_URL = 'https://api.notion.com/v1/oauth/token'
+
+export interface CallbackRouteDeps {
+  app: express.Express
+  pendingAuths: Map<string, any>
+  authCodes: Map<string, any>
+  callbackUrl: string
+  notionBasicAuth: string
+}
+
+export function setupCallbackRoute({ app, pendingAuths, authCodes, callbackUrl, notionBasicAuth }: CallbackRouteDeps) {
+  app.get('/callback', async (req, res) => {
+    const { code, state, error } = req.query as Record<string, string>
+
+    if (error) {
+      res.status(400).json({ error: 'oauth_error', error_description: error })
+      return
+    }
+
+    if (!code || !state) {
+      res.status(400).json({ error: 'invalid_request', error_description: 'Missing code or state' })
+      return
+    }
+
+    // Look up the pending auth
+    const pending = pendingAuths.get(state)
+    if (!pending) {
+      res.status(400).json({ error: 'invalid_state', error_description: 'Unknown or expired state' })
+      return
+    }
+    pendingAuths.delete(state)
+
+    try {
+      // Exchange Notion's auth code for a Notion token
+      const tokenParams = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: callbackUrl
+      })
+
+      const tokenResponse = await globalThis.fetch(NOTION_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${notionBasicAuth}`
+        },
+        body: tokenParams.toString()
+      })
+
+      if (!tokenResponse.ok) {
+        await tokenResponse.body?.cancel()
+        console.error('Notion token exchange failed:', tokenResponse.status)
+        res
+          .status(502)
+          .json({ error: 'token_exchange_failed', error_description: 'Failed to exchange code with Notion' })
+        return
+      }
+
+      const tokenData = (await tokenResponse.json()) as {
+        access_token: string
+        token_type: string
+        expires_in?: number
+        refresh_token?: string
+      }
+
+      // Issue our own auth code and store the Notion token + PKCE challenge for verification
+      const ourAuthCode = randomBytes(32).toString('hex')
+      authCodes.set(ourAuthCode, {
+        notionAccessToken: tokenData.access_token,
+        notionRefreshToken: tokenData.refresh_token,
+        expiresIn: tokenData.expires_in,
+        codeChallenge: pending.codeChallenge,
+        codeChallengeMethod: pending.codeChallengeMethod,
+        clientId: pending.clientId,
+        createdAt: Date.now()
+      })
+
+      // Redirect back to the MCP client's original redirect_uri
+      const clientRedirect = new URL(pending.clientRedirectUri)
+
+      // Prevent XSS and Open Redirect vulnerabilities via unsafe protocols
+      const protocol = clientRedirect.protocol.toLowerCase()
+      if (['javascript:', 'data:', 'vbscript:', 'file:'].includes(protocol)) {
+        res.status(400).json({ error: 'invalid_request', error_description: 'Unsafe redirect URI' })
+        return
+      }
+
+      clientRedirect.searchParams.set('code', ourAuthCode)
+      if (pending.clientState) {
+        clientRedirect.searchParams.set('state', pending.clientState)
+      }
+
+      res.redirect(clientRedirect.toString())
+    } catch (err) {
+      console.error('Callback handler error:', err)
+      res.status(500).json({ error: 'server_error', error_description: 'Internal server error' })
+    }
+  })
+}

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,8 @@
+import type express from 'express'
+
+export function setupHealthRoute(app: express.Express) {
+  // Health check (no auth required)
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', mode: 'remote', timestamp: new Date().toISOString() })
+  })
+}

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
+import { Client } from '@notionhq/client'
+import express from 'express'
+import { createMCPServer } from '../create-server.js'
+
+export interface McpRoutesDeps {
+  app: express.Express
+  mcpRateLimit: express.RequestHandler
+  authMiddleware: express.RequestHandler
+  transports: Map<string, StreamableHTTPServerTransport>
+  sessionOwners: Map<string, string>
+}
+
+export function setupMcpRoutes({ app, mcpRateLimit, authMiddleware, transports, sessionOwners }: McpRoutesDeps) {
+  const jsonParser = express.json()
+
+  // Verify session ownership for GET/DELETE endpoints
+  function verifySessionOwner(req: express.Request, res: express.Response, sessionId: string): boolean {
+    const authInfo = (req as any).auth
+    const ownerToken = sessionOwners.get(sessionId)
+    if (ownerToken && authInfo?.token !== ownerToken) {
+      res.status(403).json({ error: 'Session belongs to a different user' })
+      return false
+    }
+    return true
+  }
+
+  // MCP endpoint — POST (new session or existing)
+  app.post('/mcp', mcpRateLimit, jsonParser, authMiddleware, async (req, res) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined
+
+    // Existing session — verify the authenticated user owns this session
+    if (sessionId && transports.has(sessionId)) {
+      const authInfo = (req as any).auth
+      const ownerToken = sessionOwners.get(sessionId)
+      if (ownerToken && authInfo?.token !== ownerToken) {
+        res.status(403).json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Session belongs to a different user' },
+          id: null
+        })
+        return
+      }
+      await transports.get(sessionId)!.handleRequest(req, res, req.body)
+      return
+    }
+
+    // New session — must be initialize request
+    if (!sessionId && isInitializeRequest(req.body)) {
+      const authInfo = (req as any).auth
+      const notionToken: string = authInfo.token
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          transports.set(id, transport)
+          sessionOwners.set(id, notionToken)
+        }
+      })
+
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          transports.delete(transport.sessionId)
+          sessionOwners.delete(transport.sessionId)
+        }
+      }
+
+      // Per-session MCP server with the user's Notion token
+      const server = createMCPServer(() => new Client({ auth: notionToken, notionVersion: '2025-09-03' }))
+      await server.connect(transport)
+      await transport.handleRequest(req, res, req.body)
+      return
+    }
+
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Bad request: missing session ID or not an initialize request' },
+      id: null
+    })
+  })
+
+  // MCP endpoint — GET (SSE streaming for existing session)
+  app.get('/mcp', mcpRateLimit, authMiddleware, async (req, res) => {
+    const sessionId = req.headers['mcp-session-id'] as string
+    if (sessionId && transports.has(sessionId)) {
+      if (!verifySessionOwner(req, res, sessionId)) return
+      await transports.get(sessionId)!.handleRequest(req, res)
+    } else {
+      res.status(400).json({ error: 'Invalid or missing session' })
+    }
+  })
+
+  // MCP endpoint — DELETE (close session)
+  app.delete('/mcp', mcpRateLimit, authMiddleware, async (req, res) => {
+    const sessionId = req.headers['mcp-session-id'] as string
+    if (sessionId && transports.has(sessionId)) {
+      if (!verifySessionOwner(req, res, sessionId)) return
+      await transports.get(sessionId)!.handleRequest(req, res)
+    } else {
+      res.status(400).json({ error: 'Invalid or missing session' })
+    }
+  })
+}

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -3,18 +3,15 @@
  * Express server with Notion OAuth callback relay, Streamable HTTP transport, and session management
  */
 
-import { randomBytes, randomUUID } from 'node:crypto'
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js'
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js'
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
-import { Client } from '@notionhq/client'
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import express from 'express'
 import rateLimit from 'express-rate-limit'
 import { createNotionOAuthProvider, requestContext } from '../auth/notion-oauth-provider.js'
-import { createMCPServer } from '../create-server.js'
-
-const NOTION_TOKEN_URL = 'https://api.notion.com/v1/oauth/token'
+import { setupCallbackRoute } from '../routes/callback.js'
+import { setupHealthRoute } from '../routes/health.js'
+import { setupMcpRoutes } from '../routes/mcp.js'
 
 interface HttpConfig {
   port: number
@@ -84,194 +81,27 @@ export async function startHttp() {
     })
   )
 
-  // Notion OAuth callback relay
-  // Notion redirects here after user authorizes. We exchange the code,
-  // store the token, issue our own auth code, and redirect to MCP client.
-  app.get('/callback', async (req, res) => {
-    const { code, state, error } = req.query as Record<string, string>
-
-    if (error) {
-      res.status(400).json({ error: 'oauth_error', error_description: error })
-      return
-    }
-
-    if (!code || !state) {
-      res.status(400).json({ error: 'invalid_request', error_description: 'Missing code or state' })
-      return
-    }
-
-    // Look up the pending auth
-    const pending = pendingAuths.get(state)
-    if (!pending) {
-      res.status(400).json({ error: 'invalid_state', error_description: 'Unknown or expired state' })
-      return
-    }
-    pendingAuths.delete(state)
-
-    try {
-      // Exchange Notion's auth code for a Notion token
-      const tokenParams = new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        redirect_uri: callbackUrl
-      })
-
-      const tokenResponse = await globalThis.fetch(NOTION_TOKEN_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${notionBasicAuth}`
-        },
-        body: tokenParams.toString()
-      })
-
-      if (!tokenResponse.ok) {
-        await tokenResponse.body?.cancel()
-        console.error('Notion token exchange failed:', tokenResponse.status)
-        res
-          .status(502)
-          .json({ error: 'token_exchange_failed', error_description: 'Failed to exchange code with Notion' })
-        return
-      }
-
-      const tokenData = (await tokenResponse.json()) as {
-        access_token: string
-        token_type: string
-        expires_in?: number
-        refresh_token?: string
-      }
-
-      // Issue our own auth code and store the Notion token + PKCE challenge for verification
-      const ourAuthCode = randomBytes(32).toString('hex')
-      authCodes.set(ourAuthCode, {
-        notionAccessToken: tokenData.access_token,
-        notionRefreshToken: tokenData.refresh_token,
-        expiresIn: tokenData.expires_in,
-        codeChallenge: pending.codeChallenge,
-        codeChallengeMethod: pending.codeChallengeMethod,
-        clientId: pending.clientId,
-        createdAt: Date.now()
-      })
-
-      // Redirect back to the MCP client's original redirect_uri
-      const clientRedirect = new URL(pending.clientRedirectUri)
-
-      // Prevent XSS and Open Redirect vulnerabilities via unsafe protocols
-      const protocol = clientRedirect.protocol.toLowerCase()
-      if (['javascript:', 'data:', 'vbscript:', 'file:'].includes(protocol)) {
-        res.status(400).json({ error: 'invalid_request', error_description: 'Unsafe redirect URI' })
-        return
-      }
-
-      clientRedirect.searchParams.set('code', ourAuthCode)
-      if (pending.clientState) {
-        clientRedirect.searchParams.set('state', pending.clientState)
-      }
-
-      res.redirect(clientRedirect.toString())
-    } catch (err) {
-      console.error('Callback handler error:', err)
-      res.status(500).json({ error: 'server_error', error_description: 'Internal server error' })
-    }
+  setupCallbackRoute({
+    app,
+    pendingAuths,
+    authCodes,
+    callbackUrl,
+    notionBasicAuth
   })
 
   const authMiddleware = requireBearerAuth({ verifier: provider })
-  const jsonParser = express.json()
   const transports: Map<string, StreamableHTTPServerTransport> = new Map()
-  // Session owner binding — prevents cross-user session hijacking
-  const sessionOwners: Map<string, string> = new Map() // sessionId → notionToken
+  const sessionOwners: Map<string, string> = new Map()
 
-  // MCP endpoint — POST (new session or existing)
-  app.post('/mcp', mcpRateLimit, jsonParser, authMiddleware, async (req, res) => {
-    const sessionId = req.headers['mcp-session-id'] as string | undefined
-
-    // Existing session — verify the authenticated user owns this session
-    if (sessionId && transports.has(sessionId)) {
-      const authInfo = (req as any).auth
-      const ownerToken = sessionOwners.get(sessionId)
-      if (ownerToken && authInfo?.token !== ownerToken) {
-        res.status(403).json({
-          jsonrpc: '2.0',
-          error: { code: -32000, message: 'Session belongs to a different user' },
-          id: null
-        })
-        return
-      }
-      await transports.get(sessionId)!.handleRequest(req, res, req.body)
-      return
-    }
-
-    // New session — must be initialize request
-    if (!sessionId && isInitializeRequest(req.body)) {
-      const authInfo = (req as any).auth
-      const notionToken: string = authInfo.token
-
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        onsessioninitialized: (id) => {
-          transports.set(id, transport)
-          sessionOwners.set(id, notionToken)
-        }
-      })
-
-      transport.onclose = () => {
-        if (transport.sessionId) {
-          transports.delete(transport.sessionId)
-          sessionOwners.delete(transport.sessionId)
-        }
-      }
-
-      // Per-session MCP server with the user's Notion token
-      const server = createMCPServer(() => new Client({ auth: notionToken, notionVersion: '2025-09-03' }))
-      await server.connect(transport)
-      await transport.handleRequest(req, res, req.body)
-      return
-    }
-
-    res.status(400).json({
-      jsonrpc: '2.0',
-      error: { code: -32000, message: 'Bad request: missing session ID or not an initialize request' },
-      id: null
-    })
+  setupMcpRoutes({
+    app,
+    mcpRateLimit,
+    authMiddleware,
+    transports,
+    sessionOwners
   })
 
-  // Verify session ownership for GET/DELETE endpoints
-  function verifySessionOwner(req: express.Request, res: express.Response, sessionId: string): boolean {
-    const authInfo = (req as any).auth
-    const ownerToken = sessionOwners.get(sessionId)
-    if (ownerToken && authInfo?.token !== ownerToken) {
-      res.status(403).json({ error: 'Session belongs to a different user' })
-      return false
-    }
-    return true
-  }
-
-  // MCP endpoint — GET (SSE streaming for existing session)
-  app.get('/mcp', mcpRateLimit, authMiddleware, async (req, res) => {
-    const sessionId = req.headers['mcp-session-id'] as string
-    if (sessionId && transports.has(sessionId)) {
-      if (!verifySessionOwner(req, res, sessionId)) return
-      await transports.get(sessionId)!.handleRequest(req, res)
-    } else {
-      res.status(400).json({ error: 'Invalid or missing session' })
-    }
-  })
-
-  // MCP endpoint — DELETE (close session)
-  app.delete('/mcp', mcpRateLimit, authMiddleware, async (req, res) => {
-    const sessionId = req.headers['mcp-session-id'] as string
-    if (sessionId && transports.has(sessionId)) {
-      if (!verifySessionOwner(req, res, sessionId)) return
-      await transports.get(sessionId)!.handleRequest(req, res)
-    } else {
-      res.status(400).json({ error: 'Invalid or missing session' })
-    }
-  })
-
-  // Health check (no auth required)
-  app.get('/health', (_req, res) => {
-    res.json({ status: 'ok', mode: 'remote', timestamp: new Date().toISOString() })
-  })
+  setupHealthRoute(app)
 
   app.listen(config.port, '0.0.0.0', () => {
     console.log(`Remote MCP server listening on port ${config.port}`)


### PR DESCRIPTION
🎯 **What:** The `startHttp` function in `src/transports/http.ts` was refactored. The inline route handlers for `/callback`, `/mcp`, and `/health` were extracted into separate files under `src/routes/`. 
💡 **Why:** `startHttp` was a complex monolithic function mixing server setup, state initialization, and route logic. Extracting the routes improves maintainability, testing isolation, and readability of the main entry point while keeping the HTTP server setup concise.
✅ **Verification:** Ran `bun run check:fix` and `bun run check` to ensure code styles and typings are correct. Ran the full `bun run test` suite successfully, verifying that all original endpoint behavior is preserved.
✨ **Result:** A more modular express server setup, making route handlers easier to test and edit independently without touching the main server logic.

---
*PR created automatically by Jules for task [16921665180386252919](https://jules.google.com/task/16921665180386252919) started by @n24q02m*