### PR TITLE
fix: add status property type conversion in convertToNotionProperties

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -459,6 +459,32 @@ describe('databases', () => {
         'pages or page_properties required'
       )
     })
+
+    it('should convert a status field string to status format (not select)', async () => {
+      mockNotion.dataSources.retrieve.mockResolvedValueOnce(
+        makeDataSourceResponse({
+          properties: {
+            Name: { type: 'title', id: 'prop-1' },
+            State: { type: 'status', id: 'prop-3' }
+          }
+        })
+      )
+      mockNotion.pages.create.mockResolvedValueOnce({ id: 'p-status', url: 'https://notion.so/p-status' })
+
+      await databases(notion, {
+        action: 'create_page',
+        database_id: 'db-1',
+        page_properties: { Name: 'Todo item', State: 'Not started' }
+      })
+
+      expect(mockNotion.pages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            State: { status: { name: 'Not started' } }
+          })
+        })
+      )
+    })
   })
 
   describe('update_page', () => {

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -73,6 +73,19 @@ describe('convertToNotionProperties', () => {
         Phone: { phone_number: '+1234567890' }
       })
     })
+
+    it('converts status schema type to status format (not select)', () => {
+      const result = convertToNotionProperties({ Status: 'Not started' }, { Status: 'status' })
+      expect(result).toEqual({
+        Status: { status: { name: 'Not started' } }
+      })
+    })
+
+    it('does not fall back to select when schema type is status', () => {
+      const result = convertToNotionProperties({ State: 'In progress' }, { State: 'status' })
+      expect(result).not.toEqual({ State: { select: { name: 'In progress' } } })
+      expect(result).toEqual({ State: { status: { name: 'In progress' } } })
+    })
   })
 
   describe('string values without schema (auto-detect)', () => {

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -86,6 +86,21 @@ describe('convertToNotionProperties', () => {
       expect(result).not.toEqual({ State: { select: { name: 'In progress' } } })
       expect(result).toEqual({ State: { status: { name: 'In progress' } } })
     })
+
+    it('converts empty string for status field (API validates option names, not this layer)', () => {
+      const result = convertToNotionProperties({ Status: '' }, { Status: 'status' })
+      expect(result).toEqual({ Status: { status: { name: '' } } })
+    })
+  })
+
+  describe('string values with mixed schema (status vs select fallback)', () => {
+    it('converts status field via schema while falling back to select for unschematized field', () => {
+      const result = convertToNotionProperties({ Status: 'In Progress', Priority: 'High' }, { Status: 'status' })
+      expect(result).toEqual({
+        Status: { status: { name: 'In Progress' } },
+        Priority: { select: { name: 'High' } }
+      })
+    })
   })
 
   describe('string values without schema (auto-detect)', () => {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -75,6 +75,8 @@ export function convertToNotionProperties(
         converted[key] = { phone_number: value }
       } else if (schemaType === 'relation') {
         converted[key] = toRelation(value)
+      } else if (schemaType === 'status') {
+        converted[key] = { status: { name: value } }
       } else if (key === 'Name' || key === 'Title' || key.toLowerCase() === 'title') {
         // Fallback: guess title from key name
         converted[key] = { title: [RichText.text(value)] }


### PR DESCRIPTION
## Problem

`convertToNotionProperties()` handles string values with schema-aware type detection, but the `status` property type was missing from the chain. String values for `status` fields silently fell through to the select fallback:

```ts
// Bug: schemaType === 'status' → falls to else branch
converted[key] = { select: { name: value } }  // wrong
```

The Notion API rejects `select` values for `status` properties, causing `create_page` calls to fail with a validation error when any property is a status type.

## Fix

Add an explicit `else if` branch for `schemaType === 'status'` before the key-name heuristic fallback:

```ts
} else if (schemaType === 'status') {
  converted[key] = { status: { name: value } }
```

## Tests

- `properties.test.ts`: two unit tests confirming `status` schema type produces `{status:{name:...}}` and does NOT fall back to `{select:{name:...}}`
- `databases.test.ts`: integration test confirming a status string travels end-to-end through `create_page` in the correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)