### PR TITLE
fix: clear validation error when pages[] items missing properties wrapper

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -460,14 +460,53 @@ describe('databases', () => {
       )
     })
 
-    it('should throw a clear error when pages array items are missing the properties wrapper', async () => {
+    it('should throw with item index when pages array item is missing the properties wrapper', async () => {
       await expect(
         databases(notion, {
           action: 'create_page',
           database_id: 'db-1',
           pages: [{ Name: 'Flat item' } as any]
         })
-      ).rejects.toThrow('Each item in the pages array must have a "properties" key')
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('index 0'),
+        code: 'VALIDATION_ERROR'
+      })
+    })
+
+    it('should throw with correct index when second item is missing the properties wrapper', async () => {
+      mockNotion.pages.create.mockResolvedValueOnce({ id: 'p-1', url: 'https://notion.so/p-1' })
+
+      await expect(
+        databases(notion, {
+          action: 'create_page',
+          database_id: 'db-1',
+          pages: [{ properties: { Name: 'Valid' } }, { Name: 'Flat' } as any]
+        })
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('index 1'),
+        code: 'VALIDATION_ERROR'
+      })
+      expect(mockNotion.pages.create).not.toHaveBeenCalled()
+    })
+
+    it('should throw when pages array item has null properties', async () => {
+      await expect(
+        databases(notion, {
+          action: 'create_page',
+          database_id: 'db-1',
+          pages: [{ properties: null } as any]
+        })
+      ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' })
+    })
+
+    it('should throw when pages array item is null', async () => {
+      await expect(
+        databases(notion, {
+          action: 'create_page',
+          database_id: 'db-1',
+          pages: [null as any]
+        })
+      ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' })
     })
   })
 
@@ -509,6 +548,18 @@ describe('databases', () => {
       await expect(databases(notion, { action: 'update_page' })).rejects.toThrow(
         'pages or page_id+page_properties required'
       )
+    })
+
+    it('should throw with item index when pages array item is missing properties', async () => {
+      await expect(
+        databases(notion, {
+          action: 'update_page',
+          pages: [{ page_id: 'p-1', properties: null } as any]
+        })
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('index 0'),
+        code: 'VALIDATION_ERROR'
+      })
     })
   })
 

--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -459,6 +459,16 @@ describe('databases', () => {
         'pages or page_properties required'
       )
     })
+
+    it('should throw a clear error when pages array items are missing the properties wrapper', async () => {
+      await expect(
+        databases(notion, {
+          action: 'create_page',
+          database_id: 'db-1',
+          pages: [{ Name: 'Flat item' } as any]
+        })
+      ).rejects.toThrow('Each item in the pages array must have a "properties" key')
+    })
   })
 
   describe('update_page', () => {

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -489,14 +489,18 @@ async function createDatabasePages(notion: Client, input: DatabasesInput): Promi
     throw new NotionMCPError('pages or page_properties required', 'VALIDATION_ERROR', 'Provide items to create')
   }
 
-  const results = await processBatches(items, async (item) => {
-    if (item.properties === undefined || item.properties === null) {
+  // Validate all items before processing to avoid partial writes on malformed input
+  for (let i = 0; i < items.length; i++) {
+    if (!items[i] || items[i].properties === undefined || items[i].properties === null) {
       throw new NotionMCPError(
-        'Each item in the pages array must have a "properties" key',
+        `Item at index ${i} in the pages array is missing the "properties" key`,
         'VALIDATION_ERROR',
         'Use format: pages: [{ "properties": { "FieldName": "value" } }] - not flat objects like [{ "FieldName": "value" }]'
       )
     }
+  }
+
+  const results = await processBatches(items, async (item) => {
     const properties = convertToNotionProperties(item.properties, schema)
 
     const page = await notion.pages.create({
@@ -531,6 +535,17 @@ async function updateDatabasePages(notion: Client, input: DatabasesInput): Promi
 
   if (items.length === 0) {
     throw new NotionMCPError('pages or page_id+page_properties required', 'VALIDATION_ERROR', 'Provide items to update')
+  }
+
+  // Validate all items before processing to avoid partial writes on malformed input
+  for (let i = 0; i < items.length; i++) {
+    if (!items[i] || items[i].properties === undefined || items[i].properties === null) {
+      throw new NotionMCPError(
+        `Item at index ${i} in the pages array is missing the "properties" key`,
+        'VALIDATION_ERROR',
+        'Use format: pages: [{ "page_id": "...", "properties": { "FieldName": "value" } }]'
+      )
+    }
   }
 
   const results = await processBatches(items, async (item) => {

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -490,6 +490,13 @@ async function createDatabasePages(notion: Client, input: DatabasesInput): Promi
   }
 
   const results = await processBatches(items, async (item) => {
+    if (item.properties === undefined || item.properties === null) {
+      throw new NotionMCPError(
+        'Each item in the pages array must have a "properties" key',
+        'VALIDATION_ERROR',
+        'Use format: pages: [{ "properties": { "FieldName": "value" } }] - not flat objects like [{ "FieldName": "value" }]'
+      )
+    }
     const properties = convertToNotionProperties(item.properties, schema)
 
     const page = await notion.pages.create({


### PR DESCRIPTION
## Problem

Passing flat objects to the `pages` array in `create_page` — e.g. `[{"FieldName": "value"}]` instead of `[{ "properties": { "FieldName": "value" } }]` — caused a cryptic runtime error:

```
TypeError: Cannot convert undefined or null to object
```

This came from `Object.keys(item.properties)` inside `convertToNotionProperties` when `item.properties` was `undefined`. The error gave callers no actionable information about what went wrong.

## Fix

Add an explicit guard before the conversion call:

```ts
if (item.properties === undefined || item.properties === null) {
  throw new NotionMCPError(
    'Each item in the pages array must have a "properties" key',
    'VALIDATION_ERROR',
    'Use format: pages: [{ "properties": { "FieldName": "value" } }] - not flat objects like [{ "FieldName": "value" }]'
  )
}
```

## Tests

- `databases.test.ts`: test confirming flat `pages[]` items now throw a readable `NotionMCPError` instead of `Object.keys(undefined)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)