### PR TITLE
feat: add rate limit to callback endpoint

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -129,7 +129,7 @@ describe('startHttp', () => {
     expect(app.use).toHaveBeenCalled()
 
     // Callback endpoint registered
-    expect(app.get).toHaveBeenCalledWith('/callback', expect.any(Function))
+    expect(app.get).toHaveBeenCalledWith('/callback', expect.any(Function), expect.any(Function))
 
     // Health endpoint registered
     expect(app.get).toHaveBeenCalledWith('/health', expect.any(Function))

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -67,6 +67,14 @@ export async function startHttp() {
     legacyHeaders: false
   })
 
+  // Rate limit OAuth endpoints per IP to prevent abuse/brute-force
+  const authRateLimit = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 20, // Strict limit for auth endpoints
+    standardHeaders: 'draft-7',
+    legacyHeaders: false
+  })
+
   // Propagate request IP via AsyncLocalStorage for IP-scoped pending binds
   app.use((req, _res, next) => {
     const ip = req.ip || req.socket.remoteAddress || undefined
@@ -87,7 +95,7 @@ export async function startHttp() {
   // Notion OAuth callback relay
   // Notion redirects here after user authorizes. We exchange the code,
   // store the token, issue our own auth code, and redirect to MCP client.
-  app.get('/callback', async (req, res) => {
+  app.get('/callback', authRateLimit, async (req, res) => {
     const { code, state, error } = req.query as Record<string, string>
 
     if (error) {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing rate limit on a sensitive OAuth callback endpoint
🎯 **Impact:** An attacker could abuse the unprotected endpoint, attempting to brute-force states, overwhelm the token exchange endpoint, or cause denial of service.
🔧 **Fix:** Implemented a strict rate limit (`authRateLimit`, 20 requests per minute) on the `/callback` route using `express-rate-limit`.
✅ **Verification:** Unit tests and linter passed successfully. Verified the rate limit middleware is injected properly and the corresponding route initialization test is updated.

---
*PR created automatically by Jules for task [5885425656293087938](https://jules.google.com/task/5885425656293087938) started by @n24q02m*