### PR TITLE
feat: disable x-powered-by header in Express

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -9,6 +9,7 @@ vi.mock('express', () => {
   const mockApp = {
     use: vi.fn(),
     set: vi.fn(),
+    disable: vi.fn(),
     get: vi.fn((path: string, ...fns: Fn[]) => {
       handlers[`GET:${path}`] = fns
     }),
@@ -127,6 +128,10 @@ describe('startHttp', () => {
 
     // OAuth router mounted
     expect(app.use).toHaveBeenCalled()
+
+    // Trust proxy and disable x-powered-by
+    expect(app.set).toHaveBeenCalledWith('trust proxy', 2)
+    expect(app.disable).toHaveBeenCalledWith('x-powered-by')
 
     // Callback endpoint registered
     expect(app.get).toHaveBeenCalledWith('/callback', expect.any(Function))

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -58,6 +58,7 @@ export async function startHttp() {
 
   // Trust exactly 2 reverse proxies (Cloudflare + Caddy) for correct req.ip
   app.set('trust proxy', 2)
+  app.disable('x-powered-by')
 
   // Rate limit MCP endpoints per IP
   const mcpRateLimit = rateLimit({


### PR DESCRIPTION
🚨 **Severity**: Low
💡 **Vulnerability**: Express.js applications by default send the `X-Powered-By` response header, identifying the technology stack. This is considered a mild security risk as it helps attackers fingerprint the server.
🎯 **Impact**: Potential attackers can use the `X-Powered-By: Express` header to discover the underlying technology and tailor attacks specific to Express.js vulnerabilities.
🔧 **Fix**: Added `app.disable('x-powered-by')` to the remote HTTP transport server initialization to remove the header. Updated tests to enforce this configuration.
✅ **Verification**: Run `bun test src/transports/http.test.ts` to verify the header is disabled.

---
*PR created automatically by Jules for task [6715969493479236482](https://jules.google.com/task/6715969493479236482) started by @n24q02m*