### PR TITLE
fix: remove empty JSDoc block in errors.ts

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -65,8 +65,6 @@ function sanitizeErrorDetails(error: any): any {
 }
 
 /**
-
-/**
  * Enhance Notion API error with helpful context
  */
 export function enhanceError(error: any): NotionMCPError {


### PR DESCRIPTION
🎯 **What:** Removed an empty and unclosed JSDoc block (`/**`) directly preceding the documentation for the `enhanceError` function in `src/tools/helpers/errors.ts`.

💡 **Why:** The empty comment block served no purpose, caused potential confusion for developers reading the code, and cluttered the file. Removing it improves overall maintainability and readability.

✅ **Verification:** Ran `bun run check` to verify formatting and linting, and `bun run test` to ensure no existing functionality was broken. The tests passed successfully.

✨ **Result:** The codebase is cleaner and easier to read without the orphaned comment block.

---
*PR created automatically by Jules for task [4729355216320588784](https://jules.google.com/task/4729355216320588784) started by @n24q02m*