### PR TITLE
feat: code Health: Improve workspace return typing

### DIFF
--- a/src/tools/composite/workspace.test.ts
+++ b/src/tools/composite/workspace.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { workspace } from './workspace'
+import { type WorkspaceResult, workspace } from './workspace.js'
 
 const mockNotion = {
   users: {
@@ -22,7 +22,10 @@ describe('workspace', () => {
         bot: { owner: { type: 'workspace', workspace: true } }
       })
 
-      const result = await workspace(mockNotion as any, { action: 'info' })
+      const result = (await workspace(mockNotion as any, { action: 'info' })) as Extract<
+        WorkspaceResult,
+        { action: 'info' }
+      >
 
       expect(result.action).toBe('info')
       expect(result.bot).toEqual({
@@ -41,7 +44,10 @@ describe('workspace', () => {
         bot: {}
       })
 
-      const result = await workspace(mockNotion as any, { action: 'info' })
+      const result = (await workspace(mockNotion as any, { action: 'info' })) as Extract<
+        WorkspaceResult,
+        { action: 'info' }
+      >
 
       expect(result.bot.name).toBe('Bot')
     })
@@ -63,7 +69,10 @@ describe('workspace', () => {
         has_more: false
       })
 
-      const result = await workspace(mockNotion as any, { action: 'search', query: 'My Page' })
+      const result = (await workspace(mockNotion as any, { action: 'search', query: 'My Page' })) as Extract<
+        WorkspaceResult,
+        { action: 'search' }
+      >
 
       expect(result.action).toBe('search')
       expect(result.query).toBe('My Page')
@@ -84,7 +93,10 @@ describe('workspace', () => {
         has_more: false
       })
 
-      const result = await workspace(mockNotion as any, { action: 'search' })
+      const result = (await workspace(mockNotion as any, { action: 'search' })) as Extract<
+        WorkspaceResult,
+        { action: 'search' }
+      >
 
       expect(result.action).toBe('search')
       expect(result.query).toBeUndefined()
@@ -161,10 +173,10 @@ describe('workspace', () => {
         has_more: false
       })
 
-      const result = await workspace(mockNotion as any, {
+      const result = (await workspace(mockNotion as any, {
         action: 'search',
         limit: 2
-      })
+      })) as Extract<WorkspaceResult, { action: 'search' }>
 
       expect(result.total).toBe(2)
       expect(result.results).toHaveLength(2)
@@ -185,7 +197,10 @@ describe('workspace', () => {
         has_more: false
       })
 
-      const result = await workspace(mockNotion as any, { action: 'search' })
+      const result = (await workspace(mockNotion as any, { action: 'search' })) as Extract<
+        WorkspaceResult,
+        { action: 'search' }
+      >
 
       expect(result.results[0].title).toBe('Named Page')
     })
@@ -205,7 +220,10 @@ describe('workspace', () => {
         has_more: false
       })
 
-      const result = await workspace(mockNotion as any, { action: 'search' })
+      const result = (await workspace(mockNotion as any, { action: 'search' })) as Extract<
+        WorkspaceResult,
+        { action: 'search' }
+      >
 
       expect(result.results[0].title).toBe('My Database')
     })
@@ -225,7 +243,10 @@ describe('workspace', () => {
         has_more: false
       })
 
-      const result = await workspace(mockNotion as any, { action: 'search' })
+      const result = (await workspace(mockNotion as any, { action: 'search' })) as Extract<
+        WorkspaceResult,
+        { action: 'search' }
+      >
 
       expect(result.results[0].title).toBe('Untitled')
     })

--- a/src/tools/composite/workspace.ts
+++ b/src/tools/composite/workspace.ts
@@ -7,6 +7,34 @@ import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { autoPaginate } from '../helpers/pagination.js'
 
+export interface WorkspaceInfoResult {
+  action: 'info'
+  bot: {
+    id: string
+    name: string
+    type: string
+    owner?: any
+  }
+}
+
+export interface WorkspaceSearchResultItem {
+  id: string
+  object: string
+  title: string
+  url: string
+  last_edited_time: string
+  database_id?: string
+}
+
+export interface WorkspaceSearchResult {
+  action: 'search'
+  query?: string
+  total: number
+  results: WorkspaceSearchResultItem[]
+}
+
+export type WorkspaceResult = WorkspaceInfoResult | WorkspaceSearchResult
+
 export interface WorkspaceInput {
   action: 'info' | 'search'
 
@@ -28,14 +56,14 @@ export interface WorkspaceInput {
  * Unified workspace tool
  * Maps to: GET /v1/users/me and POST /v1/search
  */
-export async function workspace(notion: Client, input: WorkspaceInput): Promise<any> {
+export async function workspace(notion: Client, input: WorkspaceInput): Promise<WorkspaceResult> {
   return withErrorHandling(async () => {
     switch (input.action) {
       case 'info': {
         const botUser = await notion.users.retrieve({ user_id: 'me' })
 
         return {
-          action: 'info',
+          action: 'info' as const,
           bot: {
             id: (botUser as any).id,
             name: (botUser as any).name || 'Bot',
@@ -100,7 +128,7 @@ export async function workspace(notion: Client, input: WorkspaceInput): Promise<
         }
 
         return {
-          action: 'search',
+          action: 'search' as const,
           query: input.query,
           total: results.length,
           results: formattedResults

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -350,7 +350,7 @@ describe('registerTools', () => {
 
     it('should route workspace tool correctly', async () => {
       const handler = server.getHandler(3)
-      const mockResult = { action: 'search', results: [] }
+      const mockResult = { action: 'search' as const, total: 0, results: [] }
       vi.mocked(workspace).mockResolvedValue(mockResult)
 
       const result = await handler({


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the implicit `Promise<any>` return type in `workspace` tool function inside `src/tools/composite/workspace.ts`. Replaced `Promise<any>` with a strongly typed `Promise<WorkspaceResult>` which is a discriminated union of `WorkspaceInfoResult` and `WorkspaceSearchResult`.
💡 **Why:** Replacing implicit `any` improves the type safety and maintainability of the codebase, ensuring the returned data structure matches exactly what callers expect from the Notion API workspace info and search results.
✅ **Verification:** Ran `bun run check` for formatting and strict typings; updated tests in `workspace.test.ts` and `registry.test.ts` to use the newly exported `WorkspaceResult` interface and verified functionality with `bun run test`. Verified the source content edits with `cat`.
✨ **Result:** Eliminated an implicit any return type, providing clear compile-time validations without altering the underlying runtime behavior.

---
*PR created automatically by Jules for task [16211478808422658747](https://jules.google.com/task/16211478808422658747) started by @n24q02m*