### PR TITLE
feat: code Health] Remove deprecated prepend_content from pages tool schema

### DIFF
--- a/src/docs/pages.md
+++ b/src/docs/pages.md
@@ -72,7 +72,6 @@ Move a page to a new parent page.
 - `title` - Page title
 - `content` - Markdown content
 - `append_content` - Markdown to append
-- `prepend_content` - [Deprecated] Not supported by Notion API. Use blocks tool to insert at specific position
 - `parent_id` - Parent page or database ID
 - `properties` - Page properties (for database pages)
 - `property_id` - Property ID (required for get_property action)

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -79,10 +79,6 @@ const TOOLS = [
         title: { type: 'string', description: 'Page title' },
         content: { type: 'string', description: 'Markdown content' },
         append_content: { type: 'string', description: 'Markdown to append' },
-        prepend_content: {
-          type: 'string',
-          description: '[Deprecated] Not supported by Notion API — use blocks tool to insert at specific position'
-        },
         parent_id: { type: 'string', description: 'Parent page or database ID' },
         properties: { type: 'object', description: 'Page properties (for database pages)' },
         property_id: { type: 'string', description: 'Property ID (for get_property action)' },


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `prepend_content` argument from the `pages` tool input schema in `src/tools/registry.ts` and removed its documentation from `src/docs/pages.md`.

💡 **Why:** This improves the maintainability and reliability of the codebase. Since `prepend_content` is no longer supported by the underlying Notion API (users should use blocks tool to insert at specific positions), its presence in the tool schema often leads to confusion and hallucinated arguments by AI.

✅ **Verification:** Verified by running `bun run check` for syntax formatting and `bun run test` which both passed successfully without regressions. Read file contents directly using `sed` to confirm deletion.

✨ **Result:** A cleaner tool schema strictly aligned with the actual Notion API capabilities, eliminating dead code and preventing misuse.

---
*PR created automatically by Jules for task [9314511977170124811](https://jules.google.com/task/9314511977170124811) started by @n24q02m*