### PR TITLE
feat: add test for main entry point

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const startHttpMock = vi.fn()
+const startStdioMock = vi.fn()
+
+vi.mock('./transports/http.js', () => ({
+  startHttp: startHttpMock
+}))
+
+vi.mock('./transports/stdio.js', () => ({
+  startStdio: startStdioMock
+}))
+
+describe('main.ts entry point', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('should default to stdio mode if TRANSPORT_MODE is not set', async () => {
+    delete process.env.TRANSPORT_MODE
+    const main = await import('./main.js')
+
+    expect(main.mode).toBe('stdio')
+    expect(startStdioMock).toHaveBeenCalled()
+    expect(startHttpMock).not.toHaveBeenCalled()
+  })
+
+  it('should use http mode if TRANSPORT_MODE is http', async () => {
+    process.env.TRANSPORT_MODE = 'http'
+    const main = await import('./main.js')
+
+    expect(main.mode).toBe('http')
+    expect(startHttpMock).toHaveBeenCalled()
+    expect(startStdioMock).not.toHaveBeenCalled()
+  })
+
+  it('should use stdio mode if TRANSPORT_MODE is something else', async () => {
+    process.env.TRANSPORT_MODE = 'invalid'
+    const main = await import('./main.js')
+
+    expect(main.mode).toBe('invalid')
+    expect(startStdioMock).toHaveBeenCalled()
+    expect(startHttpMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
🎯 **What:** The `main.ts` entry point lacked tests. This adds a test file to verify the `TRANSPORT_MODE` logic and proper module loading.
📊 **Coverage:** The test covers the scenario where `TRANSPORT_MODE` is not set (defaults to stdio), set to 'http' (loads http transport), and set to other invalid strings (defaults to stdio).
✨ **Result:** Increased test coverage and confidence in the entry point logic without unintended side effects.

---
*PR created automatically by Jules for task [8264474926328398835](https://jules.google.com/task/8264474926328398835) started by @n24q02m*