### PR TITLE
fix: code Health: Remove any from withErrorHandling generic parameters

### DIFF
--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -237,10 +237,10 @@ export function suggestFixes(error: NotionMCPError): string[] {
 /**
  * Wrap async function with error handling
  */
-export function withErrorHandling<T extends (...args: any[]) => Promise<any>>(
-  fn: T
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+export function withErrorHandling<Args extends unknown[], Return>(
+  fn: (...args: Args) => Promise<Return>
+): (...args: Args) => Promise<Return> {
+  return async (...args: Args): Promise<Return> => {
     try {
       return await fn(...args)
     } catch (error) {


### PR DESCRIPTION
🎯 **What**: Replaced explicit `any` types in generic parameters and return types of `withErrorHandling` with typed inferences `<Args extends unknown[], Return>`.
💡 **Why**: Improves type safety across callers without utilizing generic `Parameters` and `ReturnType` wrappers around `any`. Fixes anomalous `Promise<ReturnType<T>>` (which was `Promise<Promise<Return>>`).
✅ **Verification**: Verified via `bun run test src/tools/helpers/errors.test.ts` and `bun run type-check` that typings validate seamlessly and runtime errors are processed normally.
✨ **Result**: Cleaner signatures and better IDE auto-completion for heavily-used error handler.

---
*PR created automatically by Jules for task [12974419840296406736](https://jules.google.com/task/12974419840296406736) started by @n24q02m*