### PR TITLE
fix: update PRIVACY.md and remove .jules artifact

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-# Performance Learnings
-
-- Awaiting `Promise.all` inside loop on child nodes increases API latency considerably, instead we can concurrently execute and then wait for them in order to improve recursive child nodes fetching time.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -24,7 +24,7 @@ When running locally via npm or Docker:
 ## Third-Party Services
 
 - **Notion API** (`api.notion.com`): Your data is subject to [Notion's Privacy Policy](https://www.notion.so/Privacy-Policy-3468d120cf614d4c9014c09f6aab3571).
-- **Google Cloud Run**: The remote server runs on Google Cloud. See [Google Cloud Privacy](https://cloud.google.com/terms/cloud-privacy-notice).
+- **Oracle Cloud Infrastructure**: The remote server runs on OCI. See [Oracle Cloud Privacy](https://www.oracle.com/legal/privacy/services-privacy-policy.html).
 - **Cloudflare**: DNS proxy for DDoS protection. See [Cloudflare Privacy](https://www.cloudflare.com/privacypolicy/).
 
 ## Contact


### PR DESCRIPTION
## Summary
- Replace outdated Google Cloud Run reference with OCI (server migrated months ago)
- Remove `.jules/bolt.md` accidentally merged from bot PR

## Test plan
- [x] No code changes, docs only