### PR TITLE
fix: testing improvement] Add error handling tests for processBatches

### DIFF
--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -177,6 +177,26 @@ describe('fetchChildrenRecursive', () => {
 })
 
 describe('processBatches', () => {
+  it('should stop processing and throw if an item process rejects', async () => {
+    const items = [1, 2, 3, 4, 5]
+    const error = new Error('Test error')
+    let processedCount = 0
+
+    const processFn = vi.fn(async (x: number) => {
+      processedCount++
+      if (x === 3) {
+        throw error
+      }
+      return x * 2
+    })
+
+    await expect(processBatches(items, processFn, { batchSize: 1, concurrency: 1 })).rejects.toThrow(error)
+
+    // Wait a bit to ensure no further items are processed after the throw
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(processedCount).toBe(3) // Only 1, 2, 3 should be processed
+  })
+
   it('should process all items and return results', async () => {
     const items = [1, 2, 3, 4, 5]
     const processFn = vi.fn((x: number) => Promise.resolve(x * 2))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the error handling branch inside `processBatches` utility. Specifically, we added a test to ensure that when `processFn` rejects, `processBatches` properly throws and stops processing further items.
📊 **Coverage:** The scenario where a single item process throws an error and causes the rolling window queue to short-circuit, updating the `hasError` state correctly and throwing.
✨ **Result:** The `hasError = true` branch is now covered, ensuring correct error propagation and improving the reliability of pagination utilities.

---
*PR created automatically by Jules for task [8824030593367995623](https://jules.google.com/task/8824030593367995623) started by @n24q02m*