### PR TITLE
🧪 [TEST] Missing error path test in pagination.ts

### DIFF
--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -226,4 +226,19 @@ describe('processBatches', () => {
     expect(results).toEqual([])
     expect(processFn).not.toHaveBeenCalled()
   })
+
+  it('should handle errors in processFn and stop further processing', async () => {
+    const items = [1, 2, 3, 4, 5]
+    const error = new Error('Process failed')
+    const processFn = vi.fn(async (x: number) => {
+      if (x === 2) throw error
+      return x * 2
+    })
+
+    await expect(processBatches(items, processFn, { batchSize: 1, concurrency: 1 })).rejects.toThrow('Process failed')
+
+    expect(processFn).toHaveBeenCalledWith(1)
+    expect(processFn).toHaveBeenCalledWith(2)
+    expect(processFn).not.toHaveBeenCalledWith(3)
+  })
 })


### PR DESCRIPTION
### 🎯 What
Added error path test for processBatches in pagination.ts.

### 📊 Coverage
Increased coverage for pagination.ts by testing the catch block in processBatches.

### ✨ Result
Ensured processBatches correctly handles errors and stops processing further items when one worker fails.

---
*PR created automatically by Jules for task [10109998426593283987](https://jules.google.com/task/10109998426593283987) started by @n24q02m*