### PR TITLE
fix: 🛡️ Sentinel: High - URL Sanitization Bypass in isSafeUrl

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -42,6 +42,12 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('javascript%3aalert(1)')).toBe(false)
       expect(isSafeUrl('javascript%3Aalert(1)')).toBe(false)
     })
+
+    it('should reject URLs with dangerous characters like CRLF or null bytes anywhere', () => {
+      expect(isSafeUrl('http://example.com\r\n/unsafe')).toBe(false)
+      expect(isSafeUrl('https://example.com/path\0withnull')).toBe(false)
+      expect(isSafeUrl('mailto:user@\texample.com')).toBe(false)
+    })
   })
 
   it('should allow valid relative or absolute URLs that fail parsing but are not dangerous', () => {

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -17,17 +17,21 @@ const SAFETY_WARNING =
  * Prevents XSS attacks via javascript:, data:, vbscript:, etc.
  */
 export function isSafeUrl(url: string): boolean {
+  // Reject URLs containing whitespace or control characters which could bypass checks
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security sanitization
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  const lowerUrl = url.toLowerCase()
+
   try {
-    const parsed = new URL(url)
+    const parsed = new URL(lowerUrl)
     return ['http:', 'https:', 'mailto:', 'tel:'].includes(parsed.protocol)
   } catch {
     // If URL parsing fails, it might be a relative path or an invalid URL
     // For relative paths like "/foo" or "foo", they are generally safe,
     // but we can reject strictly for now, or check for dangerous prefixes.
-
-    // Normalize URL by removing whitespace and control characters which could bypass checks
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security sanitization
-    const lowerUrl = url.toLowerCase().replace(/[\s\x00-\x1F\x7F]+/g, '')
 
     try {
       new URL(lowerUrl, 'http://relative-check.internal')


### PR DESCRIPTION
🎯 **What:** Modified `isSafeUrl` to reject URLs containing whitespace or control characters instead of stripping them.
⚠️ **Risk:** Stripping control characters allowed attackers to bypass protocol checks by injecting these characters into dangerous protocols (e.g., `java\0script:`).
🛡️ **Solution:** Implemented early rejection of any URL containing whitespace (`\s`) or control characters (`\x00-\x1F\x7F`) before any normalization or validation occurs. Added comprehensive test cases for various injection patterns.

---
*PR created automatically by Jules for task [10263300213470358119](https://jules.google.com/task/10263300213470358119) started by @n24q02m*