### PR TITLE
[CLEANUP] Unused export: suggestFixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,6 @@ import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 - Custom `NotionMCPError` class: `message`, `code`, `suggestion`, `details`
 - `withErrorHandling()` HOF wrapper for all composite tool functions
 - `retryWithBackoff()` for transient failures
-- `suggestFixes()` for AI-readable error recovery hints
 - Error details sanitized to prevent secret leakage
 
 ### Biome Lint Rules

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import {
-  aiReadableMessage,
-  enhanceError,
-  NotionMCPError,
-  retryWithBackoff,
-  suggestFixes,
-  withErrorHandling
-} from './errors'
+import { aiReadableMessage, enhanceError, NotionMCPError, retryWithBackoff, withErrorHandling } from './errors'
 
 describe('NotionMCPError', () => {
   it('should set all properties from constructor', () => {
@@ -275,52 +268,6 @@ describe('aiReadableMessage', () => {
     expect(msg).toContain('Error: Bad input')
     expect(msg).toContain('Suggestion: Fix it')
     expect(msg).toContain('Details:')
-  })
-})
-
-describe('suggestFixes', () => {
-  it('should return UNAUTHORIZED suggestions', () => {
-    const fixes = suggestFixes(new NotionMCPError('', 'UNAUTHORIZED'))
-
-    expect(fixes).toHaveLength(3)
-    expect(fixes[0]).toContain('NOTION_TOKEN')
-    expect(fixes[1]).toContain('notion.so/my-integrations')
-  })
-
-  it('should return RESTRICTED_RESOURCE suggestions', () => {
-    const fixes = suggestFixes(new NotionMCPError('', 'RESTRICTED_RESOURCE'))
-
-    expect(fixes).toHaveLength(3)
-    expect(fixes.some((f) => f.includes('Add connections'))).toBe(true)
-  })
-
-  it('should return NOT_FOUND suggestions', () => {
-    const fixes = suggestFixes(new NotionMCPError('', 'NOT_FOUND'))
-
-    expect(fixes).toHaveLength(3)
-    expect(fixes[0]).toContain('ID')
-  })
-
-  it('should return VALIDATION_ERROR suggestions', () => {
-    const fixes = suggestFixes(new NotionMCPError('', 'VALIDATION_ERROR'))
-
-    expect(fixes).toHaveLength(3)
-    expect(fixes.some((f) => f.includes('parameter'))).toBe(true)
-  })
-
-  it('should return RATE_LIMITED suggestions', () => {
-    const fixes = suggestFixes(new NotionMCPError('', 'RATE_LIMITED'))
-
-    expect(fixes).toHaveLength(3)
-    expect(fixes.some((f) => f.includes('backoff'))).toBe(true)
-  })
-
-  it('should return default suggestions for unknown codes', () => {
-    const fixes = suggestFixes(new NotionMCPError('', 'SOMETHING_ELSE'))
-
-    expect(fixes).toHaveLength(3)
-    expect(fixes[0]).toContain('status.notion.so')
-    expect(fixes.some((f) => f.includes('Try again'))).toBe(true)
   })
 })
 

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -244,52 +244,6 @@ export function aiReadableMessage(error: NotionMCPError): string {
 }
 
 /**
- * Suggest fixes based on error
- */
-export function suggestFixes(error: NotionMCPError): string[] {
-  const suggestions: string[] = []
-
-  switch (error.code) {
-    case 'UNAUTHORIZED':
-      suggestions.push('Check that NOTION_TOKEN is set in your environment')
-      suggestions.push('Verify token at https://www.notion.so/my-integrations')
-      suggestions.push('Create a new integration token if needed')
-      break
-
-    case 'RESTRICTED_RESOURCE':
-      suggestions.push('Open the page/database in Notion')
-      suggestions.push('Click "..." menu → Add connections → Select your integration')
-      suggestions.push('Grant access to parent pages if needed')
-      break
-
-    case 'NOT_FOUND':
-      suggestions.push('Verify the page/database ID is correct')
-      suggestions.push('Check that the resource was not deleted')
-      suggestions.push('Ensure you have access permissions')
-      break
-
-    case 'VALIDATION_ERROR':
-      suggestions.push('Check parameter types and formats')
-      suggestions.push('Review required vs optional parameters')
-      suggestions.push('Verify property names match database schema')
-      break
-
-    case 'RATE_LIMITED':
-      suggestions.push('Reduce request frequency')
-      suggestions.push('Implement exponential backoff retry logic')
-      suggestions.push('Batch multiple operations together')
-      break
-
-    default:
-      suggestions.push('Check Notion API status at https://status.notion.so')
-      suggestions.push('Review request parameters')
-      suggestions.push('Try again in a few moments')
-  }
-
-  return suggestions
-}
-
-/**
  * Wrap async function with error handling
  */
 export function withErrorHandling<Args extends unknown[], Return>(


### PR DESCRIPTION
This PR removes the unused 'suggestFixes' export from 'src/tools/helpers/errors.ts', its corresponding tests, and documentation in 'AGENTS.md'. The functionality was redundant as 'handleNotionError' already provides suggestions through the 'NotionMCPError' constructor.

🎯 What: Removed dead code and associated tests/docs.
💡 Why: Improve code quality and reduce maintenance overhead.
✅ Verification: Ran 'bun run check:fix' and 'bun run test'. All tests passed.
✨ Result: Cleaner codebase without unused exports.

---
*PR created automatically by Jules for task [3607981635223641127](https://jules.google.com/task/3607981635223641127) started by @n24q02m*