### PR TITLE
[TEST] Missing error path test in security.ts

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -42,6 +42,10 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('javascript%3aalert(1)')).toBe(false)
       expect(isSafeUrl('javascript%3Aalert(1)')).toBe(false)
     })
+
+    it('should return false if URL parsing fails completely', () => {
+      expect(isSafeUrl('http://[')).toBe(false)
+    })
   })
 
   it('should allow valid relative or absolute URLs that fail parsing but are not dangerous', () => {


### PR DESCRIPTION
Added a test case to cover the error path in isSafeUrl when URL parsing fails even with a base URL, ensuring 100% coverage for the function.

🎯 What: Added `expect(isSafeUrl('http://[')).toBe(false)` to `src/tools/helpers/security.test.ts`.
📊 Coverage: Exercises the inner `catch` block in `isSafeUrl`.
✨ Result: 100% code coverage for the `isSafeUrl` function.

---
*PR created automatically by Jules for task [5548813804625070099](https://jules.google.com/task/5548813804625070099) started by @n24q02m*