### PR TITLE
[CLEANUP] Unused export: CreateDatabaseResponse

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   type CreateDatabasePageResponse,
-  type CreateDatabaseResponse,
   type CreateDataSourceResponse,
+  type DatabasesResponse,
   type DeleteDatabasePageResponse,
   databases,
   type GetDatabaseResponse,
@@ -83,7 +83,7 @@ describe('databases', () => {
         parent_id: 'page-1',
         title: 'My DB',
         properties: { Name: { title: {} } }
-      })) as CreateDatabaseResponse
+      })) as Extract<DatabasesResponse, { action: 'create' }>
 
       expect(result).toEqual({
         action: 'create',

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -60,7 +60,7 @@ export interface DatabasesInput {
   }>
 }
 
-export interface CreateDatabaseResponse {
+interface CreateDatabaseResponse {
   action: 'create'
   database_id: string
   data_source_id?: string


### PR DESCRIPTION
This PR removes the unused `CreateDatabaseResponse` export from `src/tools/composite/databases.ts` and updates the corresponding test file to use the `DatabasesResponse` union type with `Extract` instead. This improves encapsulation and code quality by making internal response types private while maintaining type safety in tests.

🎯 What:
- Removed `export` from `CreateDatabaseResponse` in `src/tools/composite/databases.ts`.
- Removed `CreateDatabaseResponse` from imports in `src/tools/composite/databases.test.ts`.
- Updated type cast in tests to use `Extract<DatabasesResponse, { action: 'create' }>`.

💡 Why:
- Unused exports clutter the public API of a module.
- Making it private ensures better encapsulation.

✅ Verification:
- Ran `bun run check:fix` (Biome + Type Check).
- Ran `bun run test src/tools/composite/databases.test.ts` (All 49 tests passed).

✨ Result:
- Improved code quality and encapsulation.

---
*PR created automatically by Jules for task [17208361705007523251](https://jules.google.com/task/17208361705007523251) started by @n24q02m*