### PR TITLE
fix: 🧹 [CLEANUP] Unused export: CreateDatabasePageResponse

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  type CreateDatabasePageResponse,
   type CreateDatabaseResponse,
   type CreateDataSourceResponse,
+  type DatabasesResponse,
   type DeleteDatabasePageResponse,
   databases,
   type GetDatabaseResponse,
@@ -413,7 +413,7 @@ describe('databases', () => {
         action: 'create_page',
         database_id: 'db-1',
         page_properties: { Name: 'New Item', Status: 'Active' }
-      })) as CreateDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'create_page' }>
 
       expect(result.action).toBe('create_page')
       expect(result.database_id).toBe('db-1')
@@ -441,7 +441,7 @@ describe('databases', () => {
         action: 'create_page',
         database_id: 'db-1',
         pages: [{ properties: { Name: 'Item 1' } }, { properties: { Name: 'Item 2' } }]
-      })) as CreateDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'create_page' }>
 
       expect(result.processed).toBe(2)
       expect(result.results).toHaveLength(2)

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -92,7 +92,7 @@ export interface QueryDatabaseResponse {
   results: Record<string, any>[]
 }
 
-export interface CreateDatabasePageResponse {
+interface CreateDatabasePageResponse {
   action: 'create_page'
   database_id: string
   data_source_id: string


### PR DESCRIPTION
🎯 What: Removed the unused export of 'CreateDatabasePageResponse' and updated tests to use 'Extract' on the union type.

💡 Why: Unused exports should be made private to keep the API clean and reduce the surface area.

✅ Verification: Ran 'bun run check' and verified 'databases.test.ts' still passes.

✨ Result: Cleaner code with one less unnecessary export.

---
*PR created automatically by Jules for task [17566106249971021324](https://jules.google.com/task/17566106249971021324) started by @n24q02m*