### PR TITLE
[SECURITY] Unsafe JSON Parsing in content.ts

### DIFF
--- a/src/tools/composite/content.ts
+++ b/src/tools/composite/content.ts
@@ -54,6 +54,32 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
             'Provide an array content'
           )
         }
+
+        // Validate each block in the array
+        for (const block of content) {
+          if (!block || typeof block !== 'object') {
+            throw new NotionMCPError(
+              'Each block in the content array must be a valid object',
+              'VALIDATION_ERROR',
+              'Provide a valid array of block objects'
+            )
+          }
+          if (!('type' in block)) {
+            throw new NotionMCPError(
+              'Each block in the content array must have a "type" property',
+              'VALIDATION_ERROR',
+              'Provide a valid array of block objects with "type" properties'
+            )
+          }
+          if (typeof block.type !== 'string') {
+            throw new NotionMCPError(
+              'Each block in the content array must have a "type" string property',
+              'VALIDATION_ERROR',
+              'Provide a valid array of block objects with string "type" properties'
+            )
+          }
+        }
+
         const markdown = blocksToMarkdown(content as any)
         return {
           direction: input.direction,


### PR DESCRIPTION
### 🎯 **What:**
Improved validation of Notion blocks when converting from blocks to markdown. The tool now explicitly validates that each element in the content array (after optional JSON parsing) is a valid object with a string 'type' property.

### ⚠️ **Risk:**
Before this fix, the code only checked if the content was an array but did not validate its elements. This could lead to runtime errors or unexpected behavior in the `blocksToMarkdown` helper when processing malformed or malicious block data.

### 🛡️ **Solution:**
Added a validation loop in `src/tools/composite/content.ts` that iterates through the content array and throws a `NotionMCPError` (VALIDATION_ERROR) if any element is not a valid object or lacks a proper 'type' string property. This ensures data integrity before passing it to the conversion logic.

---
*PR created automatically by Jules for task [1877931416812943945](https://jules.google.com/task/1877931416812943945) started by @n24q02m*