### PR TITLE
🧹 [CLEANUP] Unused export: GetDatabaseResponse

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -3,9 +3,9 @@ import {
   type CreateDatabasePageResponse,
   type CreateDatabaseResponse,
   type CreateDataSourceResponse,
+  type DatabasesResponse,
   type DeleteDatabasePageResponse,
   databases,
-  type GetDatabaseResponse,
   type ListDataSourceTemplatesResponse,
   type QueryDatabaseResponse,
   type UpdateDatabasePageResponse,
@@ -137,7 +137,10 @@ describe('databases', () => {
       mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse())
       mockNotion.dataSources.retrieve.mockResolvedValueOnce(makeDataSourceResponse())
 
-      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'get' }
+      >
 
       expect(result).toEqual({
         action: 'get',
@@ -175,7 +178,10 @@ describe('databases', () => {
         })
       )
 
-      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'get' }
+      >
 
       expect(result.schema.Tags.options).toEqual(['A', 'B'])
       expect(result.schema.Total.expression).toBe('prop("Price") * prop("Qty")')
@@ -184,7 +190,10 @@ describe('databases', () => {
     it('should handle empty data_sources array', async () => {
       mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse({ data_sources: [] }))
 
-      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'get' }
+      >
 
       expect(result.data_source).toBeNull()
       expect(result.schema).toEqual({})

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -68,7 +68,7 @@ export interface CreateDatabaseResponse {
   created: boolean
 }
 
-export interface GetDatabaseResponse {
+interface GetDatabaseResponse {
   action: 'get'
   database_id: string
   title: string


### PR DESCRIPTION
🎯 **What:**
Removed the `export` keyword from the `GetDatabaseResponse` interface in `src/tools/composite/databases.ts`.

💡 **Why:**
The `GetDatabaseResponse` interface was exported but not used outside its defining module (except in tests). Making it private improves code encapsulation and aligns with the project's pattern of keeping internal response interfaces private.

✅ **Verification:**
- Updated `src/tools/composite/databases.test.ts` to remove the import of `GetDatabaseResponse`.
- Replaced usages in tests with `Extract<DatabasesResponse, { action: 'get' }>` to maintain type safety.
- Ran `bun run check:fix` to ensure no linting or TypeScript errors (specifically imported `DatabasesResponse` in the test file to support the `Extract` utility).
- Ran `bun run test src/tools/composite/databases.test.ts` and confirmed all 49 tests passed.

✨ **Result:**
Improved code quality by removing an unnecessary public export while preserving full test coverage and type safety.

---
*PR created automatically by Jules for task [540565518537030670](https://jules.google.com/task/540565518537030670) started by @n24q02m*