### PR TITLE
🛡️ Sentinel: [Low] Insufficient Base64 Validation in isValidBase64

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -103,4 +103,18 @@ describe('isValidBase64', () => {
   it('should reject string with spaces', () => {
     expect(isValidBase64('aG Vs')).toBe(false)
   })
+
+  it('should reject non-canonical base64', () => {
+    // 'aB==' has bits set in the padding area that shouldn't be there
+    expect(isValidBase64('aB==')).toBe(false)
+  })
+
+  it('should reject incorrect padding placement', () => {
+    expect(isValidBase64('a=bc')).toBe(false)
+    expect(isValidBase64('==AA')).toBe(false)
+  })
+
+  it('should reject too many padding characters', () => {
+    expect(isValidBase64('a===')).toBe(false)
+  })
 })

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -35,10 +35,23 @@ export function formatId(id: string): string {
 /**
  * Check if a string is valid base64 encoding
  * Used to validate file_content before Buffer.from
+ * Implements strict validation by checking character set, length, and canonicality
  */
 export function isValidBase64(str: string): boolean {
-  if (str.length === 0) return false
-  // Must be length divisible by 4 and only contain base64 chars
-  if (str.length % 4 !== 0) return false
-  return /^[A-Za-z0-9+/]*={0,2}$/.test(str)
+  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0) {
+    return false
+  }
+
+  // Basic regex check for character set and padding structure
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(str)) {
+    return false
+  }
+
+  // Strict check: Buffer roundtrip to ensure canonicality
+  try {
+    const buffer = Buffer.from(str, 'base64')
+    return buffer.toString('base64') === str
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## 🛡️ Sentinel Security Fix

### 🎯 **What:**
Improved base64 validation in the `isValidBase64` helper function in `src/tools/helpers/id.ts`.

### ⚠️ **Risk:**
Low. The changes tighten validation to ensure canonical base64 encoding, correct length (multiple of 4), and proper padding placement. This might reject non-canonical inputs that were previously accepted by the regex but could cause issues in downstream processing.

### 🛡️ **Solution:**
The new implementation:
1.  Checks if the input is a string and its length is a multiple of 4.
2.  Uses a regex to verify the character set (A-Za-z0-9+/) and padding structure (up to two = at the end).
3.  Performs a Buffer roundtrip check to ensure canonicality. This ensures that no unused bits are set in the padding area, which is a common source of base64 validation bypasses and inconsistencies.

### ✅ **Verification:**
- Added new test cases in `src/tools/helpers/id.test.ts` covering:
    - Non-canonical base64 (e.g., `aB==`)
    - Incorrect padding placement (e.g., `a=bc`, `==AA`)
    - Too many padding characters (e.g., `a===`)
- All 27 tests in `src/tools/helpers/id.test.ts` pass.
- Verified the logic with a standalone research script.

---
*PR created automatically by Jules for task [8787924994875496410](https://jules.google.com/task/8787924994875496410) started by @n24q02m*