### PR TITLE
[CLEANUP] Remove unused internal response exports in databases tool

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -1,17 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  type CreateDatabasePageResponse,
-  type CreateDatabaseResponse,
-  type CreateDataSourceResponse,
-  type DeleteDatabasePageResponse,
-  databases,
-  type GetDatabaseResponse,
-  type ListDataSourceTemplatesResponse,
-  type QueryDatabaseResponse,
-  type UpdateDatabasePageResponse,
-  type UpdateDatabaseResponse,
-  type UpdateDataSourceResponse
-} from './databases.js'
+import { type DatabasesResponse, databases } from './databases.js'
 
 const mockNotion = {
   databases: {
@@ -83,7 +71,7 @@ describe('databases', () => {
         parent_id: 'page-1',
         title: 'My DB',
         properties: { Name: { title: {} } }
-      })) as CreateDatabaseResponse
+      })) as Extract<DatabasesResponse, { action: 'create' }>
 
       expect(result).toEqual({
         action: 'create',
@@ -137,7 +125,10 @@ describe('databases', () => {
       mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse())
       mockNotion.dataSources.retrieve.mockResolvedValueOnce(makeDataSourceResponse())
 
-      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'get' }
+      >
 
       expect(result).toEqual({
         action: 'get',
@@ -175,7 +166,10 @@ describe('databases', () => {
         })
       )
 
-      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'get' }
+      >
 
       expect(result.schema.Tags.options).toEqual(['A', 'B'])
       expect(result.schema.Total.expression).toBe('prop("Price") * prop("Qty")')
@@ -184,7 +178,10 @@ describe('databases', () => {
     it('should handle empty data_sources array', async () => {
       mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse({ data_sources: [] }))
 
-      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as GetDatabaseResponse
+      const result = (await databases(notion, { action: 'get', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'get' }
+      >
 
       expect(result.data_source).toBeNull()
       expect(result.schema).toEqual({})
@@ -214,7 +211,10 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = (await databases(notion, { action: 'query', database_id: 'db-1' })) as QueryDatabaseResponse
+      const result = (await databases(notion, { action: 'query', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'query' }
+      >
 
       expect(result.action).toBe('query')
       expect(result.database_id).toBe('db-1')
@@ -307,7 +307,7 @@ describe('databases', () => {
         action: 'query',
         database_id: 'db-1',
         limit: 2
-      })) as QueryDatabaseResponse
+      })) as Extract<DatabasesResponse, { action: 'query' }>
 
       expect(result.total).toBe(2)
       expect(result.results).toHaveLength(2)
@@ -337,7 +337,10 @@ describe('databases', () => {
         has_more: false
       })
 
-      const result = (await databases(notion, { action: 'query', database_id: 'db-1' })) as QueryDatabaseResponse
+      const result = (await databases(notion, { action: 'query', database_id: 'db-1' })) as Extract<
+        DatabasesResponse,
+        { action: 'query' }
+      >
       const page = result.results[0]
 
       expect(page.Name).toBe('Test')
@@ -378,7 +381,7 @@ describe('databases', () => {
       const result = (await databases(notion, {
         action: 'query',
         database_id: 'ds-fallback'
-      })) as QueryDatabaseResponse
+      })) as Extract<DatabasesResponse, { action: 'query' }>
 
       expect(result.database_id).toBe('db-parent')
     })
@@ -413,7 +416,7 @@ describe('databases', () => {
         action: 'create_page',
         database_id: 'db-1',
         page_properties: { Name: 'New Item', Status: 'Active' }
-      })) as CreateDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'create_page' }>
 
       expect(result.action).toBe('create_page')
       expect(result.database_id).toBe('db-1')
@@ -441,7 +444,7 @@ describe('databases', () => {
         action: 'create_page',
         database_id: 'db-1',
         pages: [{ properties: { Name: 'Item 1' } }, { properties: { Name: 'Item 2' } }]
-      })) as CreateDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'create_page' }>
 
       expect(result.processed).toBe(2)
       expect(result.results).toHaveLength(2)
@@ -544,7 +547,7 @@ describe('databases', () => {
         action: 'update_page',
         page_id: 'page-1',
         page_properties: { Status: 'Done' }
-      })) as UpdateDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'update_page' }>
 
       expect(result.action).toBe('update_page')
       expect(result.processed).toBe(1)
@@ -561,7 +564,7 @@ describe('databases', () => {
           { page_id: 'page-1', properties: { Status: 'Done' } },
           { page_id: 'page-2', properties: { Status: 'Active' } }
         ]
-      })) as UpdateDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'update_page' }>
 
       expect(result.processed).toBe(2)
       expect(result.results).toEqual([
@@ -596,7 +599,7 @@ describe('databases', () => {
       const result = (await databases(notion, {
         action: 'delete_page',
         page_ids: ['page-1', 'page-2']
-      })) as DeleteDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'delete_page' }>
 
       expect(result.action).toBe('delete_page')
       expect(result.processed).toBe(2)
@@ -616,7 +619,7 @@ describe('databases', () => {
       const result = (await databases(notion, {
         action: 'delete_page',
         page_id: 'page-solo'
-      })) as DeleteDatabasePageResponse
+      })) as Extract<DatabasesResponse, { action: 'delete_page' }>
 
       expect(result.processed).toBe(1)
       expect(result.results[0]).toEqual({ page_id: 'page-solo', deleted: true })
@@ -640,7 +643,7 @@ describe('databases', () => {
         database_id: 'db-1',
         title: 'New Source',
         properties: { Name: { title: {} } }
-      })) as CreateDataSourceResponse
+      })) as Extract<DatabasesResponse, { action: 'create_data_source' }>
 
       expect(result).toEqual({
         action: 'create_data_source',
@@ -692,7 +695,7 @@ describe('databases', () => {
         action: 'update_data_source',
         data_source_id: 'ds-1',
         title: 'Renamed'
-      })) as UpdateDataSourceResponse
+      })) as Extract<DatabasesResponse, { action: 'update_data_source' }>
 
       expect(result).toEqual({
         action: 'update_data_source',
@@ -741,7 +744,7 @@ describe('databases', () => {
         action: 'update_database',
         database_id: 'db-1',
         title: 'New Title'
-      })) as UpdateDatabaseResponse
+      })) as Extract<DatabasesResponse, { action: 'update_database' }>
 
       expect(result).toEqual({
         action: 'update_database',
@@ -826,7 +829,7 @@ describe('databases', () => {
       const result = (await databases(notion, {
         action: 'list_templates',
         database_id: 'db-1'
-      })) as ListDataSourceTemplatesResponse
+      })) as Extract<DatabasesResponse, { action: 'list_templates' }>
 
       expect(result.action).toBe('list_templates')
       expect(result.database_id).toBe('db-1')
@@ -848,7 +851,7 @@ describe('databases', () => {
         action: 'list_templates',
         database_id: 'db-1',
         data_source_id: 'ds-custom'
-      })) as ListDataSourceTemplatesResponse
+      })) as Extract<DatabasesResponse, { action: 'list_templates' }>
 
       expect(result.data_source_id).toBe('ds-custom')
       expect(mockNotion.dataSources.listTemplates).toHaveBeenCalledWith(

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -60,7 +60,7 @@ export interface DatabasesInput {
   }>
 }
 
-export interface CreateDatabaseResponse {
+interface CreateDatabaseResponse {
   action: 'create'
   database_id: string
   data_source_id?: string
@@ -68,7 +68,7 @@ export interface CreateDatabaseResponse {
   created: boolean
 }
 
-export interface GetDatabaseResponse {
+interface GetDatabaseResponse {
   action: 'get'
   database_id: string
   title: string
@@ -84,7 +84,7 @@ export interface GetDatabaseResponse {
   schema: Record<string, any>
 }
 
-export interface QueryDatabaseResponse {
+interface QueryDatabaseResponse {
   action: 'query'
   database_id: string
   data_source_id: string
@@ -92,7 +92,7 @@ export interface QueryDatabaseResponse {
   results: Record<string, any>[]
 }
 
-export interface CreateDatabasePageResponse {
+interface CreateDatabasePageResponse {
   action: 'create_page'
   database_id: string
   data_source_id: string
@@ -104,7 +104,7 @@ export interface CreateDatabasePageResponse {
   }[]
 }
 
-export interface UpdateDatabasePageResponse {
+interface UpdateDatabasePageResponse {
   action: 'update_page'
   processed: number
   results: {
@@ -113,7 +113,7 @@ export interface UpdateDatabasePageResponse {
   }[]
 }
 
-export interface DeleteDatabasePageResponse {
+interface DeleteDatabasePageResponse {
   action: 'delete_page'
   processed: number
   results: {
@@ -122,26 +122,26 @@ export interface DeleteDatabasePageResponse {
   }[]
 }
 
-export interface CreateDataSourceResponse {
+interface CreateDataSourceResponse {
   action: 'create_data_source'
   data_source_id: string
   database_id: string
   created: boolean
 }
 
-export interface UpdateDataSourceResponse {
+interface UpdateDataSourceResponse {
   action: 'update_data_source'
   data_source_id: string
   updated: boolean
 }
 
-export interface UpdateDatabaseResponse {
+interface UpdateDatabaseResponse {
   action: 'update_database'
   database_id: string
   updated: boolean
 }
 
-export interface ListDataSourceTemplatesResponse {
+interface ListDataSourceTemplatesResponse {
   action: 'list_templates'
   database_id: string
   data_source_id: string


### PR DESCRIPTION
This PR addresses the issue of unused exports in the databases tool by removing the `export` keyword from internal response interfaces in `src/tools/composite/databases.ts`.

In accordance with the project's architectural guidelines:
- Internal response interfaces that are only used within union types are now private.
- The corresponding test file `src/tools/composite/databases.test.ts` has been updated to use `Extract<DatabasesResponse, { action: '...' }>` for type-safe casting instead of importing these interfaces.

This cleanup improves the public API surface area and maintains consistency with the project's design patterns.

Verified:
- Ran `bun run check:fix` for formatting and type checks.
- Ran `bun run test` (49 tests passed).

---
*PR created automatically by Jules for task [5784952729927620846](https://jules.google.com/task/5784952729927620846) started by @n24q02m*