### PR TITLE
[SECURITY] Unsafe JSON Parsing in convertToNotionProperties

### DIFF
--- a/src/tools/composite/content.test.ts
+++ b/src/tools/composite/content.test.ts
@@ -124,6 +124,14 @@ describe('contentConvert', () => {
           content: '{"not": "an array"}'
         })
       ).rejects.toThrow('Content must be an array for blocks-to-markdown')
+
+      // Test JSON array with non-object elements
+      await expect(
+        contentConvert({
+          direction: 'blocks-to-markdown',
+          content: '[1, 2, 3]'
+        })
+      ).rejects.toThrow('Content must be an array of objects for blocks-to-markdown')
     })
   })
 

--- a/src/tools/composite/content.ts
+++ b/src/tools/composite/content.ts
@@ -54,6 +54,13 @@ export async function contentConvert(input: ContentConvertInput): Promise<any> {
             'Provide an array content'
           )
         }
+        if (!content.every((b) => typeof b === 'object' && b !== null)) {
+          throw new NotionMCPError(
+            'Content must be an array of objects for blocks-to-markdown',
+            'VALIDATION_ERROR',
+            'Provide an array of block objects'
+          )
+        }
         const markdown = blocksToMarkdown(content as any)
         return {
           direction: input.direction,

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -303,6 +303,13 @@ describe('convertToNotionProperties', () => {
       })
     })
 
+    it('falls back to single value if JSON array contains non-string elements', () => {
+      const result = convertToNotionProperties({ Projects: '["abc123", 123]' }, { Projects: 'relation' })
+      expect(result).toEqual({
+        Projects: { relation: [{ id: '["abc123", 123]' }] }
+      })
+    })
+
     it('converts empty string to empty relation array', () => {
       const result = convertToNotionProperties({ Project: '' }, { Project: 'relation' })
       expect(result).toEqual({

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -21,7 +21,7 @@ function toRelation(value: any): { relation: { id: string }[] } {
     if (value.startsWith('[')) {
       try {
         const parsed = JSON.parse(value)
-        if (Array.isArray(parsed)) {
+        if (Array.isArray(parsed) && parsed.every((v) => typeof v === 'string')) {
           return { relation: parsed.map((v: string) => ({ id: extractPageId(v) })) }
         }
       } catch {


### PR DESCRIPTION
🎯 **What:** Fixed unsafe JSON parsing in convertToNotionProperties and contentConvert.

⚠️ **Risk:** Malformed JSON inputs could cause unexpected behavior when processing relation IDs or blocks.

🛡️ **Solution:** Added validation to ensure parsed JSON arrays contain expected types (strings for relations, objects for blocks) before processing.

---
*PR created automatically by Jules for task [10250330746312402269](https://jules.google.com/task/10250330746312402269) started by @n24q02m*