### PR TITLE
[FIX] Notion API bug with comments.list

### DIFF
--- a/tests/live/full-notion.full.test.ts
+++ b/tests/live/full-notion.full.test.ts
@@ -890,7 +890,7 @@ describe.skipIf(!NOTION_TOKEN)('Stdio + NOTION_TOKEN — Real Notion API', () =>
       if (!result.isError) {
         const text = extractText(result)
         const parsed = safeParse(text)
-        expect(parsed.results).toBeDefined()
+        expect(parsed.comments).toBeDefined()
       }
     })
   })


### PR DESCRIPTION
Fixed the test assertion for the comments.list tool in the live test suite. The tool returns a 'comments' array, but the test was checking for a 'results' property. This change ensures the test is correct when running with integration tokens, even though the Notion API currently has a known bug with OAuth tokens for this endpoint.

---
*PR created automatically by Jules for task [16877571182503223994](https://jules.google.com/task/16877571182503223994) started by @n24q02m*