### PR TITLE
[SECURITY] 🛡️ Sentinel: [CRITICAL] Fix Denial of Service in file_uploads.ts via early length checking

### DIFF
--- a/src/tools/composite/file-uploads.ts
+++ b/src/tools/composite/file-uploads.ts
@@ -126,15 +126,6 @@ async function sendFileUpload(notion: Client, input: FileUploadsInput): Promise<
     )
   }
 
-  // Validate base64 format before processing
-  if (!isValidBase64(input.file_content)) {
-    throw new NotionMCPError(
-      'file_content is not valid base64 encoding',
-      'VALIDATION_ERROR',
-      'Encode the file as base64 first. Example: Buffer.from(fileBytes).toString("base64"). The string must only contain A-Z, a-z, 0-9, +, /, and = padding.'
-    )
-  }
-
   // Check file size before processing to prevent OOM
   const approximateSize = (input.file_content.length * 3) / 4
   if (approximateSize > MAX_FILE_SIZE_BYTES) {
@@ -142,6 +133,15 @@ async function sendFileUpload(notion: Client, input: FileUploadsInput): Promise<
       `File content exceeds maximum size of ${MAX_FILE_SIZE_MB}MB per request.`,
       'VALIDATION_ERROR',
       "Split the file into smaller parts and use the 'part_number' parameter for multi-part upload."
+    )
+  }
+
+  // Validate base64 format before processing
+  if (!isValidBase64(input.file_content)) {
+    throw new NotionMCPError(
+      'file_content is not valid base64 encoding',
+      'VALIDATION_ERROR',
+      'Encode the file as base64 first. Example: Buffer.from(fileBytes).toString("base64"). The string must only contain A-Z, a-z, 0-9, +, /, and = padding.'
     )
   }
 


### PR DESCRIPTION
🎯 **What:** 
In `src/tools/composite/file-uploads.ts`, the validation logic for `sendFileUpload` performed the `isValidBase64` check before verifying the `file_content` payload length against the `MAX_FILE_SIZE_BYTES` limit.

⚠️ **Risk:** 
`isValidBase64` ultimately executes `Buffer.from(str, 'base64')`. Because `Buffer.from` allocates memory proportional to the length of the string, an attacker could supply an oversized base64 payload (e.g. hundreds of MB or several GB), causing the application to exhaust available memory (Out-of-Memory / OOM) and crash prior to the bounds check ever occurring. This is a severe Denial of Service (DoS) vulnerability.

🛡️ **Solution:** 
The file size check (which operates in O(1) time simply by inspecting `input.file_content.length`) has been hoisted *before* the `isValidBase64` format verification. The Node.js buffer parsing will now only be executed for payloads known to fall within the safe `10MB` limit.

---
*PR created automatically by Jules for task [934345333866609342](https://jules.google.com/task/934345333866609342) started by @n24q02m*