### PR TITLE
[TEST] Missing error path test in security.ts (relative URLs)

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -68,6 +68,7 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('javascript:alert(1)')).toBe(false)
       expect(isSafeUrl('java&script:alert(1)')).toBe(false)
       expect(isSafeUrl('javascript%3aalert(1)')).toBe(false)
+      expect(isSafeUrl('javascript&colon;alert(1)')).toBe(false)
 
       // Characters after delimiters should be safe
       expect(isSafeUrl('/path?arg=javascript:alert(1)')).toBe(true)
@@ -75,6 +76,9 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('page.php?id=123&type=456')).toBe(true)
       expect(isSafeUrl('/relative/path:with/colon')).toBe(true)
       expect(isSafeUrl('folder/sub:folder')).toBe(true)
+      expect(isSafeUrl('./foo:bar')).toBe(true)
+      expect(isSafeUrl('../foo:bar')).toBe(true)
+      expect(isSafeUrl('foo/bar:baz')).toBe(true)
     })
 
     it('should reject malformed URLs that fail all parsing (coverage for inner catch)', () => {


### PR DESCRIPTION
Added comprehensive test cases for \`isSafeUrl\` to cover relative URL security logic.
This ensures that:
- Suspicious characters like \`:\`, \`&\`, or \`%3a\` in the relative URL prefix (before any delimiter) are rejected.
- Valid relative paths containing colons after a directory or query delimiter (e.g., \`./file:name\`, \`foo/bar:baz\`) are allowed.
- HTML entity obfuscation in relative paths (e.g., \`javascript&colon;\`) is correctly identified and rejected.

Verified 100% code coverage for \`src/tools/helpers/security.ts\`.

---
*PR created automatically by Jules for task [14630563625910707922](https://jules.google.com/task/14630563625910707922) started by @n24q02m*