### PR TITLE
🎨 Palette: Add client-side validation for integration tokens

### DIFF
--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -18,7 +18,8 @@ export const RELAY_SCHEMA: RelayConfigSchema = {
       placeholder: 'ntn_...',
       helpUrl: 'https://www.notion.so/my-integrations',
       helpText: 'Create an integration and copy the Internal Integration Secret',
-      required: true
+      required: true,
+      validation: '^(secret_|ntn_).+'
     }
   ]
 }

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -675,7 +675,7 @@ describe('startHttp', () => {
       )
 
       expect(transportInstance.sessionId).toBeDefined()
-        const _sessionId = transportInstance.sessionId
+      const _sessionId = transportInstance.sessionId
 
       // Exercise onclose for coverage
       transportInstance.onclose()

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -675,7 +675,7 @@ describe('startHttp', () => {
       )
 
       expect(transportInstance.sessionId).toBeDefined()
-      const sessionId = transportInstance.sessionId
+        const _sessionId = transportInstance.sessionId
 
       // Exercise onclose for coverage
       transportInstance.onclose()


### PR DESCRIPTION
💡 What: Added regex validation `^(secret_|ntn_).+` to the `NOTION_TOKEN` field in `RELAY_SCHEMA`.
🎯 Why: To improve UX during credential collection in the relay setup page by providing real-time client-side feedback, preventing malformed token submissions without waiting for a server round-trip.
📸 Before/After: Form submissions with invalid tokens now show a validation error instantly instead of failing on the server.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [12003986254735565196](https://jules.google.com/task/12003986254735565196) started by @n24q02m*