### PR TITLE
[CLEANUP] Unused export setState in credential-state.ts

### DIFF
--- a/fix_file.py
+++ b/fix_file.py
@@ -1,0 +1,22 @@
+import os
+
+file_path = 'src/credential-state.ts'
+with open(file_path, 'r', encoding='utf-8') as f:
+    lines = f.readlines()
+
+new_lines = []
+skip = False
+for line in lines:
+    if 'export function setState' in line:
+        skip = True
+        continue
+    if skip:
+        if '}' in line:
+            skip = False
+        continue
+    new_lines.append(line)
+
+with open(file_path, 'w', encoding='utf-8', newline='\n') as f:
+    f.writelines(new_lines)
+
+print("File cleaned.")

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -190,10 +190,6 @@ function tryOpenBrowser(url: string): void {
   }
 }
 
-export function setState(state: CredentialState): void {
-  _state = state
-}
-
 export function resetState(): void {
   _state = 'awaiting_setup'
   _setupUrl = null


### PR DESCRIPTION
Removed the unused function `setState` from `src/credential-state.ts`. This function was exported but not used anywhere in the codebase (including tests and other source files). Verified with full test suite and lint checks.

---
*PR created automatically by Jules for task [10288179947710137743](https://jules.google.com/task/10288179947710137743) started by @n24q02m*