### PR TITLE
[SECURITY] Insecure IP Trust Configuration

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -226,7 +226,7 @@ describe('startHttp', () => {
       process.env.TRUST_PROXY = 'true'
       await startHttp()
       const mockAppTrue = (express as any).mock.results.at(-1)?.value
-      expect(mockAppTrue.set).toHaveBeenCalledWith('trust proxy', true)
+      expect(mockAppTrue.set).toHaveBeenCalledWith('trust proxy', false)
 
       // Test boolean 'false'
       process.env.TRUST_PROXY = 'false'

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -550,7 +550,7 @@ describe('startHttp', () => {
       const res = mockRes()
       await handler(req, res)
 
-      // Should NOT return 403 — handleRequest should have been called
+      // Should NOT return 403 -- handleRequest should have been called
       expect(res.status).not.toHaveBeenCalledWith(403)
     })
   })
@@ -735,7 +735,7 @@ describe('startHttp', () => {
     })
   })
 
-  describe('callback route — success flow', () => {
+  describe('callback route -- success flow', () => {
     it('should exchange token and redirect with clientState', async () => {
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -909,7 +909,7 @@ describe('startHttp', () => {
       await startHttp()
 
       const app = (express as any).mock.results[0]?.value
-      // The middleware is the first app.use() call — find it
+      // The middleware is the first app.use() call -- find it
       const useCalls = app.use.mock.calls
       // The IP middleware is passed as a function to app.use()
       // It's the one that calls requestContext.run

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -27,7 +27,7 @@ interface HttpConfig {
 
 function parseTrustProxy(value?: string): boolean | number | string {
   if (!value) return false
-  if (value === 'true') return true
+  if (value === 'true') return false
   if (value === 'false') return false
   if (/^\d+$/.test(value)) return parseInt(value, 10)
   return value

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,5 +1,5 @@
 /**
- * HTTP Transport — Remote mode with OAuth 2.1
+ * HTTP Transport -- Remote mode with OAuth 2.1
  * Express server with Notion OAuth callback relay, Streamable HTTP transport, and session management
  */
 
@@ -198,14 +198,14 @@ export async function startHttp() {
   const authMiddleware = requireBearerAuth({ verifier: provider })
   const jsonParser = express.json()
   const transports: Map<string, StreamableHTTPServerTransport> = new Map()
-  // Session owner binding — prevents cross-user session hijacking
-  const sessionOwners: Map<string, string> = new Map() // sessionId → notionToken
+  // Session owner binding -- prevents cross-user session hijacking
+  const sessionOwners: Map<string, string> = new Map() // sessionId -> notionToken
 
-  // MCP endpoint — POST (new session or existing)
+  // MCP endpoint -- POST (new session or existing)
   app.post('/mcp', mcpRateLimit, jsonParser, authMiddleware, async (req, res) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined
 
-    // Existing session — verify the authenticated user owns this session
+    // Existing session -- verify the authenticated user owns this session
     if (sessionId && transports.has(sessionId)) {
       const authInfo = (req as any).auth
       const ownerToken = sessionOwners.get(sessionId)
@@ -221,7 +221,7 @@ export async function startHttp() {
       return
     }
 
-    // New session — must be initialize request
+    // New session -- must be initialize request
     if (!sessionId && isInitializeRequest(req.body)) {
       const authInfo = (req as any).auth
       const notionToken: string = authInfo.token
@@ -266,7 +266,7 @@ export async function startHttp() {
     return true
   }
 
-  // MCP endpoint — GET (SSE streaming for existing session)
+  // MCP endpoint -- GET (SSE streaming for existing session)
   app.get('/mcp', mcpRateLimit, authMiddleware, async (req, res) => {
     const sessionId = req.headers['mcp-session-id'] as string
     if (sessionId && transports.has(sessionId)) {
@@ -277,7 +277,7 @@ export async function startHttp() {
     }
   })
 
-  // MCP endpoint — DELETE (close session)
+  // MCP endpoint -- DELETE (close session)
   app.delete('/mcp', mcpRateLimit, authMiddleware, async (req, res) => {
     const sessionId = req.headers['mcp-session-id'] as string
     if (sessionId && transports.has(sessionId)) {


### PR DESCRIPTION
Fixed the insecure IP trust configuration by preventing the 'true' value in TRUST_PROXY from being applied as true in Express. This ensures that the application does not inadvertently trust all proxies, which could lead to IP spoofing and bypass rate limiting.

- Modified `parseTrustProxy` in `src/transports/http.ts` to return `false` when 'true' is passed.
- Updated `src/transports/http.test.ts` to assert that 'true' results in `false` trust.
- Verified that other valid configurations (numeric hops, IP strings) still work as expected.

---
*PR created automatically by Jules for task [2072635447027779103](https://jules.google.com/task/2072635447027779103) started by @n24q02m*