### PR TITLE
[FIX] Missing Cache

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -6,6 +6,7 @@ import {
   type DeleteDatabasePageResponse,
   databases,
   type GetDatabaseResponse,
+  idResolutionCache,
   type ListDataSourceTemplatesResponse,
   type QueryDatabaseResponse,
   schemaCache,
@@ -69,6 +70,7 @@ function makeDataSourceResponse(overrides: Record<string, any> = {}) {
 describe('databases', () => {
   beforeEach(() => {
     schemaCache.clear()
+    idResolutionCache.clear()
     vi.resetAllMocks()
   })
 
@@ -423,6 +425,7 @@ describe('databases', () => {
   describe('create_page', () => {
     beforeEach(() => {
       schemaCache.clear()
+      idResolutionCache.clear()
       mockNotion.databases.retrieve.mockResolvedValue(makeDbRetrieveResponse())
       mockNotion.dataSources.retrieve.mockResolvedValue(makeDataSourceResponse())
     })
@@ -910,6 +913,26 @@ describe('databases', () => {
       expect(result.action).toBe('list_templates')
       expect(mockNotion.databases.retrieve).toHaveBeenCalled()
       expect(mockNotion.dataSources.retrieve).toHaveBeenCalledWith({ data_source_id: 'ds123' })
+    })
+    it('should use idResolutionCache on subsequent calls', async () => {
+      mockNotion.databases.retrieve.mockResolvedValueOnce(makeDbRetrieveResponse())
+      mockNotion.dataSources.listTemplates.mockResolvedValue({ templates: [], next_cursor: null, has_more: false })
+
+      // First call populates cache
+      await databases(notion, {
+        action: 'list_templates',
+        database_id: 'db-1'
+      })
+
+      expect(mockNotion.databases.retrieve).toHaveBeenCalledTimes(1)
+
+      // Second call should use cache
+      await databases(notion, {
+        action: 'list_templates',
+        database_id: 'db-1'
+      })
+
+      expect(mockNotion.databases.retrieve).toHaveBeenCalledTimes(1)
     })
 
     it('should throw NOT_FOUND when both database and data source are not found', async () => {

--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -788,12 +788,12 @@ describe('databases', () => {
       await databases(notion, {
         action: 'update_database',
         database_id: 'db-1',
-        icon: '📋',
+        icon: '\uD83D\uDCCB',
         cover: 'https://example.com/cover.jpg'
       })
 
       const call = mockNotion.databases.update.mock.calls[0][0]
-      expect(call.icon).toEqual({ type: 'emoji', emoji: '📋' })
+      expect(call.icon).toEqual({ type: 'emoji', emoji: '\uD83D\uDCCB' })
       expect(call.cover).toEqual({
         type: 'external',
         external: { url: 'https://example.com/cover.jpg' }

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -15,6 +15,12 @@ import * as RichText from '../helpers/richtext.js'
 // Cache for data source schema (properties)
 export const schemaCache = new Map<string, { properties: any; expiresAt: number }>()
 const SCHEMA_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+// Cache for ID resolution (database_id -> data_source_id)
+export const idResolutionCache = new Map<
+  string,
+  { result: { databaseId: string; dataSourceId: string }; expiresAt: number }
+>()
+const ID_RESOLUTION_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 
 /**
  * Get data source properties with caching
@@ -247,11 +253,22 @@ export type DatabasesResponse =
 async function resolveDataSourceId(notion: Client, id: string): Promise<{ databaseId: string; dataSourceId: string }> {
   const normalized = normalizeId(id)
 
+  // Check cache
+  const cached = idResolutionCache.get(normalized)
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.result
+  }
+
   // Try as database container first
   try {
     const database: any = await notion.databases.retrieve({ database_id: normalized })
     if (database.data_sources?.length > 0) {
-      return { databaseId: database.id, dataSourceId: database.data_sources[0].id }
+      const result = { databaseId: database.id, dataSourceId: database.data_sources[0].id }
+      idResolutionCache.set(normalized, {
+        result,
+        expiresAt: Date.now() + ID_RESOLUTION_CACHE_TTL
+      })
+      return result
     }
     throw new NotionMCPError(
       'Database has no data sources',
@@ -265,10 +282,15 @@ async function resolveDataSourceId(notion: Client, id: string): Promise<{ databa
     if (error.code === 'object_not_found') {
       try {
         const ds: any = await (notion as any).dataSources.retrieve({ data_source_id: normalized })
-        return {
+        const result = {
           databaseId: ds.parent?.database_id || normalized,
           dataSourceId: ds.id
         }
+        idResolutionCache.set(normalized, {
+          result,
+          expiresAt: Date.now() + ID_RESOLUTION_CACHE_TTL
+        })
+        return result
       } catch {
         throw new NotionMCPError(
           `ID "${id}" is not a valid database or data source`,


### PR DESCRIPTION
This PR implements a caching strategy for ID resolution in the `databases` composite tool.

### What was fixed
- Defined `idResolutionCache` in `src/tools/composite/databases.ts` with a 5-minute TTL.
- Updated `resolveDataSourceId` to check the cache before making Notion API calls and populate it upon success.
- Updated `src/tools/composite/databases.test.ts` to clear the new cache between tests and added a test case verifying that subsequent calls use the cache.

### Why
`resolveDataSourceId` is a core utility used by most database operations. By caching the resolution of database IDs to data source IDs, we reduce latency and avoid unnecessary Notion API requests, especially in bulk operations or frequent queries.

---
*PR created automatically by Jules for task [15654969437699946298](https://jules.google.com/task/15654969437699946298) started by @n24q02m*