### PR TITLE
[FIX] Missing Cache

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as markdown from '../helpers/markdown.js'
-import { blocks } from './blocks'
+import { blockCache, blocks } from './blocks'
 
 const mockNotion = {
   blocks: {
@@ -17,6 +17,7 @@ const mockNotion = {
 describe('blocks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockCache.clear()
   })
 
   describe('validation', () => {
@@ -425,4 +426,80 @@ describe('blocks', () => {
       )
     })
   })
+
+  describe('caching', () => {
+    it('should use cache for subsequent get calls', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      })
+
+      // First call - should hit API
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Second call - should use cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+    })
+
+    it('should update cache on update', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      })
+      mockNotion.blocks.update.mockResolvedValue({
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [{ plain_text: 'Updated' }] }
+      })
+
+      // Initial get to populate cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+
+      // Update call
+      await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: 'Updated'
+      })
+
+      // Get call - should use updated cache and NOT call API again
+      const result = await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(result.block.paragraph.rich_text[0].plain_text).toBe('Updated')
+      // Total calls should be 1 (from initial get), update uses cache for retrieval too
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+    })
+
+    it('should clear cache on delete', async () => {
+      mockNotion.blocks.retrieve.mockResolvedValue({
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      })
+      mockNotion.blocks.delete.mockResolvedValue({})
+
+      // Populate cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Delete
+      await blocks(mockNotion as any, { action: 'delete', block_id: 'block-1' })
+
+      // Call again - should hit API
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
+    })
+  })
+
 })

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -8,6 +8,28 @@ import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren } from '../helpers/pagination.js'
 
+// Cache for blocks
+export const blockCache = new Map<string, { block: any; expiresAt: number }>()
+const BLOCK_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * Get block with caching
+ */
+async function getCachedBlock(notion: Client, blockId: string): Promise<any> {
+  const cached = blockCache.get(blockId)
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.block
+  }
+
+  const block = await notion.blocks.retrieve({ block_id: blockId })
+  blockCache.set(blockId, {
+    block,
+    expiresAt: Date.now() + BLOCK_CACHE_TTL
+  })
+  return block
+}
+
+
 export interface BlocksInput {
   action: 'get' | 'children' | 'append' | 'update' | 'delete'
   block_id: string
@@ -28,7 +50,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
     switch (input.action) {
       case 'get': {
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        const block: any = await getCachedBlock(notion, input.block_id)
         return {
           action: 'get',
           block_id: block.id,
@@ -94,7 +116,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
         if (!input.content) {
           throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
         }
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        const block: any = await getCachedBlock(notion, input.block_id)
         const blockType = block.type
         const newBlocks = markdownToBlocks(input.content)
 
@@ -152,10 +174,16 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
           )
         }
 
-        await notion.blocks.update({
+        const updatedBlock = await notion.blocks.update({
           block_id: input.block_id,
           ...updatePayload
         } as any)
+
+        // Update cache
+        blockCache.set(input.block_id, {
+          block: updatedBlock,
+          expiresAt: Date.now() + BLOCK_CACHE_TTL
+        })
 
         return {
           action: 'update',
@@ -167,6 +195,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
       case 'delete': {
         await notion.blocks.delete({ block_id: input.block_id })
+        blockCache.delete(input.block_id)
         return {
           action: 'delete',
           block_id: input.block_id,


### PR DESCRIPTION
Implemented a caching strategy for Notion blocks in the blocks mega tool. This reduces the number of redundant API calls to Notion by storing retrieved blocks in an in-memory Map with a 5-minute TTL. The cache is updated upon block updates and cleared upon block deletion to ensure data consistency.

---
*PR created automatically by Jules for task [12750858470128930180](https://jules.google.com/task/12750858470128930180) started by @n24q02m*