### PR TITLE
[FIX] Missing Cache

### DIFF
--- a/src/tools/composite/blocks.cache.test.ts
+++ b/src/tools/composite/blocks.cache.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { blocks, blockCache } from './blocks.js'
+
+describe('blocks cache', () => {
+  const mockNotion = {
+    blocks: {
+      retrieve: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      children: {
+        list: vi.fn(),
+        append: vi.fn()
+      }
+    }
+  }
+
+  beforeEach(() => {
+    blockCache.clear()
+    vi.resetAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should use cache for subsequent get calls', async () => {
+    const blockResponse = {
+      id: 'block-1',
+      type: 'paragraph',
+      has_children: false,
+      archived: false,
+      paragraph: { rich_text: [] }
+    }
+    mockNotion.blocks.retrieve.mockResolvedValue(blockResponse)
+
+    // First call
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+    // Second call
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1) // Still 1
+  })
+
+  it('should expire cache after TTL', async () => {
+    const blockResponse = {
+      id: 'block-1',
+      type: 'paragraph',
+      has_children: false,
+      archived: false,
+      paragraph: { rich_text: [] }
+    }
+    mockNotion.blocks.retrieve.mockResolvedValue(blockResponse)
+
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+    // Fast-forward 6 minutes (TTL is 5 mins)
+    vi.advanceTimersByTime(6 * 60 * 1000)
+
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
+  })
+
+  it('should invalidate cache on update', async () => {
+    const blockResponse = {
+      id: 'block-1',
+      type: 'paragraph',
+      has_children: false,
+      archived: false,
+      paragraph: { rich_text: [] }
+    }
+    mockNotion.blocks.retrieve.mockResolvedValue(blockResponse)
+    mockNotion.blocks.update.mockResolvedValue({})
+
+    // Populate cache
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+    // Update
+    await blocks(mockNotion as any, {
+      action: 'update',
+      block_id: 'block-1',
+      content: 'New content'
+    })
+
+    // The update calls retrieve once (via getCachedBlock) but it should have been cached
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+    // Next get should call retrieve again because cache was invalidated
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
+  })
+
+  it('should invalidate cache on delete', async () => {
+    const blockResponse = {
+      id: 'block-1',
+      type: 'paragraph',
+      has_children: false,
+      archived: false,
+      paragraph: { rich_text: [] }
+    }
+    mockNotion.blocks.retrieve.mockResolvedValue(blockResponse)
+    mockNotion.blocks.delete.mockResolvedValue({})
+
+    // Populate cache
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+    // Delete
+    await blocks(mockNotion as any, { action: 'delete', block_id: 'block-1' })
+
+    // Next get should call retrieve again
+    await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+    expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as markdown from '../helpers/markdown.js'
-import { blocks } from './blocks'
+import { blocks, blockCache } from './blocks'
 
 const mockNotion = {
   blocks: {
@@ -17,6 +17,7 @@ const mockNotion = {
 describe('blocks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockCache.clear()
   })
 
   describe('validation', () => {

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -16,6 +16,27 @@ export interface BlocksInput {
   after_block_id?: string
 }
 
+// Cache for blocks
+export const blockCache = new Map<string, { block: any; expiresAt: number }>()
+const BLOCK_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * Get block with caching
+ */
+async function getCachedBlock(notion: Client, blockId: string): Promise<any> {
+  const cached = blockCache.get(blockId)
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.block
+  }
+
+  const block = await notion.blocks.retrieve({ block_id: blockId })
+  blockCache.set(blockId, {
+    block,
+    expiresAt: Date.now() + BLOCK_CACHE_TTL
+  })
+  return block
+}
+
 /**
  * Unified blocks tool
  * Maps to: GET/PATCH/DELETE /v1/blocks/{id} and GET/PATCH /v1/blocks/{id}/children
@@ -28,7 +49,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
     switch (input.action) {
       case 'get': {
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        const block: any = await getCachedBlock(notion, input.block_id)
         return {
           action: 'get',
           block_id: block.id,
@@ -94,7 +115,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
         if (!input.content) {
           throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
         }
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        const block: any = await getCachedBlock(notion, input.block_id)
         const blockType = block.type
         const newBlocks = markdownToBlocks(input.content)
 
@@ -157,6 +178,9 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
           ...updatePayload
         } as any)
 
+        // Invalidate cache
+        blockCache.delete(input.block_id)
+
         return {
           action: 'update',
           block_id: input.block_id,
@@ -167,6 +191,10 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
       case 'delete': {
         await notion.blocks.delete({ block_id: input.block_id })
+
+        // Invalidate cache
+        blockCache.delete(input.block_id)
+
         return {
           action: 'delete',
           block_id: input.block_id,


### PR DESCRIPTION
This PR introduces a caching strategy for Notion blocks in `src/tools/composite/blocks.ts`. 

### 💡 What
- A new `blockCache` is introduced using a `Map` to store block metadata.
- A `BLOCK_CACHE_TTL` of 5 minutes is set.
- The `blocks` tool's `get` and `update` actions now use `getCachedBlock` to retrieve block data.
- Successful `update` and `delete` operations trigger cache invalidation for the affected `block_id`.

### 🎯 Why
Notion API calls for retrieving block metadata are frequently repeated, especially when validating block types before updates. Caching these results improves performance and reduces API rate limit consumption.

### 🧪 Measurement
- New tests in `src/tools/composite/blocks.cache.test.ts` verify that:
    - Subsequent `get` calls use the cache.
    - Cache expires after the TTL.
    - `update` and `delete` actions correctly invalidate the cache.
- All 25 tests in the blocks test suite (including existing ones) pass successfully.

---
*PR created automatically by Jules for task [8890623636120967802](https://jules.google.com/task/8890623636120967802) started by @n24q02m*