### PR TITLE
🛡️ Sentinel: [HIGH] Fix unsafe child_process execution

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for credential state management.
+ */
+
+import { execFile } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tryOpenBrowser } from './credential-state.js'
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn()
+}))
+
+describe('tryOpenBrowser', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  it('calls open on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    tryOpenBrowser('https://example.com')
+    expect(execFile).toHaveBeenCalledWith('open', ['https://example.com'], expect.any(Function))
+  })
+
+  it('calls cmd on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    tryOpenBrowser('https://example.com')
+    expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'https://example.com'], expect.any(Function))
+  })
+
+  it('calls xdg-open on other platforms', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    tryOpenBrowser('https://example.com')
+    expect(execFile).toHaveBeenCalledWith('xdg-open', ['https://example.com'], expect.any(Function))
+  })
+
+  it('should NOT call execFile for dangerous URLs', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+
+    const dangerousUrls = [
+      'file:///etc/passwd',
+      'javascript:alert(1)',
+      'https://example.com --flag',
+      'https://example.com/ path with spaces',
+      '-flag'
+    ]
+
+    for (const url of dangerousUrls) {
+      tryOpenBrowser(url)
+    }
+
+    // This is expected to FAIL before the fix
+    expect(execFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-relay-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-relay-core'
 import { resolveConfig } from '@n24q02m/mcp-relay-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,12 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  // Guard against unsafe URLs (e.g., file://, javascript:, or flag injection)
+  if (!isSafeWebUrl(url)) {
+    return
+  }
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,5 +1,9 @@
+/**
+ * Tests for security utilities.
+ */
+
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security.js'
 
 describe('Security Utilities', () => {
   describe('isSafeUrl', () => {
@@ -81,6 +85,36 @@ describe('Security Utilities', () => {
       // http://[ is a malformed absolute URL that will fail the first new URL() call
       // and also fail the relative URL check new URL(lowerUrl, 'http://relative-check.internal')
       expect(isSafeUrl('http://[')).toBe(false)
+    })
+  })
+
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com/path?query=1')).toBe(true)
+    })
+
+    it('should reject non-web protocols', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+    })
+
+    it('should reject URLs with whitespace or control characters', () => {
+      expect(isSafeWebUrl('https://example.com ')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/ path')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\n')).toBe(false)
+    })
+
+    it('should reject URLs starting with a hyphen', () => {
+      expect(isSafeWebUrl('-flag')).toBe(false)
+      expect(isSafeWebUrl('--help')).toBe(false)
+    })
+
+    it('should reject relative URLs', () => {
+      expect(isSafeWebUrl('/path')).toBe(false)
+      expect(isSafeWebUrl('path')).toBe(false)
     })
   })
 

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -64,3 +64,29 @@ export function wrapToolResult(toolName: string, jsonText: string): string {
 
   return `<untrusted_notion_content>\n${jsonText}\n</untrusted_notion_content>\n\n${SAFETY_WARNING}`
 }
+
+/**
+ * Validates a URL to ensure it is a safe web URL (http/https only).
+ * Rejects whitespace, control characters, and non-web protocols.
+ * Also ensures the URL is absolute and does not contain flags or spaces
+ * that could be interpreted by shell commands.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  // Reject URLs starting with a hyphen to prevent flag injection in shell commands
+  if (url.startsWith('-')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Implemented strict URL validation using a new `isSafeWebUrl` helper to prevent command injection and unsafe file execution in the `tryOpenBrowser` function.

- Added `isSafeWebUrl` to `src/tools/helpers/security.ts` (enforces http/https, rejects whitespace, control characters, and leading hyphens).
- Updated `src/credential-state.ts` to use `isSafeWebUrl` before calling `execFile`.
- Added `src/credential-state.test.ts` for reproduction and verification.
- Expanded `src/tools/helpers/security.test.ts` with web URL safety cases.
- Verified all tests pass (809/809).

---
*PR created automatically by Jules for task [353870506604568262](https://jules.google.com/task/353870506604568262) started by @n24q02m*