### PR TITLE
[FIX] Notion API bug test

### DIFF
--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Error handling and enhancement for Notion MCP operations.
+ */
 import { describe, expect, it, vi } from 'vitest'
 import {
   aiReadableMessage,
@@ -248,14 +251,14 @@ describe('aiReadableMessage', () => {
     const error = new NotionMCPError('Page not found', 'NOT_FOUND', 'Check the ID')
     const msg = aiReadableMessage(error)
 
-    expect(msg).toBe('Error: Page not found\n\nSuggestion: Check the ID')
+    expect(msg).toBe('Error [NOT_FOUND]: Page not found\n\nSuggestion: Check the ID')
   })
 
   it('should format error without suggestion', () => {
     const error = new NotionMCPError('Something failed', 'UNKNOWN')
     const msg = aiReadableMessage(error)
 
-    expect(msg).toBe('Error: Something failed')
+    expect(msg).toBe('Error [UNKNOWN]: Something failed')
     expect(msg).not.toContain('Suggestion')
   })
 
@@ -263,7 +266,7 @@ describe('aiReadableMessage', () => {
     const error = new NotionMCPError('Bad input', 'VALIDATION_ERROR', undefined, { field: 'title' })
     const msg = aiReadableMessage(error)
 
-    expect(msg).toContain('Error: Bad input')
+    expect(msg).toContain('Error [VALIDATION_ERROR]: Bad input')
     expect(msg).not.toContain('Suggestion')
     expect(msg).toContain('Details:')
     expect(msg).toContain('"field": "title"')
@@ -273,7 +276,7 @@ describe('aiReadableMessage', () => {
     const error = new NotionMCPError('Bad input', 'VALIDATION_ERROR', 'Fix it', { field: 'title' })
     const msg = aiReadableMessage(error)
 
-    expect(msg).toContain('Error: Bad input')
+    expect(msg).toContain('Error [VALIDATION_ERROR]: Bad input')
     expect(msg).toContain('Suggestion: Fix it')
     expect(msg).toContain('Details:')
   })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -228,7 +228,7 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
  * Create AI-readable error message
  */
 export function aiReadableMessage(error: NotionMCPError): string {
-  let message = `Error: ${error.message}`
+  let message = `Error [${error.code}]: ${error.message}`
 
   if (error.suggestion) {
     message += `\n\nSuggestion: ${error.suggestion}`


### PR DESCRIPTION
Modified `aiReadableMessage` in `src/tools/helpers/errors.ts` to include the error code in the output string (e.g., `Error [CODE]: Message`). This ensures that tests expecting a specific error code in the tool output (like the `COMMENTS_LIST_UNAVAILABLE` check in `full-notion.full.test.ts`) can pass correctly.

Updated `src/tools/helpers/errors.test.ts` to reflect the new format and added missing file-level JSDoc.

---
*PR created automatically by Jules for task [10972624165815647700](https://jules.google.com/task/10972624165815647700) started by @n24q02m*