### PR TITLE
[FIX] Commented-out code explaining security checks

### DIFF
--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -29,9 +29,9 @@ export function isSafeUrl(url: string): boolean {
     const parsed = new URL(lowerUrl)
     return ['http:', 'https:', 'mailto:', 'tel:'].includes(parsed.protocol)
   } catch {
-    // If URL parsing fails, it might be a relative path or an invalid URL
-    // For relative paths like "/foo" or "foo", they are generally safe,
-    // but we can reject strictly for now, or check for dangerous prefixes.
+    // If URL parsing fails, it might be a relative path or an invalid URL.
+    // Relative paths like "/foo" or "foo" are safe, provided they don't
+    // use protocol obfuscation to hide dangerous absolute URLs.
 
     try {
       new URL(lowerUrl, 'http://relative-check.internal')


### PR DESCRIPTION
This PR updates an indecisive comment in `src/tools/helpers/security.ts` that mentioned potential future designs for relative URL security checks. Since the security logic is already implemented (using prefix-based checks for colons, ampersands, and encoded colons), the comment was updated to clearly explain the current behavior.

Changes:
- Replaced the "we can reject strictly for now, or check for dangerous prefixes" comment with a definitive explanation of relative URL safety.
- Verified that existing tests in `src/tools/helpers/security.test.ts` still pass.
- Ensured the codebase remains strictly ASCII and follows formatting/linting rules.

---
*PR created automatically by Jules for task [13660616422670229550](https://jules.google.com/task/13660616422670229550) started by @n24q02m*