### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent Command Injection in tryOpenBrowser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
       - name: Setup Node.js 24
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -190,8 +190,10 @@ export function tryOpenBrowser(url: string): void {
   if (platform === 'darwin') {
     execFile('open', [url], () => {})
   } else if (platform === 'win32') {
-    // Note: 'start' is a cmd internal command. We escape the URL with double quotes.
-    execFile('cmd', ['/c', 'start', '', `"${url}"`], { windowsVerbatimArguments: true }, () => {})
+    // Note: 'start' is a cmd internal command.
+    // When executing 'cmd /c start', the first double-quoted string is treated as the window title.
+    // Thus we provide an empty title ('""') followed by the URL wrapped in double quotes.
+    execFile('cmd', ['/c', 'start', '""', `"${url}"`], { windowsVerbatimArguments: true }, () => {})
   } else {
     execFile('xdg-open', [url], () => {})
   }

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -190,7 +190,8 @@ export function tryOpenBrowser(url: string): void {
   if (platform === 'darwin') {
     execFile('open', [url], () => {})
   } else if (platform === 'win32') {
-    execFile('cmd', ['/c', 'start', '', url], () => {})
+    // Note: 'start' is a cmd internal command. We escape the URL with double quotes.
+    execFile('cmd', ['/c', 'start', '', `"${url}"`], { windowsVerbatimArguments: true }, () => {})
   } else {
     execFile('xdg-open', [url], () => {})
   }

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -193,7 +193,8 @@ export function tryOpenBrowser(url: string): void {
     // Note: 'start' is a cmd internal command.
     // When executing 'cmd /c start', the first double-quoted string is treated as the window title.
     // Thus we provide an empty title ('""') followed by the URL wrapped in double quotes.
-    execFile('cmd', ['/c', 'start', '""', `"${url}"`], { windowsVerbatimArguments: true }, () => {})
+    // Ensure we do not use windowsVerbatimArguments to prevent command injection from bypassing node's parsing logic.
+    execFile('cmd', ['/c', 'start', '""', url], () => {})
   } else {
     execFile('xdg-open', [url], () => {})
   }

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-relay-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-relay-core'
 import { resolveConfig } from '@n24q02m/mcp-relay-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,12 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) {
+    console.error('Blocked attempt to open unsafe URL in browser')
+    return
+  }
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
   describe('isSafeUrl', () => {
@@ -81,6 +81,40 @@ describe('Security Utilities', () => {
       // http://[ is a malformed absolute URL that will fail the first new URL() call
       // and also fail the relative URL check new URL(lowerUrl, 'http://relative-check.internal')
       expect(isSafeUrl('http://[')).toBe(false)
+    })
+  })
+
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com')).toBe(true)
+    })
+
+    it('should reject non-web protocols like mailto, tel, javascript, etc.', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+    })
+
+    it('should reject URLs with control characters and whitespace obfuscation', () => {
+      expect(isSafeWebUrl(' https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\n')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\r\n')).toBe(false)
+      expect(isSafeWebUrl('\x00https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\x00')).toBe(false)
+    })
+
+    it('should reject URLs starting with hyphens to prevent shell flag injection', () => {
+      expect(isSafeWebUrl('-https://example.com')).toBe(false)
+      expect(isSafeWebUrl('--no-sandbox')).toBe(false)
+    })
+
+    it('should reject malformed or relative URLs', () => {
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('just-a-string')).toBe(false)
+      expect(isSafeWebUrl('http://[')).toBe(false)
     })
   })
 

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -56,6 +56,33 @@ export function isSafeUrl(url: string): boolean {
   }
 }
 
+/**
+ * Validates a URL destined to be opened via shell commands (e.g., in a browser).
+ * Stricter than isSafeUrl, allowing only http: and https: protocols,
+ * and rejecting potential shell flag injections.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  // Reject URLs with whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  // Prevent shell flag injection (e.g., passing "--no-sandbox" to open)
+  if (url.startsWith('-')) {
+    return false
+  }
+
+  const lowerUrl = url.toLowerCase()
+
+  try {
+    const parsed = new URL(lowerUrl)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
 /** Wrap tool result with safety markers if it contains external content */
 export function wrapToolResult(toolName: string, jsonText: string): string {
   if (!EXTERNAL_CONTENT_TOOLS.has(toolName)) {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command/Flag Injection in `tryOpenBrowser`. The function accepted arbitrary URLs and passed them directly to OS-level execution tools (`open`, `cmd`, `xdg-open`) via `execFile`. An attacker could exploit this by passing a URL with a dangerous scheme (e.g. `file://`, `javascript:`) or by injecting shell flags (e.g. `-a /System/Applications/Calculator.app`).
🎯 Impact: Remote Code Execution (RCE) or unexpected behavior on the machine hosting the server if a malicious setup URL is processed.
🔧 Fix: Added strict validation function `isSafeWebUrl` to `src/tools/helpers/security.ts`. This strictly validates that the URL uses the `http:` or `https:` scheme, and does not contain leading hyphens (`-`), whitespace, or control characters. The `tryOpenBrowser` function now validates URLs using this helper before executing them. 
✅ Verification: `bun run check` and `bun run test` run against full test suite, including new test cases for obfuscation, shell flag injection, and protocol checks in `security.test.ts`.

---
*PR created automatically by Jules for task [6005175161163812687](https://jules.google.com/task/6005175161163812687) started by @n24q02m*