### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability in tryOpenBrowser

### DIFF
--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-relay-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-relay-core'
 import { resolveConfig } from '@n24q02m/mcp-relay-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,12 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) {
+    console.error('Blocked attempt to open unsafe URL in browser')
+    return
+  }
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,7 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com')).toBe(true)
+    })
+
+    it('should reject non-http/https protocols', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+    })
+
+    it('should reject URLs starting with a hyphen (shell injection)', () => {
+      expect(isSafeWebUrl('-https://example.com')).toBe(false)
+      expect(isSafeWebUrl('--remote-debugging-port=1337')).toBe(false)
+    })
+
+    it('should reject URLs with control characters and whitespace', () => {
+      expect(isSafeWebUrl(' https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\n')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\r\n/unsafe')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/path\0withnull')).toBe(false)
+    })
+
+    it('should reject relative or non-absolute URLs', () => {
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('just-a-string')).toBe(false)
+    })
+  })
+
   describe('isSafeUrl', () => {
     it('should allow valid http and https URLs', () => {
       expect(isSafeUrl('https://example.com')).toBe(true)

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -16,6 +16,29 @@ const SAFETY_WARNING =
  * Validates a URL to ensure it uses a safe protocol.
  * Prevents XSS attacks via javascript:, data:, vbscript:, etc.
  */
+/**
+ * Strict validation for URLs destined for the browser (via execFile/open).
+ * Only allows http: and https: protocols.
+ * Prevents shell flag injection by rejecting leading hyphens.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  if (!url || typeof url !== 'string') return false
+
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Security sanitization
+  if (/[\s\x00-\x1F\x7F]/.test(url)) return false
+
+  // Prevent shell flag injection (e.g. "--remote-debugging-port")
+  if (url.startsWith('-')) return false
+
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
 export function isSafeUrl(url: string): boolean {
   // Reject URLs containing whitespace or control characters which could bypass checks
   // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security sanitization


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `tryOpenBrowser` function passed untrusted URLs directly to `execFile`. While `execFile` prevents traditional shell injection (`&&`, `;`), an attacker could still inject shell flags by passing a URL that starts with a hyphen (e.g., `--remote-debugging-port`), exploiting how the executed binaries parse arguments. Control characters were also not stripped, potentially allowing bypasses depending on the underlying OS parser.
🎯 **Impact:** Could allow a malicious user or crafted setup URL to execute unintended options or parameters in the host's default web browser or terminal utilities (`open`, `xdg-open`), leading to unexpected behavior or limited local execution depending on the utility.
🔧 **Fix:** 
- Implemented `isSafeWebUrl` in `src/tools/helpers/security.ts`.
- Strictly enforces `http:` and `https:` protocols.
- Explicitly rejects URLs starting with `-` to prevent shell flag injection.
- Rejects whitespace and control characters.
- Applied `isSafeWebUrl` before calling `execFile` in `tryOpenBrowser`.
✅ **Verification:** Unit tests have been added in `src/tools/helpers/security.test.ts` to cover various bypass attempts, and the test suite passes successfully. Checked with `bun run check` and `bun run test`.

---
*PR created automatically by Jules for task [16182255179403989398](https://jules.google.com/task/16182255179403989398) started by @n24q02m*