### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection risk in browser launch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-notion-mcp",
   "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
-  "version": "2.27.3",
+  "version": "2.27.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "codex",
     "opencode"
   ],
-  "version": "2.27.3",
+  "version": "2.27.4",
   "license": "MIT",
   "type": "module",
   "packageManager": "bun@1.2.21",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-notion-mcp.git",
     "source": "github"
   },
-  "version": "2.27.3",
+  "version": "2.27.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-notion-mcp",
-      "version": "2.27.3",
+      "version": "2.27.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -205,10 +205,10 @@ describe('credential-state', () => {
       const originalPlatform = process.platform
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'http://url.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('open', ['http://url.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -224,10 +224,10 @@ describe('credential-state', () => {
       const originalPlatform = process.platform
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'http://url.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'http://url.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -243,10 +243,10 @@ describe('credential-state', () => {
       const originalPlatform = process.platform
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'http://url.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('xdg-open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('xdg-open', ['http://url.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,12 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) {
+    console.error('Browser launch blocked: URL validation failed.')
+    return
+  }
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,7 +1,42 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com/path?query=1')).toBe(true)
+    })
+
+    it('should reject non-http/https protocols', () => {
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+      expect(isSafeWebUrl('mailto:test@test.com')).toBe(false)
+    })
+
+    it('should reject URLs starting with hyphens to prevent shell flag injection', () => {
+      expect(isSafeWebUrl('--no-sandbox')).toBe(false)
+      expect(isSafeWebUrl('-h')).toBe(false)
+      expect(isSafeWebUrl('  --args')).toBe(false)
+      // Normal hyphens in domain are fine
+      expect(isSafeWebUrl('https://my-domain.com')).toBe(true)
+    })
+
+    it('should reject URLs with control characters or whitespace', () => {
+      expect(isSafeWebUrl('https://example.com/\npath')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/\rpath')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/ path')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/\x00')).toBe(false)
+    })
+
+    it('should reject malformed URLs that fail parsing', () => {
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('just-a-string')).toBe(false)
+      expect(isSafeWebUrl('http://[')).toBe(false)
+    })
+  })
+
   describe('isSafeUrl', () => {
     it('should allow valid http and https URLs', () => {
       expect(isSafeUrl('https://example.com')).toBe(true)

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -64,3 +64,27 @@ export function wrapToolResult(toolName: string, jsonText: string): string {
 
   return `<untrusted_notion_content>\n${jsonText}\n</untrusted_notion_content>\n\n${SAFETY_WARNING}`
 }
+
+/**
+ * Validates a URL strictly for browser launch to prevent command injection.
+ * Only allows http: and https: protocols and prevents shell flag injection.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  // Prevent shell flag injection (e.g. --args)
+  if (url.trim().startsWith('-')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `tryOpenBrowser` function uses `execFile` to open a URL in the browser. While `execFile` prevents some shell injections, it does not prevent arguments from being interpreted as flags if the URL starts with a hyphen (e.g., `--args`). Additionally, non-web protocols like `file://` or `javascript:` could be passed directly to the OS command.
🎯 Impact: An attacker could potentially achieve command execution by crafting a malicious URL containing shell flags or execute local files if the OS handler supports it.
🔧 Fix: Created a new helper `isSafeWebUrl` that strictly validates the URL to ensure it uses the `http:` or `https:` protocol, rejects any URLs starting with a hyphen (shell flag injection mitigation), and rejects control characters/whitespace. The validation was added as an early return to `tryOpenBrowser` and tested comprehensively.
✅ Verification: Covered by existing and new unit tests inside `src/tools/helpers/security.test.ts`. Run `bun run test` to verify.

---
*PR created automatically by Jules for task [15142480285847372914](https://jules.google.com/task/15142480285847372914) started by @n24q02m*