### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in tryOpenBrowser

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-notion-mcp",
   "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
-  "version": "2.27.3",
+  "version": "2.27.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "codex",
     "opencode"
   ],
-  "version": "2.27.3",
+  "version": "2.27.4",
   "license": "MIT",
   "type": "module",
   "packageManager": "bun@1.2.21",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-notion-mcp.git",
     "source": "github"
   },
-  "version": "2.27.3",
+  "version": "2.27.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-notion-mcp",
-      "version": "2.27.3",
+      "version": "2.27.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -7,6 +7,7 @@ import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } 
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  tryOpenBrowser,
   getNotionToken,
   getSetupUrl,
   getState,
@@ -201,14 +202,25 @@ describe('credential-state', () => {
   })
 
   describe('tryOpenBrowser', () => {
-    it('calls open on darwin', async () => {
-      const originalPlatform = process.platform
+    const originalPlatform = process.platform
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    })
+
+    it('blocks malicious URLs without executing', () => {
+      tryOpenBrowser('javascript:alert(1)')
+      tryOpenBrowser('--no-sandbox')
+      tryOpenBrowser('https://example.com/ \x00')
+      expect(execFile).not.toHaveBeenCalled()
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Security warning'))
+    })
+
+    it('calls open on darwin for valid URLs', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
-      await triggerRelaySetup()
+      tryOpenBrowser('https://example.com')
 
-      expect(execFile).toHaveBeenCalledWith('open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('open', ['https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -216,18 +228,14 @@ describe('credential-state', () => {
         stderr: string
       ) => void
       callback(null, '', '')
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
-    it('calls cmd on win32', async () => {
-      const originalPlatform = process.platform
+    it('calls cmd on win32 for valid URLs', () => {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
-      await triggerRelaySetup()
+      tryOpenBrowser('https://example.com')
 
-      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -235,18 +243,14 @@ describe('credential-state', () => {
         stderr: string
       ) => void
       callback(null, '', '')
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
 
-    it('calls xdg-open on other platforms', async () => {
-      const originalPlatform = process.platform
+    it('calls xdg-open on other platforms for valid URLs', () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
-      await triggerRelaySetup()
+      tryOpenBrowser('https://example.com')
 
-      expect(execFile).toHaveBeenCalledWith('xdg-open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('xdg-open', ['https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -254,8 +258,6 @@ describe('credential-state', () => {
         stderr: string
       ) => void
       callback(null, '', '')
-
-      Object.defineProperty(process, 'platform', { value: originalPlatform })
     })
   })
 

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -7,14 +7,14 @@ import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } 
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  tryOpenBrowser,
   getNotionToken,
   getSetupUrl,
   getState,
   resetState,
   resolveCredentialState,
   setState,
-  triggerRelaySetup
+  triggerRelaySetup,
+  tryOpenBrowser
 } from './credential-state.js'
 
 vi.mock('node:child_process', () => ({

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,12 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) {
+    console.error('Security warning: Attempted to open unsafe or invalid URL in browser.')
+    return
+  }
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
   describe('isSafeUrl', () => {
@@ -91,6 +91,41 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('.:foo')).toBe(false)
       expect(isSafeUrl('.&bar')).toBe(false)
       expect(isSafeUrl('.%3aabc')).toBe(false)
+    })
+  })
+
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com')).toBe(true)
+    })
+
+    it('should reject non-http/https protocols', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+    })
+
+    it('should reject URLs starting with a hyphen (shell flag injection)', () => {
+      expect(isSafeWebUrl('-no-sandbox')).toBe(false)
+      expect(isSafeWebUrl('--no-sandbox')).toBe(false)
+      expect(isSafeWebUrl(' -no-sandbox')).toBe(false)
+      expect(isSafeWebUrl('\t--incognito')).toBe(false)
+    })
+
+    it('should reject URLs with control characters and whitespace', () => {
+      expect(isSafeWebUrl(' https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\n')).toBe(false)
+      expect(isSafeWebUrl('https://exam\rple.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/\x00')).toBe(false)
+    })
+
+    it('should reject relative URLs or malformed URLs', () => {
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('just-a-string')).toBe(false)
+      expect(isSafeWebUrl('http://[')).toBe(false)
     })
   })
 

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -56,6 +56,32 @@ export function isSafeUrl(url: string): boolean {
   }
 }
 
+/**
+ * Stricter URL validation specifically for browser launches via execFile.
+ * Enforces http/https and blocks shell flag injection.
+ */
+const SAFE_PROTOCOLS = new Set(['http:', 'https:'])
+
+export function isSafeWebUrl(url: string): boolean {
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  // Prevent shell flag injection (e.g. "--no-sandbox")
+  if (url.trimStart().startsWith('-')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return SAFE_PROTOCOLS.has(parsed.protocol.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
 /** Wrap tool result with safety markers if it contains external content */
 export function wrapToolResult(toolName: string, jsonText: string): string {
   if (!EXTERNAL_CONTENT_TOOLS.has(toolName)) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `tryOpenBrowser` used `execFile` to launch browsers with unvalidated URLs. This allowed for potential shell flag injection (e.g., `--no-sandbox`) and execution of dangerous URL protocols.
🎯 Impact: Could allow an attacker to launch arbitrary flags or unsafe protocols if they can manipulate the URL string passed during relay setup.
🔧 Fix: Implemented `isSafeWebUrl` which strictly verifies `http/https` protocols, blocks control and whitespace character obfuscation, and actively blocks shell flag injection by checking for leading hyphens. Integrated this directly into `tryOpenBrowser`.
✅ Verification: Ran unit tests specifically testing malicious URL formats and valid browser execution paths. Linting and all tests pass.

---
*PR created automatically by Jules for task [15889119256889748049](https://jules.google.com/task/15889119256889748049) started by @n24q02m*