### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute tool arrays and optimize bigram extraction

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-notion-mcp",
   "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
-  "version": "2.27.3",
+  "version": "2.27.4",
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "codex",
     "opencode"
   ],
-  "version": "2.27.3",
+  "version": "2.27.4",
   "license": "MIT",
   "type": "module",
   "packageManager": "bun@1.2.21",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-notion-mcp.git",
     "source": "github"
   },
-  "version": "2.27.3",
+  "version": "2.27.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-notion-mcp",
-      "version": "2.27.3",
+      "version": "2.27.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -198,6 +198,10 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
   let bestMatch: string | null = null
   let bestScore = 0
 
+  // Pre-calculate input bigrams once
+  const inputBigrams = new Set<string>()
+  for (let i = 0; i < lower.length - 1; i++) inputBigrams.add(lower.slice(i, i + 2))
+
   for (const option of validOptions) {
     const optionLower = option.toLowerCase()
     // Check prefix match first
@@ -205,8 +209,6 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
       return option
     }
     // Simple bigram similarity
-    const inputBigrams = new Set<string>()
-    for (let i = 0; i < lower.length - 1; i++) inputBigrams.add(lower.slice(i, i + 2))
     const optionBigrams = new Set<string>()
     for (let i = 0; i < optionLower.length - 1; i++) optionBigrams.add(optionLower.slice(i, i + 2))
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -405,6 +405,11 @@ const TOOLS = [
   }
 ]
 
+// Pre-compute tool names for O(1) lookups and O(1) error message generation in high-frequency request handlers
+const TOOL_NAMES = TOOLS.map((t) => t.name)
+const HELP_TOOL_NAMES = TOOLS.filter((t) => t.name !== 'help').map((t) => t.name)
+const HELP_TOOL_NAMES_SET = new Set(HELP_TOOL_NAMES)
+
 /**
  * Register all tools with MCP server
  * @param notionClientFactory - Returns a Notion Client.
@@ -515,12 +520,11 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
           // Security: validate tool_name against allowlist to prevent path traversal
-          const validToolNames = TOOLS.filter((t) => t.name !== 'help').map((t) => t.name)
-          if (!validToolNames.includes(toolName)) {
+          if (!HELP_TOOL_NAMES_SET.has(toolName)) {
             throw new NotionMCPError(
               `Invalid tool name: ${toolName}`,
               'VALIDATION_ERROR',
-              `Valid tools: ${validToolNames.join(', ')}`
+              `Valid tools: ${HELP_TOOL_NAMES.join(', ')}`
             )
           }
           const docFile = `${basename(toolName)}.md`
@@ -533,13 +537,12 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         }
         default: {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new NotionMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'UNKNOWN_TOOL',
-            `Available tools: ${validTools.join(', ')}`
+            `Available tools: ${TOOL_NAMES.join(', ')}`
           )
         }
       }


### PR DESCRIPTION
💡 What
1. Extracted loop-invariant set population in `src/tools/helpers/errors.ts` (`findClosestMatch`). The input bigrams are now calculated once, instead of being recalculated for every item in `validOptions`.
2. Pre-computed derived tool constants (`TOOL_NAMES`, `HELP_TOOL_NAMES_SET`) in `src/tools/registry.ts` at the module level, rather than doing `.filter().map()` inside the high-frequency MCP request handler for the `help` or `default` actions.

🎯 Why
Both of these fix unnecessary redundant operations. In `findClosestMatch`, slicing strings and instantiating Sets inside the loop adds an $O(N \times M)$ overhead (where N is the number of options and M is the length of the string). In the MCP registry handler, the array `.filter().map()` executes on *every* request, creating unnecessary garbage collection pressure and CPU cycles.

📊 Impact
- Reduces memory allocations and CPU cycles spent on slicing strings during error recovery text searches.
- Provides an $O(1)$ lookup for validating help documentation requests, down from $O(N)$.
- Generally reduces garbage collection pressure on the event loop for the MCP server.

🔬 Measurement
Run `bun run test src/tools/registry.test.ts` and `bun run test src/tools/helpers/errors.test.ts` to verify functionality remains identical. Benchmarking a high volume of requests against the unoptimized paths would show a decrease in garbage collection pauses.

---
*PR created automatically by Jules for task [14469500716972710097](https://jules.google.com/task/14469500716972710097) started by @n24q02m*