### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -413,6 +413,10 @@ const TOOLS = [
   }
 ]
 
+const TOOL_NAMES = TOOLS.map((t) => t.name)
+const HELP_TOOL_NAMES = TOOLS.filter((t) => t.name !== 'help').map((t) => t.name)
+const HELP_TOOL_NAMES_SET = new Set(HELP_TOOL_NAMES)
+
 /**
  * Register all tools with MCP server
  * @param notionClientFactory - Returns a Notion Client.
@@ -523,12 +527,11 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
         case 'help': {
           const toolName = (args as { tool_name: string }).tool_name
           // Security: validate tool_name against allowlist to prevent path traversal
-          const validToolNames = TOOLS.filter((t) => t.name !== 'help').map((t) => t.name)
-          if (!validToolNames.includes(toolName)) {
+          if (!HELP_TOOL_NAMES_SET.has(toolName)) {
             throw new NotionMCPError(
               `Invalid tool name: ${toolName}`,
               'VALIDATION_ERROR',
-              `Valid tools: ${validToolNames.join(', ')}`
+              `Valid tools: ${HELP_TOOL_NAMES.join(', ')}`
             )
           }
           // Security: Use basename() to ensure we only look for files directly inside DOCS_DIR,
@@ -548,13 +551,12 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         }
         default: {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new NotionMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'UNKNOWN_TOOL',
-            `Available tools: ${validTools.join(', ')}`
+            `Available tools: ${TOOL_NAMES.join(', ')}`
           )
         }
       }


### PR DESCRIPTION
💡 What: Pre-calculate valid tool names and sets in `src/tools/registry.ts`.
🎯 Why: Avoid O(N) array allocations (.map/.filter) on every tool request during validation and error handling.
📊 Impact: Reduces memory allocation and speeds up tool request validation by using O(1) Set lookups and cached arrays.
🔬 Measurement: Run the test suite and observe the speed of `findClosestMatch` and tool name validation.

---
*PR created automatically by Jules for task [17487783830943646019](https://jules.google.com/task/17487783830943646019) started by @n24q02m*