### PR TITLE
🛡️ Sentinel: Fix unsafe child_process execution in tryOpenBrowser

### DIFF
--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -13,6 +13,7 @@ import type { RelaySession } from '@n24q02m/mcp-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, tryOpenBrowser, writeConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -110,7 +111,14 @@ export async function triggerRelaySetup(): Promise<string | null> {
 
     // Try to open browser (best-effort, non-blocking). mcp-core dedupes
     // repeat calls for the same URL within a 5-minute window.
-    void tryOpenBrowser(session.relayUrl)
+    // Defense-in-depth: validate with isSafeWebUrl before passing to any
+    // browser-opening helper so a malicious relay response cannot inject
+    // shell flags or control characters via the URL.
+    if (isSafeWebUrl(session.relayUrl)) {
+      void tryOpenBrowser(session.relayUrl)
+    } else {
+      console.error(`Security blocked attempt to open unsafe URL: ${session.relayUrl}`)
+    }
 
     console.error(`\nSetup required. Open this URL to configure:\n${session.relayUrl}\n`)
     console.error(

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
   describe('isSafeUrl', () => {
@@ -91,6 +91,37 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('.:foo')).toBe(false)
       expect(isSafeUrl('.&bar')).toBe(false)
       expect(isSafeUrl('.%3aabc')).toBe(false)
+    })
+  })
+
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com/path?query=1')).toBe(true)
+    })
+
+    it('should reject non-web protocols', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+    })
+
+    it('should reject URLs starting with a hyphen (shell flag injection)', () => {
+      expect(isSafeWebUrl('-oProxyCommand=calc.exe')).toBe(false)
+      expect(isSafeWebUrl('--help')).toBe(false)
+    })
+
+    it('should reject URLs with spaces or control characters', () => {
+      expect(isSafeWebUrl('https://example.com/ path')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/\npath')).toBe(false)
+      expect(isSafeWebUrl('https://example.com/\0path')).toBe(false)
+    })
+
+    it('should reject malformed URLs', () => {
+      expect(isSafeWebUrl('not-a-url')).toBe(false)
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('http://[')).toBe(false)
     })
   })
 

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -56,6 +56,33 @@ export function isSafeUrl(url: string): boolean {
   }
 }
 
+/**
+ * Strict validation for URLs destined for a web browser launch (execFile-style).
+ * Only allows http: and https: protocols and guards against shell-flag injection
+ * and control-character payloads that could sneak past simple argv passing on
+ * platforms where the browser-opening command is sensitive to leading hyphens
+ * or embedded whitespace.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  // Prevent shell flag injection (e.g., "-oProxyCommand=...")
+  if (url.startsWith('-')) {
+    return false
+  }
+
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control-char sanitization
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
 /** Wrap tool result with safety markers if it contains external content */
 export function wrapToolResult(toolName: string, jsonText: string): string {
   if (!EXTERNAL_CONTENT_TOOLS.has(toolName)) {


### PR DESCRIPTION
💡 What
Implemented strict URL validation for browser opening and added comprehensive tests.

🎯 Why
The previous implementation passed URLs directly to `execFile` arguments without validation, allowing for shell flag injection or execution of local files.

🛡️ Vulnerability
Commands like `open` or `cmd /c start` can interpret leading hyphens as flags, potentially leading to command execution or information leakage.

🔬 Prevention
Use `isSafeWebUrl` to enforce http/https protocols and block arguments starting with hyphens.

---
*PR created automatically by Jules for task [14032496492677410244](https://jules.google.com/task/14032496492677410244) started by @n24q02m*