### PR TITLE
[PERF] Loop optimization

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -683,14 +683,19 @@ interface ParseResult {
 
 function parseCalloutBlock(lines: string[], startIndex: number, match: RegExpMatchArray): ParseResult {
   const calloutType = match[1].toUpperCase()
-  let calloutContent = match[2] || ''
+  const contentLines: string[] = []
+  if (match[2]) {
+    contentLines.push(match[2])
+  }
   let i = startIndex
 
   // Collect continuation lines (lines starting with >)
   while (i + 1 < lines.length && lines[i + 1].startsWith('> ')) {
     i++
-    calloutContent += (calloutContent ? '\n' : '') + lines[i].slice(2)
+    contentLines.push(lines[i].slice(2))
   }
+
+  const calloutContent = contentLines.join('\n')
 
   const icon = getCalloutIcon(calloutType)
   const color = getCalloutColor(calloutType)


### PR DESCRIPTION
Refactored `parseCalloutBlock` in `src/tools/helpers/markdown.ts` to use an array for collecting continuation lines instead of string concatenation within the loop.

This optimization reduces the number of intermediate string allocations and decreases garbage collection pressure, which is particularly beneficial in high-throughput markdown parsing scenarios in the Bun environment.

Existing unit tests for callouts (including multi-line cases) pass successfully.

---
*PR created automatically by Jules for task [2840094296400926926](https://jules.google.com/task/2840094296400926926) started by @n24q02m*