### PR TITLE
[CLEANUP] Unused export setState in credential-state.ts

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -12,7 +12,6 @@ import {
   getState,
   resetState,
   resolveCredentialState,
-  setState,
   triggerRelaySetup
 } from './credential-state.js'
 
@@ -133,16 +132,20 @@ describe('credential-state', () => {
     })
 
     it('returns immediately if already setup_in_progress', async () => {
-      setState('setup_in_progress')
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      await triggerRelaySetup()
+      vi.mocked(createSession).mockClear()
+
       const url = await triggerRelaySetup()
       expect(createSession).not.toHaveBeenCalled()
-      expect(url).toBeNull() // _setupUrl is null initially
+      expect(url).toBe('url')
     })
   })
 
   describe('resetState', () => {
-    it('resets all state and calls deleteConfig', () => {
-      setState('configured')
+    it('resets all state and calls deleteConfig', async () => {
+      process.env.NOTION_TOKEN = 'token'
+      await resolveCredentialState()
       resetState()
       expect(getState()).toBe('awaiting_setup')
       expect(getNotionToken()).toBeNull()

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -190,10 +190,6 @@ function tryOpenBrowser(url: string): void {
   }
 }
 
-export function setState(state: CredentialState): void {
-  _state = state
-}
-
 export function resetState(): void {
   _state = 'awaiting_setup'
   _setupUrl = null


### PR DESCRIPTION
Removed the unused setState function and its export from src/credential-state.ts. Refactored src/credential-state.test.ts to remove dependencies on it, instead using public APIs (triggerRelaySetup and resolveCredentialState) to transition between states in test cases. All tests (747) passed and lint/format checks are clean.

---
*PR created automatically by Jules for task [4612098962281561676](https://jules.google.com/task/4612098962281561676) started by @n24q02m*