### PR TITLE
[TEST] Missing error path test in isSafeUrl

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -91,6 +91,28 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('.:foo')).toBe(false)
       expect(isSafeUrl('.&bar')).toBe(false)
       expect(isSafeUrl('.%3aabc')).toBe(false)
+      expect(isSafeUrl('/path/with:colon')).toBe(true)
+      expect(isSafeUrl('path?arg=foo:bar')).toBe(true)
+      expect(isSafeUrl('path#foo:bar')).toBe(true)
+    })
+
+    it('should handle malformed absolute but valid relative URLs (hitting inner try)', () => {
+      // These fail the first new URL() but pass the second with base URL
+      expect(isSafeUrl('[')).toBe(true)
+      expect(isSafeUrl(']')).toBe(true)
+      expect(isSafeUrl('{')).toBe(true)
+      expect(isSafeUrl('}')).toBe(true)
+      expect(isSafeUrl('|')).toBe(true)
+      expect(isSafeUrl('^')).toBe(true)
+      expect(isSafeUrl('`')).toBe(true)
+      expect(isSafeUrl('[:foo')).toBe(false)
+      expect(isSafeUrl('&:foo')).toBe(false)
+    })
+
+    it('should handle empty or near-empty strings', () => {
+      expect(isSafeUrl('')).toBe(true)
+      expect(isSafeUrl('.')).toBe(true)
+      expect(isSafeUrl('..')).toBe(true)
     })
   })
 


### PR DESCRIPTION
This PR addresses a missing error path test in the `isSafeUrl` function within `src/tools/helpers/security.ts`. 

Specifically, it adds tests for:
- Malformed absolute URLs that fail initial parsing but are valid as relative URLs, thereby hitting the inner `try-catch` block for deeper validation.
- Edge cases including empty strings and near-empty strings (e.g., ".", "..").
- More complex relative URL scenarios involving delimiters like `?` and `#` combined with suspicious prefixes.

These additions ensure that the security logic for URL validation is thoroughly exercised and that code coverage for the `security.ts` helper remains at 100%.

---
*PR created automatically by Jules for task [8194237558341848868](https://jules.google.com/task/8194237558341848868) started by @n24q02m*