### PR TITLE
[FIX] Notion API bug test

### DIFF
--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -248,14 +248,14 @@ describe('aiReadableMessage', () => {
     const error = new NotionMCPError('Page not found', 'NOT_FOUND', 'Check the ID')
     const msg = aiReadableMessage(error)
 
-    expect(msg).toBe('Error: Page not found\n\nSuggestion: Check the ID')
+    expect(msg).toBe('Error [NOT_FOUND]: Page not found\n\nSuggestion: Check the ID')
   })
 
   it('should format error without suggestion', () => {
     const error = new NotionMCPError('Something failed', 'UNKNOWN')
     const msg = aiReadableMessage(error)
 
-    expect(msg).toBe('Error: Something failed')
+    expect(msg).toBe('Error [UNKNOWN]: Something failed')
     expect(msg).not.toContain('Suggestion')
   })
 
@@ -263,7 +263,7 @@ describe('aiReadableMessage', () => {
     const error = new NotionMCPError('Bad input', 'VALIDATION_ERROR', undefined, { field: 'title' })
     const msg = aiReadableMessage(error)
 
-    expect(msg).toContain('Error: Bad input')
+    expect(msg).toContain('Error [VALIDATION_ERROR]: Bad input')
     expect(msg).not.toContain('Suggestion')
     expect(msg).toContain('Details:')
     expect(msg).toContain('"field": "title"')
@@ -273,7 +273,7 @@ describe('aiReadableMessage', () => {
     const error = new NotionMCPError('Bad input', 'VALIDATION_ERROR', 'Fix it', { field: 'title' })
     const msg = aiReadableMessage(error)
 
-    expect(msg).toContain('Error: Bad input')
+    expect(msg).toContain('Error [VALIDATION_ERROR]: Bad input')
     expect(msg).toContain('Suggestion: Fix it')
     expect(msg).toContain('Details:')
   })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -228,7 +228,7 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
  * Create AI-readable error message
  */
 export function aiReadableMessage(error: NotionMCPError): string {
-  let message = `Error: ${error.message}`
+  let message = `Error [${error.code}]: ${error.message}`
 
   if (error.suggestion) {
     message += `\n\nSuggestion: ${error.suggestion}`

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -527,7 +527,7 @@ describe('registerTools', () => {
 
       expect(result.isError).toBe(true)
       expect(result.content[0].type).toBe('text')
-      expect(result.content[0].text).toContain('Error: Page not found')
+      expect(result.content[0].text).toContain('Error [NOT_FOUND]: Page not found')
       expect(result.content[0].text).toContain('Suggestion: Check the ID')
     })
 
@@ -540,7 +540,7 @@ describe('registerTools', () => {
       })
 
       expect(result.isError).toBe(true)
-      expect(result.content[0].text).toContain('Error: Something unexpected broke')
+      expect(result.content[0].text).toContain('Error [TOOL_ERROR]: Something unexpected broke')
       expect(result.content[0].text).toContain('Suggestion: Check the error details and try again')
     })
 


### PR DESCRIPTION
This PR includes the Notion MCP error code in the AI-readable message format.

The change was prompted by a known Notion API bug where `comments.list` returns a 404 with OAuth tokens. The codebase handles this by catching the 404 and re-throwing a custom `COMMENTS_LIST_UNAVAILABLE` error if the page is confirmed to exist.

However, the live integration test `tests/live/full-notion.full.test.ts` was failing to verify this fix because it checks the tool result text for the string 'COMMENTS_LIST_UNAVAILABLE', which was previously missing from the AI-readable output.

By updating `aiReadableMessage` to include the error code in brackets (e.g., `Error [COMMENTS_LIST_UNAVAILABLE]: ...`), we allow the test suite and AI agents to programmatically identify specific error types from the text response.

- Updated `src/tools/helpers/errors.ts` to include the error code in `aiReadableMessage`.
- Updated unit tests in `src/tools/helpers/errors.test.ts` and `src/tools/registry.test.ts` to match the new format.

---
*PR created automatically by Jules for task [7541746398107264229](https://jules.google.com/task/7541746398107264229) started by @n24q02m*