### PR TITLE
[FIX] Actionable TODO for Notion Token Error Message

### DIFF
--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -100,7 +100,7 @@ export async function triggerRelaySetup(): Promise<string | null> {
       session = await createSession(relayUrl, SERVER_NAME, RELAY_SCHEMA)
     } catch {
       console.error(
-        `Cannot reach relay server at ${relayUrl}. Set NOTION_TOKEN manually.\nGet your token from https://www.notion.so/my-integrations`
+        `Cannot reach relay server at ${relayUrl}. Set NOTION_TOKEN manually.\nGet your token from https://www.notion.so/my-integrations. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx`
       )
       _state = 'awaiting_setup'
       return null

--- a/src/relay-setup.ts
+++ b/src/relay-setup.ts
@@ -46,7 +46,7 @@ export async function ensureConfig(): Promise<string | null> {
     session = await createSession(relayUrl, SERVER_NAME, RELAY_SCHEMA)
   } catch {
     console.error(
-      `Cannot reach relay server at ${relayUrl}. Set NOTION_TOKEN manually.\nGet your token from https://www.notion.so/my-integrations`
+      `Cannot reach relay server at ${relayUrl}. Set NOTION_TOKEN manually.\nGet your token from https://www.notion.so/my-integrations. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx`
     )
     return null
   }

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -119,7 +119,7 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
     message: 'Invalid or missing Notion API token',
     code: 'UNAUTHORIZED',
     suggestion:
-      'Set NOTION_TOKEN environment variable with a valid integration token from https://www.notion.so/my-integrations'
+      'Set NOTION_TOKEN environment variable with a valid integration token from https://www.notion.so/my-integrations. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx'
   },
   restricted_resource: {
     message: 'Integration does not have access to this resource',
@@ -250,7 +250,7 @@ export function suggestFixes(error: NotionMCPError): string[] {
   switch (error.code) {
     case 'UNAUTHORIZED':
       suggestions.push('Check that NOTION_TOKEN is set in your environment')
-      suggestions.push('Verify token at https://www.notion.so/my-integrations')
+      suggestions.push('Verify token at https://www.notion.so/my-integrations. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx')
       suggestions.push('Create a new integration token if needed')
       break
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -471,7 +471,7 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
         }
         const url = getSetupUrl()
         const setupInstructions = url
-          ? `Setup in progress. Open this URL to configure your Notion token:\n${url}\n\nOr set NOTION_TOKEN manually in your MCP server config.`
+          ? `Setup in progress. Open this URL to configure your Notion token:\n${url}\n\nOr set NOTION_TOKEN manually in your MCP server config. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx`
           : 'NOTION_TOKEN environment variable is not set. Get your integration token from https://www.notion.so/my-integrations and set it as NOTION_TOKEN in your MCP server config. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx'
         return {
           content: [{ type: 'text', text: setupInstructions }],

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -38,7 +38,7 @@ export async function startHttp() {
       throw new NotionMCPError(
         'Notion token not configured',
         'NOT_CONFIGURED',
-        `Open /authorize on this server in your browser to paste your Notion integration token. Get a token at https://www.notion.so/my-integrations`
+        `Open /authorize on this server in your browser to paste your Notion integration token. Get a token at https://www.notion.so/my-integrations. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx`
       )
     }
     return new Client({ auth: currentToken, notionVersion: '2025-09-03' })

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -32,7 +32,7 @@ export async function startStdio() {
     console.error(
       'Warning: NOTION_TOKEN not set. help and content_convert tools available; other tools will show setup instructions.'
     )
-    console.error('Get your token from https://www.notion.so/my-integrations')
+    console.error('Get your token from https://www.notion.so/my-integrations. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx')
 
     notionClientFactory = () => {
       // Check if token was acquired via background relay poll since startup
@@ -50,7 +50,7 @@ export async function startStdio() {
 
       const setupUrl = getSetupUrl()
       const setupInstructions = setupUrl
-        ? `Setup in progress. Open this URL to configure your Notion token:\n${setupUrl}\n\nOr set NOTION_TOKEN manually in your MCP server config.`
+        ? `Setup in progress. Open this URL to configure your Notion token:\n${setupUrl}\n\nOr set NOTION_TOKEN manually in your MCP server config. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx`
         : 'NOTION_TOKEN environment variable is not set. Get your integration token from https://www.notion.so/my-integrations and set it as NOTION_TOKEN in your MCP server config. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx'
       throw new NotionMCPError('Notion token not configured', 'NOT_CONFIGURED', setupInstructions)
     }


### PR DESCRIPTION
Standardized the Notion integration token error messages across the codebase to ensure they are actionable and consistent. Each message now includes the official integration URL and a clear example of the token format (NOTION_TOKEN=ntn_xxxxxxxxxxxxx). This resolves the actionable TODO for making the error message more helpful.

---
*PR created automatically by Jules for task [10215649062826614921](https://jules.google.com/task/10215649062826614921) started by @n24q02m*