### PR TITLE
[FIX] Missing Cache

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as markdown from '../helpers/markdown.js'
-import { blocks } from './blocks'
+import { blockCache, blocks } from './blocks'
 
 const mockNotion = {
   blocks: {
@@ -17,6 +17,7 @@ const mockNotion = {
 describe('blocks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockCache.clear()
   })
 
   describe('validation', () => {
@@ -423,6 +424,102 @@ describe('blocks', () => {
       await expect(blocks(mockNotion as any, { action: 'invalid' as any, block_id: 'block-1' })).rejects.toThrow(
         'Unknown action: invalid'
       )
+    })
+  })
+
+  describe('caching', () => {
+    it('should use cache for get action', async () => {
+      const mockBlock = {
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      }
+      mockNotion.blocks.retrieve.mockResolvedValue(mockBlock)
+
+      // First call - should call API
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Second call - should use cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+    })
+
+    it('should use cache for update action (retrieval phase)', async () => {
+      const mockBlock = {
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      }
+      mockNotion.blocks.retrieve.mockResolvedValue(mockBlock)
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      // Populate cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Update call - should use cache for retrieve
+      await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: 'new content'
+      })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+      expect(mockNotion.blocks.update).toHaveBeenCalledTimes(1)
+    })
+
+    it('should invalidate cache after update', async () => {
+      const mockBlock = {
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      }
+      mockNotion.blocks.retrieve.mockResolvedValue(mockBlock)
+      mockNotion.blocks.update.mockResolvedValue({})
+
+      // Populate cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Update call - invalidates cache
+      await blocks(mockNotion as any, {
+        action: 'update',
+        block_id: 'block-1',
+        content: 'new content'
+      })
+
+      // Next get call - should call API again
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
+    })
+
+    it('should invalidate cache after delete', async () => {
+      const mockBlock = {
+        id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        paragraph: { rich_text: [] }
+      }
+      mockNotion.blocks.retrieve.mockResolvedValue(mockBlock)
+      mockNotion.blocks.delete.mockResolvedValue({})
+
+      // Populate cache
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Delete call - invalidates cache
+      await blocks(mockNotion as any, { action: 'delete', block_id: 'block-1' })
+
+      // Next get call - should call API again
+      await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -4,6 +4,10 @@
  */
 
 import type { Client } from '@notionhq/client'
+// Cache for block metadata
+export const blockCache = new Map<string, { block: any; expiresAt: number }>()
+const BLOCK_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren } from '../helpers/pagination.js'
@@ -14,6 +18,25 @@ export interface BlocksInput {
   content?: string // Markdown format
   position?: 'start' | 'end' | 'after_block'
   after_block_id?: string
+}
+
+/**
+ * Get block metadata with caching
+ */
+async function getBlock(notion: Client, blockId: string): Promise<any> {
+  const cached = blockCache.get(blockId)
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.block
+  }
+
+  const block: any = await notion.blocks.retrieve({ block_id: blockId })
+
+  blockCache.set(blockId, {
+    block,
+    expiresAt: Date.now() + BLOCK_CACHE_TTL
+  })
+
+  return block
 }
 
 /**
@@ -28,7 +51,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
     switch (input.action) {
       case 'get': {
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        const block = await getBlock(notion, input.block_id)
         return {
           action: 'get',
           block_id: block.id,
@@ -94,7 +117,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
         if (!input.content) {
           throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
         }
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        const block = await getBlock(notion, input.block_id)
         const blockType = block.type
         const newBlocks = markdownToBlocks(input.content)
 
@@ -157,6 +180,8 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
           ...updatePayload
         } as any)
 
+        blockCache.delete(input.block_id)
+
         return {
           action: 'update',
           block_id: input.block_id,
@@ -167,6 +192,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
       case 'delete': {
         await notion.blocks.delete({ block_id: input.block_id })
+        blockCache.delete(input.block_id)
         return {
           action: 'delete',
           block_id: input.block_id,


### PR DESCRIPTION
Add caching strategy to blocks composite tool to reduce redundant Notion API calls.

Changes:
- Implemented `blockCache` (Map) with a 5-minute TTL in `src/tools/composite/blocks.ts`.
- Added `getBlock` helper to check cache before calling `notion.blocks.retrieve`.
- Updated 'get' and 'update' actions to use the cache.
- Implemented cache invalidation in 'update' and 'delete' actions upon success.
- Updated `src/tools/composite/blocks.test.ts` to ensure test isolation (clearing cache in `beforeEach`) and added tests for cache hits and invalidation.

---
*PR created automatically by Jules for task [5005749197516321043](https://jules.google.com/task/5005749197516321043) started by @n24q02m*