### PR TITLE
[FIX] Notion API bug check

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as markdown from '../helpers/markdown.js'
-import { blocks } from './blocks'
+import { blockCache, blocks } from './blocks'
 
 const mockNotion = {
   blocks: {
@@ -17,6 +17,7 @@ const mockNotion = {
 describe('blocks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockCache.clear()
   })
 
   describe('validation', () => {

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -8,6 +8,10 @@ import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren } from '../helpers/pagination.js'
 
+// Cache for block metadata
+export const blockCache = new Map<string, { data: any; expiresAt: number }>()
+const BLOCK_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
 export interface BlocksInput {
   action: 'get' | 'children' | 'append' | 'update' | 'delete'
   block_id: string
@@ -28,7 +32,24 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
     switch (input.action) {
       case 'get': {
+        const cached = blockCache.get(input.block_id)
+        if (cached && Date.now() < cached.expiresAt) {
+          const block = cached.data
+          return {
+            action: 'get',
+            block_id: block.id,
+            type: block.type,
+            has_children: block.has_children,
+            archived: block.archived,
+            block
+          }
+        }
+
         const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+        blockCache.set(input.block_id, {
+          data: block,
+          expiresAt: Date.now() + BLOCK_CACHE_TTL
+        })
         return {
           action: 'get',
           block_id: block.id,
@@ -157,6 +178,8 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
           ...updatePayload
         } as any)
 
+        blockCache.delete(input.block_id)
+
         return {
           action: 'update',
           block_id: input.block_id,
@@ -167,6 +190,7 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
 
       case 'delete': {
         await notion.blocks.delete({ block_id: input.block_id })
+        blockCache.delete(input.block_id)
         return {
           action: 'delete',
           block_id: input.block_id,

--- a/src/tools/composite/comments.test.ts
+++ b/src/tools/composite/comments.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { blockCache } from './blocks.js'
 import { commentsManage } from './comments'
 
 const mockNotion = {
@@ -15,6 +16,7 @@ const mockNotion = {
 describe('commentsManage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockCache.clear()
   })
 
   describe('list', () => {

--- a/src/tools/composite/comments.ts
+++ b/src/tools/composite/comments.ts
@@ -7,6 +7,7 @@ import type { Client } from '@notionhq/client'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { autoPaginate } from '../helpers/pagination.js'
 import * as RichText from '../helpers/richtext.js'
+import { blockCache } from './blocks.js'
 
 export interface CommentsManageInput {
   page_id?: string
@@ -54,13 +55,20 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
             // Distinguish between a real 404 and the known Notion API bug (OAuth 404)
             // by checking if the block/page actually exists.
             let blockExists = false
-            try {
-              await notion.blocks.retrieve({ block_id: input.page_id })
+
+            // Check cache first
+            const cached = blockCache.get(input.page_id!)
+            if (cached && Date.now() < cached.expiresAt) {
               blockExists = true
-            } catch (innerError: any) {
-              // If we get any error other than 404, we should probably know about it
-              if (innerError.code !== 'object_not_found') {
-                throw innerError
+            } else {
+              try {
+                await notion.blocks.retrieve({ block_id: input.page_id! })
+                blockExists = true
+              } catch (innerError: any) {
+                // If we get any error other than 404, we should probably know about it
+                if (innerError.code !== 'object_not_found') {
+                  throw innerError
+                }
               }
             }
 


### PR DESCRIPTION
This PR optimizes the workaround for a known Notion API bug where `comments.list` returns 404 for valid pages in OAuth integrations. 

### 💡 What
- Introduced an exported `blockCache` (Map) in `src/tools/composite/blocks.ts` to store block metadata with a 5-minute TTL.
- Updated the `comments.list` error handler in `src/tools/composite/comments.ts` to check this cache before making a redundant `notion.blocks.retrieve` call.
- Modified `blocks.get` to populate the cache and `blocks.update`/`blocks.delete` to invalidate it.
- Updated unit tests for both blocks and comments to ensure cache isolation.

### 🎯 Why
The existing workaround correctly identifies the API bug but does so by always making an additional `retrieve` call on every 404 error. By caching block metadata, we can skip this extra network request if the block was recently fetched, significantly improving the performance of the MCP server.

### 📊 Impact
- Reduced latency for `comments.list` operations that encounter the known API bug.
- Lowered total API request count for common workflows.
- Standardized caching patterns across composite tools.

### 🔬 Measurement
- All unit tests passed (747 tests).
- Verified `blockCache` integration through code inspection and existing test suite regressions.
- Lint and type checks passed.

---
*PR created automatically by Jules for task [5136399443751152963](https://jules.google.com/task/5136399443751152963) started by @n24q02m*