### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in tryOpenBrowser

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -212,10 +212,10 @@ describe('credential-state', () => {
     it('calls open on darwin', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'https://example.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('open', ['https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -228,10 +228,10 @@ describe('credential-state', () => {
     it('calls cmd on win32', async () => {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'https://example.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -244,10 +244,10 @@ describe('credential-state', () => {
     it('calls xdg-open on other platforms', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'https://example.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('xdg-open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('xdg-open', ['https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -262,7 +262,10 @@ describe('credential-state', () => {
     it('cleans up active session on SIGINT', async () => {
       vi.useRealTimers()
       const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(createSession).mockResolvedValue({ sessionId: 'exit-session-int', relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({
+        sessionId: 'exit-session-int',
+        relayUrl: 'https://example.com'
+      } as any)
 
       await triggerRelaySetup()
       process.emit('SIGINT' as any)
@@ -278,7 +281,10 @@ describe('credential-state', () => {
     it('cleans up active session on SIGTERM', async () => {
       vi.useRealTimers()
       const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(createSession).mockResolvedValue({ sessionId: 'exit-session-term', relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({
+        sessionId: 'exit-session-term',
+        relayUrl: 'https://example.com'
+      } as any)
 
       await triggerRelaySetup()
       process.emit('SIGTERM' as any)
@@ -295,7 +301,7 @@ describe('credential-state', () => {
       vi.useRealTimers()
       vi.mocked(fetch).mockRejectedValue(new Error('network error'))
       const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(createSession).mockResolvedValue({ sessionId: 'error-session', relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ sessionId: 'error-session', relayUrl: 'https://example.com' } as any)
 
       await triggerRelaySetup()
       process.emit('SIGINT' as any)

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,12 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) {
+    console.error(`Refused to open unsafe URL in browser: ${url}`)
+    return
+  }
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -64,3 +64,33 @@ export function wrapToolResult(toolName: string, jsonText: string): string {
 
   return `<untrusted_notion_content>\n${jsonText}\n</untrusted_notion_content>\n\n${SAFETY_WARNING}`
 }
+
+/**
+ * Validates a web URL for safe opening in external browsers.
+ * Stricter than isSafeUrl: requires http/https and prevents shell flag injection.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  // Reject empty URLs
+  if (!url || typeof url !== 'string') {
+    return false
+  }
+
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security sanitization
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  // Prevent shell flag injection (if URL is passed as an argument starting with -)
+  if (url.startsWith('-')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    // Only allow standard web protocols
+    return ['http:', 'https:'].includes(parsed.protocol.toLowerCase())
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `tryOpenBrowser` function accepts arbitrary string inputs and directly passes them to `execFile`. While `execFile` prevents arbitrary shell command execution, it is still vulnerable to **shell argument/flag injection** if an argument starts with a `-`. An attacker could pass flags to `open`, `cmd`, or `xdg-open` leading to unintended behavior or local file access if `file://` protocols are permitted.
🎯 **Impact**: Potential localized command flag injection and unauthorized local file access during the authentication flow via manipulated relay URLs.
🔧 **Fix**: 
- Created `isSafeWebUrl` in `src/tools/helpers/security.ts` to strictly validate web URLs. It rejects leading hyphens (`-`), whitespace, control characters, and enforces `http:` or `https:` protocols.
- Updated `tryOpenBrowser` in `src/credential-state.ts` to block execution and log an error if the URL is deemed unsafe.
- Updated the tests in `src/credential-state.test.ts` to use `https://example.com` instead of the non-compliant `url` to properly test the workflow under the new security restrictions.
- Logged the learning securely in `.jules/sentinel.md`.

✅ **Verification**: 
- `bun run check:fix` passes.
- `bun run test` completes entirely with no regressions.

---
*PR created automatically by Jules for task [5111994302741739132](https://jules.google.com/task/5111994302741739132) started by @n24q02m*