### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection risk in tryOpenBrowser

### DIFF
--- a/add_isSafeWebUrl.py
+++ b/add_isSafeWebUrl.py
@@ -1,0 +1,42 @@
+import sys
+
+with open('src/tools/helpers/security.ts', 'r') as f:
+    content = f.read()
+
+new_func = """
+
+/**
+ * Strict validation for browser-destined URLs.
+ * Allows only http: and https: protocols.
+ * Rejects leading hyphens to prevent shell flag injection.
+ * Rejects whitespace and control characters.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  if (!url || typeof url !== 'string') {
+    return false
+  }
+
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Security sanitization
+  if (/[\\s\\x00-\\x1F\\x7F]/.test(url)) {
+    return false
+  }
+
+  // Reject leading hyphens which might be parsed as shell flags
+  if (url.startsWith('-')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+"""
+
+content += new_func
+
+with open('src/tools/helpers/security.ts', 'w') as f:
+    f.write(content)

--- a/add_isSafeWebUrl_tests.py
+++ b/add_isSafeWebUrl_tests.py
@@ -1,0 +1,50 @@
+import sys
+
+with open('src/tools/helpers/security.test.ts', 'r') as f:
+    content = f.read()
+
+# Update the import
+content = content.replace("import { isSafeUrl, wrapToolResult } from './security'", "import { isSafeUrl, wrapToolResult, isSafeWebUrl } from './security'")
+
+new_tests = """
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com')).toBe(true)
+    })
+
+    it('should reject non-http/https protocols', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+    })
+
+    it('should reject URLs with control characters and whitespace', () => {
+      expect(isSafeWebUrl(' https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com ')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\\n')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\\r')).toBe(false)
+      expect(isSafeWebUrl('\\x00https://example.com')).toBe(false)
+    })
+
+    it('should reject URLs with leading hyphens', () => {
+      expect(isSafeWebUrl('-https://example.com')).toBe(false)
+      expect(isSafeWebUrl('--flag')).toBe(false)
+    })
+
+    it('should reject malformed URLs that fail parsing', () => {
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('just-a-string')).toBe(false)
+      expect(isSafeWebUrl('http://[')).toBe(false)
+    })
+  })
+"""
+
+# Insert the new tests before the last describe block
+parts = content.split("  describe('wrapToolResult', () => {")
+content = parts[0] + new_tests + "\n  describe('wrapToolResult', () => {" + parts[1]
+
+with open('src/tools/helpers/security.test.ts', 'w') as f:
+    f.write(content)

--- a/secure_tryOpenBrowser.py
+++ b/secure_tryOpenBrowser.py
@@ -1,0 +1,40 @@
+import sys
+
+with open('src/credential-state.ts', 'r') as f:
+    content = f.read()
+
+# Add import
+import_stmt = "import { isSafeWebUrl } from './tools/helpers/security.js'\n"
+content = content.replace("import { RELAY_SCHEMA } from './relay-schema.js'", "import { RELAY_SCHEMA } from './relay-schema.js'\n" + import_stmt)
+
+# Update tryOpenBrowser
+old_func = """function tryOpenBrowser(url: string): void {
+  const platform = process.platform
+
+  if (platform === 'darwin') {
+    execFile('open', [url], () => {})
+  } else if (platform === 'win32') {
+    execFile('cmd', ['/c', 'start', '', url], () => {})
+  } else {
+    execFile('xdg-open', [url], () => {})
+  }
+}"""
+
+new_func = """export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) return
+
+  const platform = process.platform
+
+  if (platform === 'darwin') {
+    execFile('open', [url], () => {})
+  } else if (platform === 'win32') {
+    execFile('cmd', ['/c', 'start', '', url], () => {})
+  } else {
+    execFile('xdg-open', [url], () => {})
+  }
+}"""
+
+content = content.replace(old_func, new_func)
+
+with open('src/credential-state.ts', 'w') as f:
+    f.write(content)

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -212,10 +212,10 @@ describe('credential-state', () => {
     it('calls open on darwin', async () => {
       Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'https://example.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('open', ['https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -228,10 +228,10 @@ describe('credential-state', () => {
     it('calls cmd on win32', async () => {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'https://example.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -244,10 +244,10 @@ describe('credential-state', () => {
     it('calls xdg-open on other platforms', async () => {
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
 
-      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ relayUrl: 'https://example.com' } as any)
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('xdg-open', ['url'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith('xdg-open', ['https://example.com'], expect.any(Function))
       // Trigger callback for coverage
       const callback = vi.mocked(execFile).mock.calls[0][2] as (
         error: Error | null,
@@ -262,7 +262,10 @@ describe('credential-state', () => {
     it('cleans up active session on SIGINT', async () => {
       vi.useRealTimers()
       const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(createSession).mockResolvedValue({ sessionId: 'exit-session-int', relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({
+        sessionId: 'exit-session-int',
+        relayUrl: 'https://example.com'
+      } as any)
 
       await triggerRelaySetup()
       process.emit('SIGINT' as any)
@@ -278,7 +281,10 @@ describe('credential-state', () => {
     it('cleans up active session on SIGTERM', async () => {
       vi.useRealTimers()
       const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(createSession).mockResolvedValue({ sessionId: 'exit-session-term', relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({
+        sessionId: 'exit-session-term',
+        relayUrl: 'https://example.com'
+      } as any)
 
       await triggerRelaySetup()
       process.emit('SIGTERM' as any)
@@ -295,7 +301,7 @@ describe('credential-state', () => {
       vi.useRealTimers()
       vi.mocked(fetch).mockRejectedValue(new Error('network error'))
       const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(createSession).mockResolvedValue({ sessionId: 'error-session', relayUrl: 'url' } as any)
+      vi.mocked(createSession).mockResolvedValue({ sessionId: 'error-session', relayUrl: 'https://example.com' } as any)
 
       await triggerRelaySetup()
       process.emit('SIGINT' as any)

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -14,6 +14,7 @@ import type { RelaySession } from '@n24q02m/mcp-core'
 import { createSession, deleteConfig, pollForResult, sendMessage, writeConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { RELAY_SCHEMA } from './relay-schema.js'
+import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
@@ -178,7 +179,9 @@ async function pollRelayBackground(relayBaseUrl: string, session: RelaySession):
  * Try to open URL in default browser (best-effort).
  * Uses execFile (not exec) to avoid shell injection.
  */
-function tryOpenBrowser(url: string): void {
+export function tryOpenBrowser(url: string): void {
+  if (!isSafeWebUrl(url)) return
+
   const platform = process.platform
 
   if (platform === 'darwin') {

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
   describe('isSafeUrl', () => {
@@ -91,6 +91,40 @@ describe('Security Utilities', () => {
       expect(isSafeUrl('.:foo')).toBe(false)
       expect(isSafeUrl('.&bar')).toBe(false)
       expect(isSafeUrl('.%3aabc')).toBe(false)
+    })
+  })
+
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com')).toBe(true)
+    })
+
+    it('should reject non-http/https protocols', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+      expect(isSafeWebUrl('file:///etc/passwd')).toBe(false)
+    })
+
+    it('should reject URLs with control characters and whitespace', () => {
+      expect(isSafeWebUrl(' https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com ')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\n')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\r')).toBe(false)
+      expect(isSafeWebUrl('\x00https://example.com')).toBe(false)
+    })
+
+    it('should reject URLs with leading hyphens', () => {
+      expect(isSafeWebUrl('-https://example.com')).toBe(false)
+      expect(isSafeWebUrl('--flag')).toBe(false)
+    })
+
+    it('should reject malformed URLs that fail parsing', () => {
+      expect(isSafeWebUrl('/relative/path')).toBe(false)
+      expect(isSafeWebUrl('just-a-string')).toBe(false)
+      expect(isSafeWebUrl('http://[')).toBe(false)
     })
   })
 

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -64,3 +64,33 @@ export function wrapToolResult(toolName: string, jsonText: string): string {
 
   return `<untrusted_notion_content>\n${jsonText}\n</untrusted_notion_content>\n\n${SAFETY_WARNING}`
 }
+
+/**
+ * Strict validation for browser-destined URLs.
+ * Allows only http: and https: protocols.
+ * Rejects leading hyphens to prevent shell flag injection.
+ * Rejects whitespace and control characters.
+ */
+export function isSafeWebUrl(url: string): boolean {
+  if (!url || typeof url !== 'string') {
+    return false
+  }
+
+  // Reject URLs containing whitespace or control characters
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Security sanitization
+  if (/[\s\x00-\x1F\x7F]/.test(url)) {
+    return false
+  }
+
+  // Reject leading hyphens which might be parsed as shell flags
+  if (url.startsWith('-')) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return ['http:', 'https:'].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}

--- a/update_credential_state_tests.py
+++ b/update_credential_state_tests.py
@@ -1,0 +1,14 @@
+import sys
+
+with open('src/credential-state.test.ts', 'r') as f:
+    content = f.read()
+
+# We only want to replace 'url' with 'https://example.com' in specific contexts.
+# The `url` is used mostly in mock objects or arguments passed to commands.
+
+content = content.replace("relayUrl: 'url'", "relayUrl: 'https://example.com'")
+content = content.replace("['url']", "['https://example.com']")
+content = content.replace("'', 'url']", "'', 'https://example.com']")
+
+with open('src/credential-state.test.ts', 'w') as f:
+    f.write(content)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `tryOpenBrowser` in `src/credential-state.ts` used unvalidated input in `execFile`. If an attacker managed to pass a URL starting with a hyphen, it could have been interpreted as an executable flag instead of an argument, potentially leading to command injection or DoS.
🎯 Impact: Exploiting this requires controlling the `url` returned from `session.relayUrl`, which is a lower probability, but the impact of arbitrary flags to `open` or `xdg-open` is high. 
🔧 Fix: Implemented `isSafeWebUrl` in `src/tools/helpers/security.ts` to strictly validate URLs for `http:` and `https:`, reject whitespace and control characters, and reject leading hyphens. Added a guard to `tryOpenBrowser` utilizing this validator.
✅ Verification: Ran `bun run test` to verify `isSafeUrl` and `tryOpenBrowser` functionality, all 756 tests pass.

---
*PR created automatically by Jules for task [8831590320477863421](https://jules.google.com/task/8831590320477863421) started by @n24q02m*