### PR TITLE
fix: bump @n24q02m/mcp-core to ^1.4.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.4.0",
+        "@n24q02m/mcp-core": "^1.4.1",
         "@notionhq/client": "^5.19.0",
         "zod": "^4.3.6",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.8.0", "env-paths": "^3.0.0", "jose": "^6.2.2" } }, "sha512-4eFZffN5OqbfDoHGfOoJgBaD/43A4Qkp8XczLMfriLERsfErSV4V+P/yhluiS6HkIJENub7oTnlPANv8LH+M/g=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.4.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.8.0", "env-paths": "^3.0.0", "jose": "^6.2.2" } }, "sha512-JxwrbuNPFkJ9/JVHxfi7ui0RPJK8RRYUzB8dp7Jq+vDDYZzEw/DI60i5RkK65YrIswbI4mNiN62bzj+3Zf0IjA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.4.0",
+    "@n24q02m/mcp-core": "^1.4.1",
     "@notionhq/client": "^5.19.0",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

Bumps `@n24q02m/mcp-core` from `^1.4.0` to `^1.4.1`.

mcp-core v1.4.1 contains the GET / auto-redirect fix for the delegated OAuth app. Without this, visiting the bare URL (https://better-notion-mcp.n24q02m.com/) returned 404 instead of kicking off the OAuth flow.

## Changes

- `package.json`: `@n24q02m/mcp-core` `^1.4.0` -> `^1.4.1`
- `bun.lock`: regenerated

## Test plan

- [x] `bun install` succeeds
- [x] `bun run type-check` passes
- [x] `bun run test` passes (757 tests green)
- [ ] CI green
- [ ] After merge + CD stable dispatch: verify https://better-notion-mcp.n24q02m.com/ redirects to OAuth (not 404)

Closes #555