### PR TITLE
fix: bump @n24q02m/mcp-core to 1.6.2 + fix remote-oauth multi-user

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.6.1",
+        "@n24q02m/mcp-core": "^1.6.2",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.6.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.2" } }, "sha512-OIlFsW3yunh4409xnd5iQHKaxAUClqRiM7mqYZA0YR5oNOxKGkRfQf5vaJTXxqElj4PzSjtm+9HDRvcbHLQPSA=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.6.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.2" } }, "sha512-w1CsepuQMToUZ6Q+uTMvD8vDSCk0rMvgH8K2okpLXxhnsnqmbBjTyQYpLLvUXW3cIMjlWMyU53L/5SM9/96yxg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.6.1",
+    "@n24q02m/mcp-core": "^1.6.2",
     "@notionhq/client": "^5.20.0",
     "zod": "^4.3.6"
   },

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -90,6 +90,11 @@ export async function startHttp(): Promise<void> {
           const accessToken = String(tokens.access_token ?? '')
           const sub = String((tokens as { owner_user_id?: string }).owner_user_id ?? 'default')
           if (accessToken) tokenStore.save(sub, accessToken)
+          // Return sub so mcp-core (>=1.6.2) propagates it into the bearer
+          // JWT's `sub` claim, which `authScope` below then matches back
+          // to the stored Notion token. Without this, bearer JWT sub is
+          // hardcoded 'local-user' -> tokenStore.get() returns undefined.
+          return sub
         }
       },
       authScope: async (claims, next) => {


### PR DESCRIPTION
Closes #572. Bumps pin and returns sub from onTokenReceived (requires mcp-core >=1.6.2).