### PR TITLE
fix: mark state=configured in remote-oauth mode

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -17,7 +17,7 @@ import { type RelayConfigSchema, runLocalServer, writeConfig } from '@n24q02m/mc
 import { Client } from '@notionhq/client'
 import { NotionTokenStore } from '../auth/notion-token-store.js'
 import { createMCPServer } from '../create-server.js'
-import { getNotionToken, resolveCredentialState } from '../credential-state.js'
+import { getNotionToken, resolveCredentialState, setState } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { NotionMCPError } from '../tools/helpers/errors.js'
 
@@ -102,6 +102,12 @@ export async function startHttp(): Promise<void> {
         await subjectContext.run({ sub }, next)
       }
     })
+    // In remote-oauth mode the server itself is fully configured once OAuth
+    // client credentials are validated; per-user Notion tokens live in
+    // `tokenStore` keyed by JWT sub, not in the single-user credential-state
+    // module. Mark state=configured so `config(action=status)` reflects
+    // server readiness (matrix step [7]).
+    setState('configured')
     console.error(`[${SERVER_NAME}] remote-oauth mode on http://${handle.host}:${handle.port}/mcp`)
   } else {
     handle = await runLocalServer(() => createMCPServer(notionClientFactory) as unknown as McpServer, {


### PR DESCRIPTION
## Summary

Found via E2E Phase 3 Config #1 (notion http remote-oauth):

- `credential-state._state` defaults to `'awaiting_setup'` and only flips to `'configured'` via the local-relay `onCredentialsSaved` callback
- In remote-oauth, per-user Notion tokens live in `NotionTokenStore` keyed by JWT sub — the state machine is never touched
- Result: `config(action=status)` returned `state=awaiting_setup` even on a fully-configured remote-oauth server
- Matrix step [7] requires `state=configured` in response → this was a FAIL

Fix: call `setState('configured')` after `runLocalServer(...)` succeeds in the remote-oauth branch. The server IS configured once OAuth client credentials are validated; per-user tokens are tracked separately.

## Test plan

- [x] 746 unit tests pass
- [x] Type check + biome
- [ ] E2E re-run Config #1: verify `state=configured` in config(status) response