### PR TITLE
fix: bump @n24q02m/mcp-core to 1.6.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.6.2",
+        "@n24q02m/mcp-core": "^1.6.3",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.6.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.2" } }, "sha512-w1CsepuQMToUZ6Q+uTMvD8vDSCk0rMvgH8K2okpLXxhnsnqmbBjTyQYpLLvUXW3cIMjlWMyU53L/5SM9/96yxg=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.6.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.2" } }, "sha512-7V8ZnhFngSkOCmQmIyjW9qJx4Ps4KAf+Pu7fcKgdHiApV1w9ZnIZuduibUVvqZ6eiV0Jmn6yK/XllQGyILdkCg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.6.2",
+    "@n24q02m/mcp-core": "^1.6.3",
     "@notionhq/client": "^5.20.0",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Summary

Pulls mcp-core 1.6.3 which fixes the relay credential form bug: on successful POST /authorize, the form now actually navigates the browser to `redirect_url` instead of showing a static "close tab" message. This was causing external OAuth clients (Python MCP SDK test harness, Claude Code CLI bearer, desktop apps) to hang forever while the user kept resubmitting.

Also bundles the v2.28.8 remote-oauth `setState('configured')` fix already on main.

## Test plan

- [x] 746/746 tests pass
- [x] Lint + type check
- [ ] E2E Config #1 re-run (remote-oauth) to verify still PASS
- [ ] E2E Config #2 re-run (local-relay) to verify callback fires + state=configured