### PR TITLE
fix: sync credential-state after local-relay token save

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -122,6 +122,11 @@ export async function startHttp(): Promise<void> {
           // Persist to encrypted config so the token survives process restarts
           // — otherwise the user would have to re-paste after every restart.
           await writeConfig(SERVER_NAME, { NOTION_TOKEN: token })
+          // Sync credential-state module so config(action=status) reports the
+          // up-to-date state (state=configured, has_token=true) without
+          // waiting for a process restart. Without this, `getState()` stays
+          // at its 'awaiting_setup' default even though the token is active.
+          await resolveCredentialState()
           console.error(`[${SERVER_NAME}] Notion token received via /authorize and saved`)
         }
         return null


### PR DESCRIPTION
Same bug class as remote-oauth fix in v2.28.8, but for the local-relay branch: onCredentialsSaved persists to config.enc + scope-local `localToken` but never updates credential-state module. Result: `config(action=status)` returns `state=awaiting_setup` + `has_token=false` after successful form submit.

Fix: call `resolveCredentialState()` after `writeConfig` — re-reads config.enc and sets both `_notionToken` + `_state=configured`.

Found via E2E Phase 3 Config #2 (local-relay) 2026-04-22.

## Test plan
- [x] 746/746 tests pass
- [ ] Config #2 re-run verify state=configured after submit