### PR TITLE
fix: report per-JWT-sub has_token in remote-oauth config status

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,12 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.7.0",
+        "@n24q02m/mcp-core": "^1.7.4",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.12",
+        "@biomejs/biome": "^2.4.13",
         "@types/node": "^24.12.2",
         "@vitest/coverage-v8": "^4.1.5",
         "esbuild": "^0.28.0",
@@ -35,23 +35,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.13", "@biomejs/cli-darwin-x64": "2.4.13", "@biomejs/cli-linux-arm64": "2.4.13", "@biomejs/cli-linux-arm64-musl": "2.4.13", "@biomejs/cli-linux-x64": "2.4.13", "@biomejs/cli-linux-x64-musl": "2.4.13", "@biomejs/cli-win32-arm64": "2.4.13", "@biomejs/cli-win32-x64": "2.4.13" }, "bin": { "biome": "bin/biome" } }, "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.13", "", { "os": "linux", "cpu": "x64" }, "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.13", "", { "os": "linux", "cpu": "x64" }, "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.13", "", { "os": "win32", "cpu": "x64" }, "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.7.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.2" } }, "sha512-SYNcjMhemp8FEGtX1LFCC89pWzA9u+R/a1rMIy3jLGIwLPAIoJep3lKJHaibGnsWH3RvWVuN7KxoO2Tv6fZRNg=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.7.5", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.2" } }, "sha512-QM0MxxWii8whr3yCnBXBiY7E/eRDIIRQT6IZWUrVThUklW1GBKEp+qi+dd0zaLdCtmffaET/sdV3S74tqgIJbQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.6.3",
+        "@n24q02m/mcp-core": "^1.7.4",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6"
       },
@@ -18,7 +18,7 @@
         "better-notion-mcp": "bin/cli.mjs"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.12",
+        "@biomejs/biome": "^2.4.13",
         "@types/node": "^24.12.2",
         "@vitest/coverage-v8": "^4.1.5",
         "esbuild": "^0.28.0",
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@n24q02m/mcp-core": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@n24q02m/mcp-core/-/mcp-core-1.6.3.tgz",
-      "integrity": "sha512-7V8ZnhFngSkOCmQmIyjW9qJx4Ps4KAf+Pu7fcKgdHiApV1w9ZnIZuduibUVvqZ6eiV0Jmn6yK/XllQGyILdkCg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@n24q02m/mcp-core/-/mcp-core-1.7.4.tgz",
+      "integrity": "sha512-0Mt5vYSC1j673UpTeRuI2+NVV1oUGf4ckUJEv0Lsie+JrGFpdCz4Thblmq2D05bCjkoXIxLTLmTFCig4wIFE7A==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.7.0",
+    "@n24q02m/mcp-core": "^1.7.4",
     "@notionhq/client": "^5.20.0",
     "zod": "^4.3.6"
   },
@@ -65,7 +65,7 @@
     "esbuild"
   ],
   "devDependencies": {
-    "@biomejs/biome": "^2.4.12",
+    "@biomejs/biome": "^2.4.13",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.5",
     "esbuild": "^0.28.0",

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -10,9 +10,11 @@ import {
   getNotionToken,
   getSetupUrl,
   getState,
+  getSubjectToken,
   resetState,
   resolveCredentialState,
   setState,
+  setSubjectTokenResolver,
   triggerRelaySetup
 } from './credential-state.js'
 
@@ -230,6 +232,34 @@ describe('credential-state', () => {
       process.emit('SIGINT' as any)
       await new Promise((resolve) => setTimeout(resolve, 50))
       expect(exitMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('subject token resolver', () => {
+    beforeEach(() => {
+      // Reset to default (module-global single-user fallback)
+      setSubjectTokenResolver(() => getNotionToken())
+    })
+
+    it('defaults to single-user module global when no resolver injected', () => {
+      setState('awaiting_setup')
+      expect(getSubjectToken()).toBeNull()
+    })
+
+    it('returns injected per-subject token for remote-oauth mode', () => {
+      let currentSub = 'alice'
+      const storeByAlice = 'ntn_alice_token'
+      const storeByBob = 'ntn_bob_token'
+      setSubjectTokenResolver(() => {
+        if (currentSub === 'alice') return storeByAlice
+        if (currentSub === 'bob') return storeByBob
+        return null
+      })
+      expect(getSubjectToken()).toBe(storeByAlice)
+      currentSub = 'bob'
+      expect(getSubjectToken()).toBe(storeByBob)
+      currentSub = 'unknown'
+      expect(getSubjectToken()).toBeNull()
     })
   })
 })

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -52,6 +52,24 @@ export function getNotionToken(): string | null {
 }
 
 /**
+ * Per-request token resolver. `local-relay` mode leaves the default resolver,
+ * which reads the single-user module global. `remote-oauth` mode injects a
+ * resolver that reads the per-JWT-sub `NotionTokenStore` so that
+ * `config(action=status)` reflects whether the CURRENT caller has a Notion
+ * access token — not whether the server process has any global token, which
+ * is always null in multi-user remote-oauth mode.
+ */
+let _subjectTokenResolver: () => string | null = () => _notionToken
+
+export function setSubjectTokenResolver(fn: () => string | null): void {
+  _subjectTokenResolver = fn
+}
+
+export function getSubjectToken(): string | null {
+  return _subjectTokenResolver()
+}
+
+/**
  * Fast, synchronous-ish credential check. Called during startup.
  *
  * Checks (in order):

--- a/src/tools/composite/config.test.ts
+++ b/src/tools/composite/config.test.ts
@@ -4,6 +4,8 @@ vi.mock('../../credential-state.js', () => ({
   getState: vi.fn(() => 'awaiting_setup'),
   getSetupUrl: vi.fn(() => null),
   getNotionToken: vi.fn(() => null),
+  getSubjectToken: vi.fn(() => null),
+  setSubjectTokenResolver: vi.fn(),
   triggerRelaySetup: vi.fn(),
   resetState: vi.fn(),
   resolveCredentialState: vi.fn()
@@ -13,6 +15,7 @@ import {
   getNotionToken,
   getSetupUrl,
   getState,
+  getSubjectToken,
   resetState,
   resolveCredentialState,
   triggerRelaySetup
@@ -26,6 +29,7 @@ describe('config', () => {
     vi.mocked(getState).mockReturnValue('awaiting_setup')
     vi.mocked(getSetupUrl).mockReturnValue(null)
     vi.mocked(getNotionToken).mockReturnValue(null)
+    vi.mocked(getSubjectToken).mockReturnValue(null)
   })
 
   describe('status action', () => {
@@ -42,6 +46,7 @@ describe('config', () => {
     it('should return configured state with relay token', async () => {
       vi.mocked(getState).mockReturnValue('configured')
       vi.mocked(getNotionToken).mockReturnValue('ntn_test123')
+      vi.mocked(getSubjectToken).mockReturnValue('ntn_test123')
       vi.mocked(getSetupUrl).mockReturnValue(null)
       // No env var
       delete process.env.NOTION_TOKEN
@@ -56,6 +61,7 @@ describe('config', () => {
     it('should return configured state with environment token', async () => {
       vi.mocked(getState).mockReturnValue('configured')
       vi.mocked(getNotionToken).mockReturnValue('ntn_env_token')
+      vi.mocked(getSubjectToken).mockReturnValue('ntn_env_token')
       process.env.NOTION_TOKEN = 'ntn_env_token'
 
       const result = await config({ action: 'status' })
@@ -137,6 +143,7 @@ describe('config', () => {
     it('should re-check credentials and return configured state', async () => {
       vi.mocked(resolveCredentialState).mockResolvedValue('configured')
       vi.mocked(getNotionToken).mockReturnValue('ntn_resolved')
+      vi.mocked(getSubjectToken).mockReturnValue('ntn_resolved')
 
       const result = await config({ action: 'setup_complete' })
 
@@ -150,6 +157,7 @@ describe('config', () => {
     it('should return awaiting_setup when no credentials found', async () => {
       vi.mocked(resolveCredentialState).mockResolvedValue('awaiting_setup')
       vi.mocked(getNotionToken).mockReturnValue(null)
+      vi.mocked(getSubjectToken).mockReturnValue(null)
 
       const result = await config({ action: 'setup_complete' })
 

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -5,9 +5,9 @@
  */
 
 import {
-  getNotionToken,
   getSetupUrl,
   getState,
+  getSubjectToken,
   resetState,
   resolveCredentialState,
   triggerRelaySetup
@@ -30,7 +30,7 @@ export async function config(input: ConfigInput): Promise<any> {
       case 'status': {
         const state = getState()
         const setupUrl = getSetupUrl()
-        const token = getNotionToken()
+        const token = getSubjectToken()
         return {
           action: 'status',
           state,
@@ -75,7 +75,7 @@ export async function config(input: ConfigInput): Promise<any> {
         return {
           action: 'setup_complete',
           state: newState,
-          has_token: getNotionToken() !== null,
+          has_token: getSubjectToken() !== null,
           message:
             newState === 'configured'
               ? 'Credentials verified. Notion tools are ready.'

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -17,7 +17,7 @@ import { type RelayConfigSchema, runLocalServer, writeConfig } from '@n24q02m/mc
 import { Client } from '@notionhq/client'
 import { NotionTokenStore } from '../auth/notion-token-store.js'
 import { createMCPServer } from '../create-server.js'
-import { getNotionToken, resolveCredentialState, setState } from '../credential-state.js'
+import { getNotionToken, resolveCredentialState, setState, setSubjectTokenResolver } from '../credential-state.js'
 import { RELAY_SCHEMA } from '../relay-schema.js'
 import { NotionMCPError } from '../tools/helpers/errors.js'
 
@@ -108,6 +108,13 @@ export async function startHttp(): Promise<void> {
     // module. Mark state=configured so `config(action=status)` reflects
     // server readiness (matrix step [7]).
     setState('configured')
+    // Route `getSubjectToken()` to the per-user store so
+    // `config(action=status).has_token` reflects whether THIS caller has
+    // authorized, instead of always-null single-user global.
+    setSubjectTokenResolver(() => {
+      const ctx = subjectContext.getStore()
+      return ctx ? (tokenStore.get(ctx.sub) ?? null) : null
+    })
     console.error(`[${SERVER_NAME}] remote-oauth mode on http://${handle.host}:${handle.port}/mcp`)
   } else {
     handle = await runLocalServer(() => createMCPServer(notionClientFactory) as unknown as McpServer, {


### PR DESCRIPTION
## Summary

`config(action=status).has_token` was always `false` in remote-oauth mode because it queried the single-user module global from `credential-state.ts` instead of the per-JWT-sub `NotionTokenStore`.

## Fix

- New `setSubjectTokenResolver()` / `getSubjectToken()` in `credential-state.ts`. Default resolver preserves single-user behavior (module global).
- `startHttp()` remote-oauth injects resolver reading `NotionTokenStore` by active `subjectContext.sub`.
- `config(action=status)` + `config(action=setup_complete)` use `getSubjectToken()`.
- Tests updated + new coverage for resolver dispatch.

## Context

Discovered 2026-04-24 during Phase 3 E2E Test A for config #1 (notion remote-oauth). Functional OAuth works — `workspace(action=info)` returns real workspace data — only the status report was wrong.

## Test plan
- [ ] 742/742 tests pass
- [ ] `bun run check` (biome + tsc) green
- [ ] Manual: deployed container → OAuth → `config(action=status)` returns `has_token: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)