### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Windows tryOpenBrowser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Authorization headers (like `Authorization` and `authorization`) were leaking within the HTTP error payload objects inside `config.headers`, `request._headers` and `headers` objects when `enhanceError` was called on network errors, as these nested properties were not cleaned by the `stripSensitiveFields` logic.
 **Learning:** Generic error serialization can unintentionally capture standard HTTP metadata which usually contains tokens or credentials, leading to unintended leakage when errors are output to clients or logs.
 **Prevention:** Always perform an explicit redaction of common auth-related header locations inside error response payloads that come from HTTP client instances before relaying error details outside of their execution context.
+
+## 2024-05-18 - Fix Command Injection on Windows via tryOpenBrowser
+**Vulnerability:** In `tryOpenBrowser`, using `execFile('cmd', ['/c', 'start', '', url])` to open URLs on Windows was vulnerable to command injection because `cmd.exe` processes shell metacharacters like `&` within its arguments before passing them to the internal `start` command, completely bypassing `execFile`'s usual protections against shell injection.
+**Learning:** `child_process.execFile` does not protect against shell injection when the executed binary is itself a shell (like `cmd.exe`). Any arguments passed to it will undergo normal shell parsing rules.
+**Prevention:** Avoid spawning shell binaries entirely for generic tasks. To open URLs on Windows securely without invoking `cmd.exe`, use the OS-level file protocol handler directly via `execFile('rundll32', ['url.dll,FileProtocolHandler', url])`.

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -192,13 +192,17 @@ describe('credential-state', () => {
       expect(execFile).toHaveBeenCalledWith('open', ['http://127.0.0.1:7001/'], expect.any(Function))
     })
 
-    it('calls cmd on win32', async () => {
+    it('calls rundll32 on win32', async () => {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
       vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ port: 7002 }) as any)
 
       await triggerRelaySetup()
 
-      expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'http://127.0.0.1:7002/'], expect.any(Function))
+      expect(execFile).toHaveBeenCalledWith(
+        'rundll32',
+        ['url.dll,FileProtocolHandler', 'http://127.0.0.1:7002/'],
+        expect.any(Function)
+      )
     })
 
     it('calls xdg-open on other platforms', async () => {

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -194,7 +194,7 @@ export function tryOpenBrowser(url: string): void {
   if (platform === 'darwin') {
     execFile('open', [url], () => {})
   } else if (platform === 'win32') {
-    execFile('cmd', ['/c', 'start', '', url], () => {})
+    execFile('rundll32', ['url.dll,FileProtocolHandler', url], () => {})
   } else {
     execFile('xdg-open', [url], () => {})
   }


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `tryOpenBrowser` function in `src/credential-state.ts` used `execFile('cmd', ['/c', 'start', '', url])` to open URLs on Windows. When `execFile` executes `cmd.exe`, the arguments are interpreted by the Windows command shell. This means that if a URL contained shell metacharacters like `&`, it could be abused to execute arbitrary commands, completely bypassing standard `execFile` shell injection protections.
🎯 **Impact**: Remote Code Execution (RCE) via command injection if an attacker could control the `url` parameter passed to `tryOpenBrowser` in a Windows environment.
🔧 **Fix**: Replaced the `cmd.exe` invocation with `execFile('rundll32', ['url.dll,FileProtocolHandler', url])`. This directly uses the OS-level file protocol handler to open the URL, entirely bypassing shell parsing and eliminating the attack vector. Updated tests accordingly.
✅ **Verification**: Tests pass, run `bun run test` and `bun run check:fix` successfully. Code reviewed and journal updated.

---
*PR created automatically by Jules for task [11706909953582037002](https://jules.google.com/task/11706909953582037002) started by @n24q02m*