### PR TITLE
fix: document MCP_MODE remote-oauth vs local-relay in setup docs

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -226,10 +226,11 @@ If `NOTION_TOKEN` is not set in stdio mode, the server opens a relay setup page:
 | Variable | Required | Default | Description |
 |:---------|:---------|:--------|:------------|
 | `NOTION_TOKEN` | Yes (stdio) | -- | Notion internal integration token (`ntn_...`). |
-| `TRANSPORT_MODE` | No | `stdio` | Set to `http` for remote OAuth mode. |
+| `MCP_MODE` | No | `remote-oauth` (when `TRANSPORT_MODE=http`) | Selects the HTTP relay flavour: `remote-oauth` (delegated OAuth 2.1 to `api.notion.com`; multi-user with per-JWT-sub tokens; deployed at `better-notion-mcp.n24q02m.com`) or `local-relay` (paste-form for the integration token; single-user). |
+| `TRANSPORT_MODE` | No | `stdio` | Legacy alias still honoured — set to `http` to enable HTTP transport (then pick `MCP_MODE`). `MCP_TRANSPORT=stdio` forces the stdio fallback. |
 | `PUBLIC_URL` | Yes (http) | -- | Server's public URL for OAuth redirects. |
-| `NOTION_OAUTH_CLIENT_ID` | Yes (http) | -- | Notion Public Integration client ID. |
-| `NOTION_OAUTH_CLIENT_SECRET` | Yes (http) | -- | Notion Public Integration client secret. |
+| `NOTION_OAUTH_CLIENT_ID` | Yes (`MCP_MODE=remote-oauth`) | -- | Notion Public Integration client ID. |
+| `NOTION_OAUTH_CLIENT_SECRET` | Yes (`MCP_MODE=remote-oauth`) | -- | Notion Public Integration client secret. |
 | `DCR_SERVER_SECRET` | Yes (http) | -- | HMAC secret for stateless Dynamic Client Registration. |
 | `PORT` | No | `8080` | Server port. |
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -128,10 +128,11 @@ Your MCP client handles the OAuth flow automatically. A browser window opens for
 | Variable | Required | Default | Description |
 |:---------|:---------|:--------|:------------|
 | `NOTION_TOKEN` | Yes (stdio) | -- | Notion internal integration token (`ntn_...`). Not needed for HTTP/OAuth mode. |
-| `TRANSPORT_MODE` | No | `stdio` | Set to `http` for remote OAuth mode. |
+| `MCP_MODE` | No | `remote-oauth` (when `TRANSPORT_MODE=http`) | Selects the HTTP relay flavour: `remote-oauth` (delegated OAuth 2.1 to `api.notion.com`; multi-user) or `local-relay` (paste-form for the integration token; single-user). |
+| `TRANSPORT_MODE` | No | `stdio` | Legacy alias still honoured — set to `http` to enable HTTP transport (then pick `MCP_MODE`). |
 | `PUBLIC_URL` | Yes (http) | -- | Server's public URL for OAuth redirects. |
-| `NOTION_OAUTH_CLIENT_ID` | Yes (http) | -- | Notion Public Integration client ID. |
-| `NOTION_OAUTH_CLIENT_SECRET` | Yes (http) | -- | Notion Public Integration client secret. |
+| `NOTION_OAUTH_CLIENT_ID` | Yes (`MCP_MODE=remote-oauth`) | -- | Notion Public Integration client ID. |
+| `NOTION_OAUTH_CLIENT_SECRET` | Yes (`MCP_MODE=remote-oauth`) | -- | Notion Public Integration client secret. |
 | `DCR_SERVER_SECRET` | Yes (http) | -- | HMAC secret for stateless client registration. |
 | `PORT` | No | `8080` | Server port (http mode only). |
 


### PR DESCRIPTION
Adds explicit `MCP_MODE` rows to setup-manual.md and setup-with-agent.md env-var tables, plus tightens the required column for the OAuth client envs to point at `MCP_MODE=remote-oauth` only. Mirrors CLAUDE.md#Modes (Phase L2 restored 2026-04-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)