### PR TITLE
fix: pin @latest in plugin.json to bypass npx cache stale versions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   "mcpServers": {
     "better-notion-mcp": {
       "command": "npx",
-      "args": ["-y", "@n24q02m/better-notion-mcp"],
+      "args": ["--yes", "@n24q02m/better-notion-mcp@latest"],
       "env": { "MCP_TRANSPORT": "stdio" }
     }
   }

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.10.0",
+        "@n24q02m/mcp-core": "^1.11.1",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.10.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-5CSIsdFOumSL6Y0OGpsyl78FxqSo13lbrAJn8YRcfXLMTvVGak0iyKPkBkxsfUMW50fXkueFQHZepaLAipCySA=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.11.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-++qPIQv7t/mSmds8HzsUAQ4p2AQ/5/Vfp2juWU7A0nyC4WYxVfjDH+Gk5mSed7nNDpcA723LvPXfPcTyOKD5xg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.10.0",
+    "@n24q02m/mcp-core": "^1.11.1",
     "@notionhq/client": "^5.20.0",
     "zod": "^4.3.6"
   },

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -11,6 +11,17 @@ vi.mock('./composite/workspace.js', () => ({ workspace: vi.fn() }))
 vi.mock('./composite/file-uploads.js', () => ({ fileUploads: vi.fn() }))
 vi.mock('./composite/config.js', () => ({ config: vi.fn() }))
 
+// Mock mcp-core open-relay helper to avoid spawning daemons in tests
+vi.mock('@n24q02m/mcp-core', () => ({
+  buildOpenRelayHandler: vi.fn(() =>
+    vi.fn(async () => ({
+      url: 'http://127.0.0.1:9999/',
+      browserOpened: false,
+      status: 'unconfigured' as const
+    }))
+  )
+}))
+
 // Mock credential state (tests run with credentials already configured)
 vi.mock('../credential-state.js', () => ({
   getState: vi.fn(() => 'configured'),
@@ -46,7 +57,8 @@ const EXPECTED_TOOL_NAMES = [
   'content_convert',
   'file_uploads',
   'help',
-  'config'
+  'config',
+  'config__open_relay'
 ]
 
 const EXPECTED_RESOURCE_URIS = [
@@ -101,11 +113,11 @@ describe('registerTools', () => {
   })
 
   describe('ListTools handler', () => {
-    it('should return exactly 10 tools', async () => {
+    it('should return exactly 11 tools', async () => {
       const handler = server.getHandler(0)
       const result = await handler()
 
-      expect(result.tools).toHaveLength(10)
+      expect(result.tools).toHaveLength(11)
     })
 
     it('should return all expected tool names', async () => {
@@ -419,6 +431,33 @@ describe('registerTools', () => {
       // config is called without notion client
       expect(config).toHaveBeenCalledWith({ action: 'status' })
       expect(result.content[0].text).toBe(JSON.stringify(mockResult, null, 2))
+    })
+
+    it('should route config__open_relay tool and return relay URL JSON', async () => {
+      const handler = server.getHandler(3)
+
+      const result = await handler({
+        params: { name: 'config__open_relay', arguments: {} }
+      })
+
+      const parsed = JSON.parse(result.content[0].text)
+      expect(parsed).toEqual({
+        url: 'http://127.0.0.1:9999/',
+        browserOpened: false,
+        status: 'unconfigured'
+      })
+      expect(result.isError).toBeUndefined()
+    })
+
+    it('should expose config__open_relay in TOOLS list with empty input schema', async () => {
+      const listHandler = server.getHandler(0)
+      const result = await listHandler()
+      const tool = result.tools.find((t: any) => t.name === 'config__open_relay')
+
+      expect(tool).toBeDefined()
+      expect(tool.inputSchema.type).toBe('object')
+      expect(tool.inputSchema.properties).toEqual({})
+      expect(tool.inputSchema.additionalProperties).toBe(false)
     })
 
     it('should route file_uploads tool correctly', async () => {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -13,8 +13,10 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema
 } from '@modelcontextprotocol/sdk/types.js'
+import { buildOpenRelayHandler } from '@n24q02m/mcp-core'
 import type { Client } from '@notionhq/client'
 import { getSetupUrl, getState, triggerRelaySetup } from '../credential-state.js'
+import { RELAY_SCHEMA } from '../relay-schema.js'
 // Import mega tools
 import { blocks } from './composite/blocks.js'
 import { commentsManage } from './composite/comments.js'
@@ -29,7 +31,9 @@ import { aiReadableMessage, findClosestMatch, NotionMCPError } from './helpers/e
 import { wrapToolResult } from './helpers/security.js'
 
 // Tools that work without a Notion token
-const TOKEN_FREE_TOOLS = new Set(['help', 'content_convert', 'config'])
+const TOKEN_FREE_TOOLS = new Set(['help', 'content_convert', 'config', 'config__open_relay'])
+
+const openRelayHandler = buildOpenRelayHandler('better-notion-mcp', RELAY_SCHEMA)
 
 // Get docs directory path - works for both bundled CLI and unbundled code
 const __filename = fileURLToPath(import.meta.url)
@@ -410,6 +414,24 @@ const TOOLS = [
       },
       required: ['action']
     }
+  },
+  {
+    name: 'config__open_relay',
+    description:
+      'Open the relay configuration form for better-notion-mcp in the user browser. Returns the relay URL, whether the browser launched, and the current credential state. Auto-respawns the daemon if it has died.',
+    annotations: {
+      title: 'Open Relay',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+      required: []
+    }
   }
 ]
 
@@ -516,6 +538,9 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         case 'config':
           result = await config(args as any)
+          break
+        case 'config__open_relay':
+          result = await openRelayHandler()
           break
         case 'file_uploads':
           result = await fileUploads(notion, args as any)


### PR DESCRIPTION
Field bug from Wave 8 Test B: Claude Code spawned cached 2.10.1 instead of latest 2.30.3, missing MCP_TRANSPORT=stdio detection. Pin @latest so npx always fetches fresh.