### PR TITLE
fix: D18.2 eager relay + bump mcp-core to 1.11.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.11.1",
+        "@n24q02m/mcp-core": "^1.11.3",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.11.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-++qPIQv7t/mSmds8HzsUAQ4p2AQ/5/Vfp2juWU7A0nyC4WYxVfjDH+Gk5mSed7nNDpcA723LvPXfPcTyOKD5xg=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.11.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-ZRbO105JY5MVn/mo2sNduFVarBkrzz9aBvAbMWzRC0gqOQDoqwL3A9oiJukjeubmTQzpGRLRujufWV138WvV5Q=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.11.1",
+    "@n24q02m/mcp-core": "^1.11.3",
     "@notionhq/client": "^5.20.0",
     "zod": "^4.3.6"
   },

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -155,6 +155,21 @@ describe('main.ts', () => {
       startHttpMock.mockRejectedValueOnce(new Error('HTTP failed'))
       await expect(startServer('http')).rejects.toThrow('HTTP failed')
     })
+
+    it('passes RELAY_SCHEMA as eagerRelaySchema to runSmartStdioProxy in stdio mode (D18.2)', async () => {
+      const { runSmartStdioProxy } = await import('@n24q02m/mcp-core/transport')
+      const spy = vi.mocked(runSmartStdioProxy)
+      spy.mockClear()
+
+      await startServer('stdio')
+
+      expect(spy).toHaveBeenCalledOnce()
+      const options = spy.mock.calls[0]![2]!
+      expect(options.eagerRelaySchema).toBeDefined()
+      expect(options.eagerRelaySchema!.fields).toEqual(
+        expect.arrayContaining([expect.objectContaining({ key: 'NOTION_TOKEN' })])
+      )
+    })
   })
 
   describe('bootstrap and exports', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,9 +48,12 @@ export async function startServer(mode: string): Promise<void> {
     const { startHttp } = await import('./transports/http.js')
     await startHttp()
   } else {
+    const { RELAY_SCHEMA } = await import('./relay-schema.js')
     const daemonCmd = [process.execPath, process.argv[1]!]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const exitCode = await runSmartStdioProxy('better-notion-mcp', daemonCmd, {
-      env: { TRANSPORT_MODE: 'http', MCP_MODE: 'local-relay' }
+      env: { TRANSPORT_MODE: 'http', MCP_MODE: 'local-relay' },
+      eagerRelaySchema: RELAY_SCHEMA as any
     })
     process.exit(exitCode)
   }


### PR DESCRIPTION
Per Bridge v2 addendum spec (Wave 10 Tasks 10.3 + 10.6).

- Wire `eagerRelaySchema: RELAY_SCHEMA` into `runSmartStdioProxy` stdio branch (D18.2)
- Bump `@n24q02m/mcp-core` to `^1.11.3`
- Add unit test asserting `eagerRelaySchema` is passed with correct NOTION_TOKEN field