### PR TITLE
fix: revert eagerRelaySchema usage (D18 rollback)

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -155,21 +155,6 @@ describe('main.ts', () => {
       startHttpMock.mockRejectedValueOnce(new Error('HTTP failed'))
       await expect(startServer('http')).rejects.toThrow('HTTP failed')
     })
-
-    it('passes RELAY_SCHEMA as eagerRelaySchema to runSmartStdioProxy in stdio mode (D18.2)', async () => {
-      const { runSmartStdioProxy } = await import('@n24q02m/mcp-core/transport')
-      const spy = vi.mocked(runSmartStdioProxy)
-      spy.mockClear()
-
-      await startServer('stdio')
-
-      expect(spy).toHaveBeenCalledOnce()
-      const options = spy.mock.calls[0]![2]!
-      expect(options.eagerRelaySchema).toBeDefined()
-      expect(options.eagerRelaySchema!.fields).toEqual(
-        expect.arrayContaining([expect.objectContaining({ key: 'NOTION_TOKEN' })])
-      )
-    })
   })
 
   describe('bootstrap and exports', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,12 +48,9 @@ export async function startServer(mode: string): Promise<void> {
     const { startHttp } = await import('./transports/http.js')
     await startHttp()
   } else {
-    const { RELAY_SCHEMA } = await import('./relay-schema.js')
     const daemonCmd = [process.execPath, process.argv[1]!]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const exitCode = await runSmartStdioProxy('better-notion-mcp', daemonCmd, {
-      env: { TRANSPORT_MODE: 'http', MCP_MODE: 'local-relay' },
-      eagerRelaySchema: RELAY_SCHEMA as any
+      env: { TRANSPORT_MODE: 'http', MCP_MODE: 'local-relay' }
     })
     process.exit(exitCode)
   }


### PR DESCRIPTION
Drop eagerRelaySchema arg per mcp-core 1.11.4 D18 rollback. See mcp-core PR #134.

Daemon-side runLocalServer auto-opens browser when unconfigured (mcp-core PR #116, already shipped). Bridge-side eager block was redundant + caused 2-3 tabs per spawn + bridge respawn loop = infinite spam (P0 regression user reported 2026-04-29 session rollback-d18-plugin-daemon).

Tests: 745/745 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)