### PR TITLE
fix: rebuild against mcp-core 1.11.5 fork-bomb fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,3 +75,4 @@ export async function bootstrap(selectedMode: string = mode) {
 if (isMain(import.meta.url) && process.env.NODE_ENV !== 'test') {
   bootstrap()
 }
+// Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)


### PR DESCRIPTION
Bump bundle to include mcp-core 1.11.5 env-strip fix (mcp-core PR #135). Notion did not exhibit fork-bomb directly but rebuild ensures parity + defense-in-depth.