### PR TITLE
feat: stdio-pure + http-multi-user (drop daemon-bridge)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.11.3",
+        "@n24q02m/mcp-core": "1.13.0-beta.4",
         "@notionhq/client": "^5.20.0",
         "zod": "^4.3.6",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.11.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-ZRbO105JY5MVn/mo2sNduFVarBkrzz9aBvAbMWzRC0gqOQDoqwL3A9oiJukjeubmTQzpGRLRujufWV138WvV5Q=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.13.0-beta.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.9.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-cmRGwPGlzqa+YvqEyQTOaGYkyoITHQyWjxLK3qpn+9TQZxq+8OyKZG7KqjPTuqS9SzGLtN1MYKeEgUAKe0gdvg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.11.3",
+    "@n24q02m/mcp-core": "1.13.0-beta.4",
     "@notionhq/client": "^5.20.0",
     "zod": "^4.3.6"
   },

--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -1,71 +1,52 @@
 /**
  * Tests for credential state management.
+ *
+ * Post stdio-pure + http-multi-user split (2026-05-01): no relay spawn,
+ * no setupUrl, no triggerRelaySetup. Just env/file resolution + state
+ * machine + per-subject token resolver.
  */
 
-import { execFile } from 'node:child_process'
-import { deleteConfig, runLocalServer, writeConfig } from '@n24q02m/mcp-core'
+import { deleteConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getNotionToken,
-  getSetupUrl,
   getState,
   getSubjectToken,
   resetState,
   resolveCredentialState,
   setState,
-  setSubjectTokenResolver,
-  triggerRelaySetup
+  setSubjectTokenResolver
 } from './credential-state.js'
 
-vi.mock('node:child_process', () => ({
-  execFile: vi.fn()
-}))
-
 vi.mock('@n24q02m/mcp-core', () => ({
-  deleteConfig: vi.fn(),
-  runLocalServer: vi.fn(),
-  writeConfig: vi.fn()
+  deleteConfig: vi.fn()
 }))
 
 vi.mock('@n24q02m/mcp-core/storage', () => ({
   resolveConfig: vi.fn()
 }))
 
-function makeHandle(overrides: Partial<{ host: string; port: number; close: () => Promise<void> }> = {}) {
-  return {
-    host: overrides.host ?? '127.0.0.1',
-    port: overrides.port ?? 54321,
-    close: overrides.close ?? (() => Promise.resolve())
-  }
-}
-
 describe('credential-state', () => {
-  let consoleSpy: any
+  let consoleSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     vi.resetAllMocks()
-    vi.useFakeTimers()
     consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    vi.mocked(deleteConfig).mockResolvedValue(undefined as any)
-    vi.mocked(writeConfig).mockResolvedValue(undefined as any)
-    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null })
+    vi.mocked(deleteConfig).mockResolvedValue(undefined as never)
+    vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null } as never)
 
     resetState()
     delete process.env.NOTION_TOKEN
-    delete process.env.MCP_RELAY_URL
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
-    vi.useRealTimers()
-    vi.unstubAllGlobals()
   })
 
   it('initial state is awaiting_setup', () => {
     expect(getState()).toBe('awaiting_setup')
-    expect(getSetupUrl()).toBeNull()
     expect(getNotionToken()).toBeNull()
   })
 
@@ -82,7 +63,7 @@ describe('credential-state', () => {
       vi.mocked(resolveConfig).mockResolvedValue({
         config: { NOTION_TOKEN: 'file-token' },
         source: 'file'
-      })
+      } as never)
       const state = await resolveCredentialState()
       expect(state).toBe('configured')
       expect(getNotionToken()).toBe('file-token')
@@ -96,64 +77,9 @@ describe('credential-state', () => {
     })
 
     it('handles config read failure gracefully', async () => {
-      vi.mocked(resolveConfig).mockRejectedValue(new Error('read error'))
+      vi.mocked(resolveConfig).mockRejectedValue(new Error('read error') as never)
       const state = await resolveCredentialState()
       expect(state).toBe('awaiting_setup')
-    })
-  })
-
-  describe('triggerRelaySetup', () => {
-    it('returns null when spawning the local server fails', async () => {
-      vi.mocked(runLocalServer).mockRejectedValue(new Error('cannot bind'))
-      const url = await triggerRelaySetup()
-      expect(url).toBeNull()
-      expect(getState()).toBe('awaiting_setup')
-    })
-
-    it('spawns a local HTTP server and returns its URL', async () => {
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ port: 55123 }) as any)
-
-      const url = await triggerRelaySetup()
-
-      expect(url).toBe('http://127.0.0.1:55123/')
-      expect(getSetupUrl()).toBe('http://127.0.0.1:55123/')
-      expect(getState()).toBe('setup_in_progress')
-      expect(execFile).toHaveBeenCalled() // tryOpenBrowser
-
-      const call = vi.mocked(runLocalServer).mock.calls[0]
-      const options = call[1]
-      expect(options.port).toBe(0)
-      expect(options.host).toBe('127.0.0.1')
-      expect(options.serverName).toBe('better-notion-mcp')
-      expect(options.relaySchema).toBeDefined()
-    })
-
-    it('persists the token and transitions to configured on form submit', async () => {
-      const closeMock = vi.fn().mockResolvedValue(undefined)
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ close: closeMock }) as any)
-
-      await triggerRelaySetup()
-
-      const onCredentialsSaved = vi.mocked(runLocalServer).mock.calls[0][1].onCredentialsSaved as (
-        creds: Record<string, string>
-      ) => Promise<unknown>
-      await onCredentialsSaved({ NOTION_TOKEN: 'relay-token' })
-
-      expect(getState()).toBe('configured')
-      expect(getNotionToken()).toBe('relay-token')
-      expect(writeConfig).toHaveBeenCalledWith('better-notion-mcp', { NOTION_TOKEN: 'relay-token' })
-
-      // Grace timer should close the spawn without blocking the caller.
-      await vi.advanceTimersByTimeAsync(5_000)
-      expect(closeMock).toHaveBeenCalled()
-    })
-
-    it('returns the current URL if already setup_in_progress', async () => {
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ port: 60000 }) as any)
-      const first = await triggerRelaySetup()
-      const second = await triggerRelaySetup()
-      expect(second).toBe(first)
-      expect(runLocalServer).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -166,76 +92,11 @@ describe('credential-state', () => {
       expect(deleteConfig).toHaveBeenCalledWith('better-notion-mcp')
     })
 
-    it('handles deleteConfig failure in resetState', async () => {
-      vi.mocked(deleteConfig).mockRejectedValue(new Error('delete failed'))
+    it('handles deleteConfig failure in resetState', () => {
+      vi.mocked(deleteConfig).mockRejectedValue(new Error('delete failed') as never)
       resetState()
       expect(getState()).toBe('awaiting_setup')
       expect(deleteConfig).toHaveBeenCalled()
-    })
-
-    it('closes any active local handle', async () => {
-      const closeMock = vi.fn().mockResolvedValue(undefined)
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ close: closeMock }) as any)
-      await triggerRelaySetup()
-      resetState()
-      expect(closeMock).toHaveBeenCalled()
-    })
-  })
-
-  describe('tryOpenBrowser', () => {
-    it('calls open on darwin', async () => {
-      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ port: 7001 }) as any)
-
-      await triggerRelaySetup()
-
-      expect(execFile).toHaveBeenCalledWith('open', ['http://127.0.0.1:7001/'], expect.any(Function))
-    })
-
-    it('calls rundll32 on win32', async () => {
-      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ port: 7002 }) as any)
-
-      await triggerRelaySetup()
-
-      expect(execFile).toHaveBeenCalledWith(
-        'rundll32',
-        ['url.dll,FileProtocolHandler', 'http://127.0.0.1:7002/'],
-        expect.any(Function)
-      )
-    })
-
-    it('calls xdg-open on other platforms', async () => {
-      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ port: 7003 }) as any)
-
-      await triggerRelaySetup()
-
-      expect(execFile).toHaveBeenCalledWith('xdg-open', ['http://127.0.0.1:7003/'], expect.any(Function))
-    })
-  })
-
-  describe('signal handlers', () => {
-    it('closes the active spawn on SIGINT', async () => {
-      vi.useRealTimers()
-      const closeMock = vi.fn().mockResolvedValue(undefined)
-      const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      vi.mocked(runLocalServer).mockResolvedValue(makeHandle({ close: closeMock }) as any)
-
-      await triggerRelaySetup()
-      process.emit('SIGINT' as any)
-      await new Promise((resolve) => setTimeout(resolve, 50))
-
-      expect(closeMock).toHaveBeenCalled()
-      expect(exitMock).toHaveBeenCalled()
-    })
-
-    it('handles SIGINT when no active spawn', async () => {
-      vi.useRealTimers()
-      const exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
-      process.emit('SIGINT' as any)
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      expect(exitMock).toHaveBeenCalled()
     })
   })
 

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -1,50 +1,39 @@
 /**
  * Non-blocking credential state management for better-notion-mcp.
  *
- * State machine: awaiting_setup -> setup_in_progress -> configured
+ * State machine: awaiting_setup -> configured
  * Reset: configured -> awaiting_setup (via reset)
  *
- * When no credentials are present, triggerRelaySetup() spawns a LOCAL HTTP
- * server (via mcp-core runLocalServer with the notion relaySchema) on a
- * random 127.0.0.1 port and returns its /authorize URL. The user pastes
- * their Notion integration token into that local form; onCredentialsSaved
- * persists it to config.enc. The stdio/HTTP server that called us then
- * reads the saved config on its next state resolve and transitions to
- * `configured`. The spawn is LOCAL-ONLY — we never hit a remote relay URL
- * and never follow the server's default mode for the stdio fallback.
- * See `~/.claude/skills/mcp-dev/references/mode-matrix.md` section
- * `stdio proxy` for the canonical rule.
+ * Post stdio-pure + http-multi-user split (2026-05-01): the daemon-bridge
+ * relay setup spawn is gone. In stdio mode the server fails fast with a
+ * clear stderr message when NOTION_TOKEN is missing (see main.ts). In HTTP
+ * mode the OAuth 2.1 AS in mcp-core serves the credential form directly at
+ * /authorize on the same port as /mcp -- no separate spawn, no random port.
+ *
+ * This module is the single source of truth for "is the server configured?"
+ * It supports two token resolution strategies:
+ *  - stdio / single-user: module-global ``_notionToken`` from env or
+ *    config.enc, set during ``resolveCredentialState``.
+ *  - HTTP / multi-user (remote-oauth): per-JWT-sub resolver injected by the
+ *    HTTP transport so ``config(action=status)`` reflects whether the
+ *    CURRENT caller has a Notion access token.
  */
 
-import { execFile } from 'node:child_process'
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import type { LocalServerHandle, RelayConfigSchema } from '@n24q02m/mcp-core'
-import { deleteConfig, runLocalServer, writeConfig } from '@n24q02m/mcp-core'
+import { deleteConfig } from '@n24q02m/mcp-core'
 import { resolveConfig } from '@n24q02m/mcp-core/storage'
-import { RELAY_SCHEMA } from './relay-schema.js'
-import { isSafeWebUrl } from './tools/helpers/security.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 const CREDENTIAL_KEY = 'NOTION_TOKEN'
 const REQUIRED_FIELDS = [CREDENTIAL_KEY]
 
-/** Grace window so the browser renders "Connected" before the spawn closes. */
-const SPAWN_CLEANUP_MS = 5_000
-
-export type CredentialState = 'awaiting_setup' | 'setup_in_progress' | 'configured'
+export type CredentialState = 'awaiting_setup' | 'configured'
 
 // Module-level state
 let _state: CredentialState = 'awaiting_setup'
-let _setupUrl: string | null = null
 let _notionToken: string | null = null
-let _activeHandle: LocalServerHandle | null = null
 
 export function getState(): CredentialState {
   return _state
-}
-
-export function getSetupUrl(): string | null {
-  return _setupUrl
 }
 
 export function getNotionToken(): string | null {
@@ -52,12 +41,12 @@ export function getNotionToken(): string | null {
 }
 
 /**
- * Per-request token resolver. `local-relay` mode leaves the default resolver,
- * which reads the single-user module global. `remote-oauth` mode injects a
- * resolver that reads the per-JWT-sub `NotionTokenStore` so that
- * `config(action=status)` reflects whether the CURRENT caller has a Notion
- * access token — not whether the server process has any global token, which
- * is always null in multi-user remote-oauth mode.
+ * Per-request token resolver. Stdio / single-user leaves the default
+ * resolver, which reads the module global. ``remote-oauth`` HTTP mode
+ * injects a resolver that reads the per-JWT-sub ``NotionTokenStore`` so
+ * that ``config(action=status)`` reflects whether the CURRENT caller has a
+ * Notion access token -- not whether the server process has any global
+ * token, which is always null in multi-user remote-oauth mode.
  */
 let _subjectTokenResolver: () => string | null = () => _notionToken
 
@@ -75,12 +64,12 @@ export function getSubjectToken(): string | null {
  * Checks (in order):
  * 1. ENV VARS -- NOTION_TOKEN present -> configured
  * 2. CONFIG FILE -- saved relay config has token -> configured
- * 3. NOTHING -- awaiting_setup (server starts fast, relay triggered lazily)
+ * 3. NOTHING -- awaiting_setup
  *
  * Returns new state. Takes <50ms (single file read).
  */
 export async function resolveCredentialState(): Promise<CredentialState> {
-  // 1. Check env var (already checked by caller, but be defensive)
+  // 1. Check env var
   const envToken = process.env.NOTION_TOKEN
   if (envToken) {
     _notionToken = envToken
@@ -89,7 +78,8 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     return _state
   }
 
-  // 2. Check saved relay config file
+  // 2. Check saved relay config file (HTTP mode only -- stdio shouldn't get
+  // here without env, see main.ts startServer('stdio') guard).
   try {
     const result = await resolveConfig(SERVER_NAME, REQUIRED_FIELDS)
     if (result.config !== null) {
@@ -108,115 +98,12 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   return _state
 }
 
-/**
- * Lazy setup trigger. Spawns a local HTTP credential form on a random port
- * and returns its URL. Caller surfaces the URL to the user (stderr or tool
- * response). Non-blocking — the user submits the form in their browser and
- * onCredentialsSaved persists to config.enc in the background.
- */
-export async function triggerRelaySetup(): Promise<string | null> {
-  if (_state !== 'awaiting_setup') {
-    return _setupUrl
-  }
-
-  _state = 'setup_in_progress'
-
-  try {
-    const handle = await runLocalServer(stubMcpFactory, {
-      serverName: SERVER_NAME,
-      port: 0,
-      host: '127.0.0.1',
-      relaySchema: RELAY_SCHEMA as unknown as RelayConfigSchema,
-      onCredentialsSaved: async (creds) => {
-        const token = creds?.[CREDENTIAL_KEY]
-        if (typeof token === 'string' && token.length > 0) {
-          _notionToken = token
-          await writeConfig(SERVER_NAME, { [CREDENTIAL_KEY]: token })
-          _state = 'configured'
-          console.error('Notion config saved via local relay')
-          // Close the spawn after a short grace so the browser renders the
-          // "Connected" response before the server goes away.
-          setTimeout(() => {
-            closeActiveHandle().catch(() => {})
-          }, SPAWN_CLEANUP_MS)
-        }
-        return null
-      }
-    })
-
-    _activeHandle = handle
-    _setupUrl = `http://${handle.host}:${handle.port}/`
-
-    // Try to open browser (best-effort, non-blocking)
-    tryOpenBrowser(_setupUrl)
-
-    console.error(`\nSetup required. Open this URL to configure:\n${_setupUrl}\n`)
-    console.error('Paste your Notion integration token (https://www.notion.so/my-integrations) in the form.\n')
-
-    return _setupUrl
-  } catch (err) {
-    console.error(`Relay setup failed: ${err}. Server continues in awaiting_setup.`)
-    _state = 'awaiting_setup'
-    return null
-  }
-}
-
-async function closeActiveHandle(): Promise<void> {
-  const handle = _activeHandle
-  if (!handle) return
-  _activeHandle = null
-  await handle.close().catch(() => {})
-}
-
-/**
- * Minimal MCP server factory for the setup-only spawn. The spawned server
- * exists solely to render the /authorize paste form; /mcp should never be
- * called against it (clients use the primary stdio or http transport).
- * Returning an empty McpServer keeps the types happy without wiring any
- * tools, which would require a credentialed Notion client we don't yet have.
- */
-function stubMcpFactory(): McpServer {
-  return new McpServer({ name: `${SERVER_NAME}-setup`, version: '0.0.0' })
-}
-
-/**
- * Try to open URL in default browser (best-effort).
- * Uses execFile (not exec) to avoid shell injection.
- */
-export function tryOpenBrowser(url: string): void {
-  if (!isSafeWebUrl(url)) {
-    console.error(`Refused to open unsafe URL in browser: ${url}`)
-    return
-  }
-
-  const platform = process.platform
-
-  if (platform === 'darwin') {
-    execFile('open', [url], () => {})
-  } else if (platform === 'win32') {
-    execFile('rundll32', ['url.dll,FileProtocolHandler', url], () => {})
-  } else {
-    execFile('xdg-open', [url], () => {})
-  }
-}
-
 export function setState(state: CredentialState): void {
   _state = state
 }
 
 export function resetState(): void {
   _state = 'awaiting_setup'
-  _setupUrl = null
   _notionToken = null
-  closeActiveHandle().catch(() => {})
   deleteConfig(SERVER_NAME).catch(() => {})
 }
-
-// Cleanup active local spawn on process exit
-const handleExit = async () => {
-  await closeActiveHandle()
-  process.exit()
-}
-
-process.on('SIGINT', handleExit)
-process.on('SIGTERM', handleExit)

--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -23,30 +23,30 @@ describe('initServer', () => {
     process.argv = originalArgv
   })
 
-  it('dispatches stdio when --stdio flag is set', async () => {
-    process.argv = [process.argv[0], 'main.js', '--stdio']
-    const { initServer } = await import('./init-server.js')
-    await initServer()
-    expect(startServerMock).toHaveBeenCalledWith('stdio')
-  })
-
-  it('dispatches stdio when MCP_TRANSPORT=stdio', async () => {
-    process.env.MCP_TRANSPORT = 'stdio'
-    const { initServer } = await import('./init-server.js')
-    await initServer()
-    expect(startServerMock).toHaveBeenCalledWith('stdio')
-  })
-
-  it('dispatches stdio when TRANSPORT_MODE=stdio', async () => {
-    process.env.TRANSPORT_MODE = 'stdio'
-    const { initServer } = await import('./init-server.js')
-    await initServer()
-    expect(startServerMock).toHaveBeenCalledWith('stdio')
-  })
-
-  it('dispatches http by default', async () => {
+  it('dispatches http when --http flag is set', async () => {
+    process.argv = [process.argv[0], 'main.js', '--http']
     const { initServer } = await import('./init-server.js')
     await initServer()
     expect(startServerMock).toHaveBeenCalledWith('http')
+  })
+
+  it('dispatches http when MCP_TRANSPORT=http', async () => {
+    process.env.MCP_TRANSPORT = 'http'
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('http')
+  })
+
+  it('dispatches http when TRANSPORT_MODE=http', async () => {
+    process.env.TRANSPORT_MODE = 'http'
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('http')
+  })
+
+  it('dispatches stdio by default (post stdio-pure migration)', async () => {
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('stdio')
   })
 })

--- a/src/init-server.ts
+++ b/src/init-server.ts
@@ -1,28 +1,19 @@
 /**
  * Better Notion MCP Server — Entry point
  *
- * Transport selection:
- *  - stdio (backward compat): `--stdio`, `MCP_TRANSPORT=stdio`, or `TRANSPORT_MODE=stdio`
- *  - http (default): local mode via `@n24q02m/mcp-core` runLocalServer
+ * Transport selection (post stdio-pure + http-multi-user split, 2026-05-01):
+ *  - stdio (default): NOTION_TOKEN env required, MCP SDK StdioServerTransport
+ *    directly (no daemon proxy hop). Single-user.
+ *  - http (opt-in): `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`.
+ *    Always remote-oauth, always multi-user (per-JWT-sub Notion token store).
  *
- * HTTP mode uses the local OAuth 2.1 AS from `mcp-core` which serves the
- * credential form (user pastes Notion integration token) on /authorize and
- * issues a local JWT for /mcp Bearer auth. Remote mode (delegated upstream
- * Notion OAuth) is intentionally not wired here -- per L2 migration scope,
- * remote mode is deferred and will be re-added once multi-user per-user token
- * storage is in place.
+ * Spec: 2026-05-01-stdio-pure-http-multiuser.md §5.2.1.
  */
 
 export async function initServer() {
-  const isStdio =
-    process.argv.includes('--stdio') || process.env.MCP_TRANSPORT === 'stdio' || process.env.TRANSPORT_MODE === 'stdio'
-
-  if (isStdio) {
-    const { startServer } = await import('./main.js')
-    await startServer('stdio')
-    return
-  }
+  const isHttp =
+    process.argv.includes('--http') || process.env.MCP_TRANSPORT === 'http' || process.env.TRANSPORT_MODE === 'http'
 
   const { startServer } = await import('./main.js')
-  await startServer('http')
+  await startServer(isHttp ? 'http' : 'stdio')
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -166,6 +166,7 @@ describe('main.ts', () => {
     })
 
     it('verifies direct stdio transport when mode is stdio', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
       await startServer('stdio')
       expect(stdioServerCtor).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'better-notion-mcp' }),
@@ -178,9 +179,20 @@ describe('main.ts', () => {
     })
 
     it('verifies direct stdio transport when mode is unknown', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
       await startServer('unknown')
       expect(stdioServerCtor).toHaveBeenCalled()
       expect(stdioConnectMock).toHaveBeenCalled()
+    })
+
+    it('exits 1 with stderr message when stdio mode is selected without NOTION_TOKEN', async () => {
+      delete process.env.NOTION_TOKEN
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+      await startServer('stdio')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('NOTION_TOKEN'))
+      expect(stdioServerCtor).not.toHaveBeenCalled()
+      stderrSpy.mockRestore()
     })
 
     it('verifies error propagation from startHttp', async () => {
@@ -195,6 +207,7 @@ describe('main.ts', () => {
     })
 
     it('verifies execution with default mode', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
       await bootstrap()
       expect(stdioConnectMock).toHaveBeenCalled()
     })
@@ -205,6 +218,7 @@ describe('main.ts', () => {
     })
 
     it('verifies startup errors in bootstrap', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       stdioConnectMock.mockRejectedValueOnce(new Error('Test failure'))
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,8 +70,27 @@ export async function startServer(mode: string): Promise<void> {
     return
   }
 
+  // Stdio mode is single-user and requires NOTION_TOKEN env. Fail fast
+  // with a clear stderr message instead of starting a server that can't
+  // serve any tools. Spec 2026-05-01-stdio-pure-http-multiuser.md §5.2.1.
+  if (!process.env.NOTION_TOKEN) {
+    const msg = `[better-notion-mcp] NOTION_TOKEN required for stdio mode but not set.
+
+Options:
+  1. Set env in plugin config:
+     {"command": "npx", "args": [...], "env": {"NOTION_TOKEN": "ntn_..."}}
+
+  2. Switch to HTTP mode (browser-based setup):
+     See docs/setup-manual.md "Method 5: Self-Hosting HTTP Mode"
+
+Documentation: https://github.com/n24q02m/better-notion-mcp#setup
+`
+    process.stderr.write(msg)
+    process.exit(1)
+    return
+  }
+
   // Direct MCP SDK stdio transport (no daemon proxy hop).
-  // See spec 2026-04-30-multi-mode-stdio-http-architecture.md Task 3.1.
   await resolveCredentialState()
 
   const server = new Server(

--- a/src/tools/composite/config.test.ts
+++ b/src/tools/composite/config.test.ts
@@ -1,35 +1,39 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../credential-state.js', () => ({
   getState: vi.fn(() => 'awaiting_setup'),
-  getSetupUrl: vi.fn(() => null),
   getNotionToken: vi.fn(() => null),
   getSubjectToken: vi.fn(() => null),
   setSubjectTokenResolver: vi.fn(),
-  triggerRelaySetup: vi.fn(),
   resetState: vi.fn(),
   resolveCredentialState: vi.fn()
 }))
 
 import {
   getNotionToken,
-  getSetupUrl,
   getState,
   getSubjectToken,
   resetState,
-  resolveCredentialState,
-  triggerRelaySetup
+  resolveCredentialState
 } from '../../credential-state.js'
 import { config } from './config.js'
 
 describe('config', () => {
+  const originalPublicUrl = process.env.PUBLIC_URL
+
   beforeEach(() => {
     vi.clearAllMocks()
     // Default: no token, awaiting_setup
     vi.mocked(getState).mockReturnValue('awaiting_setup')
-    vi.mocked(getSetupUrl).mockReturnValue(null)
     vi.mocked(getNotionToken).mockReturnValue(null)
     vi.mocked(getSubjectToken).mockReturnValue(null)
+    delete process.env.PUBLIC_URL
+    delete process.env.NOTION_TOKEN
+  })
+
+  afterEach(() => {
+    if (originalPublicUrl !== undefined) process.env.PUBLIC_URL = originalPublicUrl
+    else delete process.env.PUBLIC_URL
   })
 
   describe('status action', () => {
@@ -47,9 +51,7 @@ describe('config', () => {
       vi.mocked(getState).mockReturnValue('configured')
       vi.mocked(getNotionToken).mockReturnValue('ntn_test123')
       vi.mocked(getSubjectToken).mockReturnValue('ntn_test123')
-      vi.mocked(getSetupUrl).mockReturnValue(null)
-      // No env var
-      delete process.env.NOTION_TOKEN
+      // No env var, no PUBLIC_URL -> token_source 'relay'
 
       const result = await config({ action: 'status' })
 
@@ -69,62 +71,38 @@ describe('config', () => {
       expect(result.state).toBe('configured')
       expect(result.has_token).toBe(true)
       expect(result.token_source).toBe('environment')
-
-      delete process.env.NOTION_TOKEN
     })
 
-    it('should include setup_url when available', async () => {
-      vi.mocked(getState).mockReturnValue('setup_in_progress')
-      vi.mocked(getSetupUrl).mockReturnValue('https://example.com/setup/abc123')
+    it('should return setup_url derived from PUBLIC_URL in HTTP mode', async () => {
+      vi.mocked(getState).mockReturnValue('configured')
+      vi.mocked(getSubjectToken).mockReturnValue('ntn_oauth_token')
+      process.env.PUBLIC_URL = 'https://better-notion-mcp.example.com'
 
       const result = await config({ action: 'status' })
 
-      expect(result.state).toBe('setup_in_progress')
-      expect(result.setup_url).toBe('https://example.com/setup/abc123')
+      expect(result.setup_url).toBe('https://better-notion-mcp.example.com/authorize')
+      expect(result.token_source).toBe('oauth')
     })
   })
 
   describe('setup_start action', () => {
-    it('should trigger relay setup and return URL', async () => {
-      vi.mocked(triggerRelaySetup).mockResolvedValue('https://example.com/setup/xyz')
-      vi.mocked(getState).mockReturnValueOnce('awaiting_setup').mockReturnValue('setup_in_progress')
+    it('should return PUBLIC_URL/authorize when in HTTP mode', async () => {
+      process.env.PUBLIC_URL = 'https://better-notion-mcp.example.com'
 
       const result = await config({ action: 'setup_start' })
 
-      expect(triggerRelaySetup).toHaveBeenCalled()
       expect(result.action).toBe('setup_start')
-      expect(result.setup_url).toBe('https://example.com/setup/xyz')
-      expect(result.message).toContain('Relay setup started')
+      expect(result.setup_url).toBe('https://better-notion-mcp.example.com/authorize')
+      expect(result.message).toContain('OAuth flow')
     })
 
-    it('should return message when already configured without force', async () => {
-      vi.mocked(getState).mockReturnValue('configured')
-
+    it('should return stdio guidance when no PUBLIC_URL', async () => {
+      // No PUBLIC_URL -> stdio mode
       const result = await config({ action: 'setup_start' })
 
-      expect(triggerRelaySetup).not.toHaveBeenCalled()
-      expect(result.state).toBe('configured')
-      expect(result.message).toContain('Already configured')
-    })
-
-    it('should trigger relay setup when configured with force', async () => {
-      vi.mocked(getState).mockReturnValueOnce('configured').mockReturnValue('setup_in_progress')
-      vi.mocked(triggerRelaySetup).mockResolvedValue('https://example.com/setup/forced')
-
-      const result = await config({ action: 'setup_start', force: true })
-
-      expect(triggerRelaySetup).toHaveBeenCalled()
-      expect(result.setup_url).toBe('https://example.com/setup/forced')
-    })
-
-    it('should handle relay setup failure gracefully', async () => {
-      vi.mocked(triggerRelaySetup).mockResolvedValue(null)
-      vi.mocked(getState).mockReturnValue('awaiting_setup')
-
-      const result = await config({ action: 'setup_start' })
-
+      expect(result.action).toBe('setup_start')
       expect(result.setup_url).toBeNull()
-      expect(result.message).toContain('Set NOTION_TOKEN manually')
+      expect(result.message).toContain('NOTION_TOKEN')
     })
   })
 
@@ -189,7 +167,7 @@ describe('config', () => {
 
   describe('invalid action', () => {
     it('should throw error for unsupported action', async () => {
-      await expect(config({ action: 'invalid' as any })).rejects.toThrow('Unsupported action: invalid')
+      await expect(config({ action: 'invalid' as never })).rejects.toThrow('Unsupported action: invalid')
     })
   })
 })

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -4,14 +4,7 @@
  * Does NOT require a Notion client -- works independently.
  */
 
-import {
-  getSetupUrl,
-  getState,
-  getSubjectToken,
-  resetState,
-  resolveCredentialState,
-  triggerRelaySetup
-} from '../../credential-state.js'
+import { getState, getSubjectToken, resetState, resolveCredentialState } from '../../credential-state.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 
 export interface ConfigInput {
@@ -29,35 +22,38 @@ export async function config(input: ConfigInput): Promise<any> {
     switch (input.action) {
       case 'status': {
         const state = getState()
-        const setupUrl = getSetupUrl()
         const token = getSubjectToken()
+        const publicUrl = process.env.PUBLIC_URL ?? null
         return {
           action: 'status',
           state,
           has_token: token !== null,
-          setup_url: setupUrl,
-          token_source: token ? (process.env.NOTION_TOKEN ? 'environment' : 'relay') : null
+          setup_url: publicUrl ? `${publicUrl}/authorize` : null,
+          token_source: token ? (process.env.NOTION_TOKEN ? 'environment' : publicUrl ? 'oauth' : 'relay') : null
         }
       }
 
       case 'setup_start': {
-        const currentState = getState()
-        if (currentState === 'configured' && !input.force) {
+        // Post stdio-pure + http-multi-user split (2026-05-01): the
+        // daemon-bridge relay setup spawn is gone. In stdio mode the
+        // server requires NOTION_TOKEN env at startup. In HTTP mode the
+        // OAuth flow lives at <PUBLIC_URL>/authorize served by the same
+        // process -- no separate trigger needed.
+        const publicUrl = process.env.PUBLIC_URL
+        if (publicUrl) {
           return {
             action: 'setup_start',
-            state: 'configured',
-            message: 'Already configured. Use force: true to trigger relay setup anyway, or setup_reset first.'
+            state: getState(),
+            setup_url: `${publicUrl}/authorize`,
+            message: `Open ${publicUrl}/authorize in your browser to complete the Notion OAuth flow.`
           }
         }
-
-        const url = await triggerRelaySetup()
         return {
           action: 'setup_start',
           state: getState(),
-          setup_url: url,
-          message: url
-            ? 'Relay setup started. Open the URL in your browser to configure your Notion token.'
-            : 'Could not start relay setup. Set NOTION_TOKEN manually.'
+          setup_url: null,
+          message:
+            'In stdio mode set NOTION_TOKEN env var in your MCP plugin config (get token from https://www.notion.so/my-integrations). To use HTTP/OAuth flow run with TRANSPORT_MODE=http and PUBLIC_URL set.'
         }
       }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -15,8 +15,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { buildOpenRelayHandler } from '@n24q02m/mcp-core'
 import type { Client } from '@notionhq/client'
-import { getSetupUrl, getState, triggerRelaySetup } from '../credential-state.js'
-import { RELAY_SCHEMA } from '../relay-schema.js'
+import { getState } from '../credential-state.js'
 // Import mega tools
 import { blocks } from './composite/blocks.js'
 import { commentsManage } from './composite/comments.js'
@@ -33,7 +32,12 @@ import { wrapToolResult } from './helpers/security.js'
 // Tools that work without a Notion token
 const TOKEN_FREE_TOOLS = new Set(['help', 'content_convert', 'config', 'config__open_relay'])
 
-const openRelayHandler = buildOpenRelayHandler('better-notion-mcp', RELAY_SCHEMA)
+// publicUrl is null in stdio mode (no relay form to open). HTTP mode
+// substitutes it with PUBLIC_URL so the tool returns a valid /authorize URL.
+const openRelayHandler = buildOpenRelayHandler({
+  serverName: 'better-notion-mcp',
+  publicUrl: process.env.PUBLIC_URL ?? null
+})
 
 // Get docs directory path - works for both bundled CLI and unbundled code
 const __filename = fileURLToPath(import.meta.url)
@@ -491,18 +495,18 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
       }
     }
 
-    // Credential guard: trigger relay and show URL in tool response (not just stderr).
-    // help and content_convert work without a token.
+    // Credential guard. In stdio mode the server exits at startup if
+    // NOTION_TOKEN is missing (see main.ts startServer('stdio')); reaching
+    // this branch means HTTP mode where the per-subject token store is
+    // empty for the current caller. help and content_convert work without
+    // a token.
     if (!TOKEN_FREE_TOOLS.has(name)) {
       const credState = getState()
       if (credState !== 'configured') {
-        if (credState === 'awaiting_setup') {
-          await triggerRelaySetup()
-        }
-        const url = getSetupUrl()
-        const setupInstructions = url
-          ? `Setup in progress. Open this URL to configure your Notion token:\n${url}\n\nOr set NOTION_TOKEN manually in your MCP server config.`
-          : 'NOTION_TOKEN environment variable is not set. Get your integration token from https://www.notion.so/my-integrations and set it as NOTION_TOKEN in your MCP server config. Example: NOTION_TOKEN=ntn_xxxxxxxxxxxxx'
+        const publicUrl = process.env.PUBLIC_URL
+        const setupInstructions = publicUrl
+          ? `Notion access token is not present for this session. Open ${publicUrl}/authorize in your browser to complete the Notion OAuth flow, then retry the tool.`
+          : 'Notion access token is not present. In stdio mode set NOTION_TOKEN env var (https://www.notion.so/my-integrations). In HTTP mode complete the OAuth flow at <PUBLIC_URL>/authorize.'
         return {
           content: [{ type: 'text', text: setupInstructions }],
           isError: true

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,149 +1,99 @@
 /**
- * HTTP Transport -- dispatches between two modes per MCP matrix:
+ * HTTP Transport -- single remote-oauth multi-user mode.
  *
- *   MCP_MODE=remote-oauth (default) -- runLocalServer with delegatedOAuth
- *     {flow:'redirect', upstream: Notion OAuth}. Per-user Notion tokens stored
- *     by JWT `sub`. This is what the deployed `better-notion-mcp.n24q02m.com`
- *     serves; also the recommended self-host config.
+ * Post stdio-pure + http-multi-user split (2026-05-01): the MCP_MODE flavor
+ * (``local-relay`` vs ``remote-oauth``) is gone. HTTP mode is always
+ * delegated OAuth 2.1 redirect flow to Notion at
+ * ``https://api.notion.com/v1/oauth/authorize`` with per-JWT-sub Notion
+ * token storage. Single-user paste-token relay form is no longer supported
+ * here -- use stdio mode with NOTION_TOKEN env for single-user setups.
  *
- *   MCP_MODE=local-relay -- runLocalServer with relaySchema (paste integration
- *     token on /authorize). Single-user, no external OAuth. Recommended only
- *     for local development or offline environments.
+ * Required env: NOTION_OAUTH_CLIENT_ID, NOTION_OAUTH_CLIENT_SECRET,
+ * DCR_SERVER_SECRET (multi-user JWT signing).
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { type RelayConfigSchema, runLocalServer, writeConfig } from '@n24q02m/mcp-core'
+import { runHttpServer } from '@n24q02m/mcp-core'
 import { Client } from '@notionhq/client'
 import { NotionTokenStore } from '../auth/notion-token-store.js'
 import { createMCPServer } from '../create-server.js'
-import { getNotionToken, resolveCredentialState, setState, setSubjectTokenResolver } from '../credential-state.js'
-import { RELAY_SCHEMA } from '../relay-schema.js'
+import { resolveCredentialState, setState, setSubjectTokenResolver } from '../credential-state.js'
 import { NotionMCPError } from '../tools/helpers/errors.js'
 
 const SERVER_NAME = 'better-notion-mcp'
 
 export const subjectContext = new AsyncLocalStorage<{ sub: string }>()
 
-export type HttpMode = 'remote-oauth' | 'local-relay'
-
-export function resolveHttpMode(env: NodeJS.ProcessEnv): HttpMode {
-  const raw = env.MCP_MODE?.toLowerCase().trim()
-  if (raw === 'local-relay' || raw === 'remote-oauth') return raw
-  return 'remote-oauth'
-}
-
 export async function startHttp(): Promise<void> {
-  const mode = resolveHttpMode(process.env)
   await resolveCredentialState()
 
   const tokenStore = new NotionTokenStore()
-  let localToken: string | null = getNotionToken()
 
   const notionClientFactory = () => {
-    if (mode === 'remote-oauth') {
-      const ctx = subjectContext.getStore()
-      const token = ctx ? tokenStore.get(ctx.sub) : undefined
-      if (!token) {
-        throw new NotionMCPError(
-          'Notion access token not present for this session',
-          'NOT_CONFIGURED',
-          'Re-authorize via the Notion OAuth flow on /authorize.'
-        )
-      }
-      return new Client({ auth: token, notionVersion: '2025-09-03' })
-    }
-    if (!localToken) {
+    const ctx = subjectContext.getStore()
+    const token = ctx ? tokenStore.get(ctx.sub) : undefined
+    if (!token) {
       throw new NotionMCPError(
-        'Notion integration token not configured',
+        'Notion access token not present for this session',
         'NOT_CONFIGURED',
-        'Open /authorize on this server in your browser to paste your Notion integration token.'
+        'Re-authorize via the Notion OAuth flow on /authorize.'
       )
     }
-    return new Client({ auth: localToken, notionVersion: '2025-09-03' })
+    return new Client({ auth: token, notionVersion: '2025-09-03' })
   }
 
   const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 0
   const host = process.env.HOST
 
-  let handle: Awaited<ReturnType<typeof runLocalServer>>
-  if (mode === 'remote-oauth') {
-    const clientId = process.env.NOTION_OAUTH_CLIENT_ID
-    const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET
-    if (!clientId || !clientSecret) {
-      throw new Error('NOTION_OAUTH_CLIENT_ID and NOTION_OAUTH_CLIENT_SECRET are required for remote-oauth mode.')
-    }
-    handle = await runLocalServer(() => createMCPServer(notionClientFactory) as unknown as McpServer, {
-      serverName: SERVER_NAME,
-      port,
-      host,
-      delegatedOAuth: {
-        flow: 'redirect',
-        upstream: {
-          authorizeUrl: 'https://api.notion.com/v1/oauth/authorize',
-          tokenUrl: 'https://api.notion.com/v1/oauth/token',
-          clientId,
-          clientSecret,
-          scopes: []
-        },
-        onTokenReceived: (tokens) => {
-          const accessToken = String(tokens.access_token ?? '')
-          const sub = String((tokens as { owner_user_id?: string }).owner_user_id ?? 'default')
-          if (accessToken) tokenStore.save(sub, accessToken)
-          // Return sub so mcp-core (>=1.6.2) propagates it into the bearer
-          // JWT's `sub` claim, which `authScope` below then matches back
-          // to the stored Notion token. Without this, bearer JWT sub is
-          // hardcoded 'local-user' -> tokenStore.get() returns undefined.
-          return sub
-        }
-      },
-      authScope: async (claims, next) => {
-        const sub = typeof claims.sub === 'string' ? claims.sub : 'default'
-        await subjectContext.run({ sub }, next)
-      }
-    })
-    // In remote-oauth mode the server itself is fully configured once OAuth
-    // client credentials are validated; per-user Notion tokens live in
-    // `tokenStore` keyed by JWT sub, not in the single-user credential-state
-    // module. Mark state=configured so `config(action=status)` reflects
-    // server readiness (matrix step [7]).
-    setState('configured')
-    // Route `getSubjectToken()` to the per-user store so
-    // `config(action=status).has_token` reflects whether THIS caller has
-    // authorized, instead of always-null single-user global.
-    setSubjectTokenResolver(() => {
-      const ctx = subjectContext.getStore()
-      return ctx ? (tokenStore.get(ctx.sub) ?? null) : null
-    })
-    console.error(`[${SERVER_NAME}] remote-oauth mode on http://${handle.host}:${handle.port}/mcp`)
-  } else {
-    handle = await runLocalServer(() => createMCPServer(notionClientFactory) as unknown as McpServer, {
-      serverName: SERVER_NAME,
-      port,
-      host,
-      relaySchema: RELAY_SCHEMA as unknown as RelayConfigSchema,
-      onCredentialsSaved: async (creds) => {
-        const token = creds?.NOTION_TOKEN
-        if (typeof token === 'string' && token.length > 0) {
-          localToken = token
-          // Persist to encrypted config so the token survives process restarts
-          // — otherwise the user would have to re-paste after every restart.
-          await writeConfig(SERVER_NAME, { NOTION_TOKEN: token })
-          // Sync credential-state module so config(action=status) reports the
-          // up-to-date state (state=configured, has_token=true) without
-          // waiting for a process restart. Without this, `getState()` stays
-          // at its 'awaiting_setup' default even though the token is active.
-          await resolveCredentialState()
-          console.error(`[${SERVER_NAME}] Notion token received via /authorize and saved`)
-        }
-        return null
-      }
-    })
-    console.error(`[${SERVER_NAME}] local-relay mode on http://${handle.host}:${handle.port}/mcp`)
-    if (!localToken) {
-      console.error(`[${SERVER_NAME}] Open http://${handle.host}:${handle.port}/authorize to paste your Notion token`)
-    }
+  const clientId = process.env.NOTION_OAUTH_CLIENT_ID
+  const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET
+  if (!clientId || !clientSecret) {
+    throw new Error('NOTION_OAUTH_CLIENT_ID and NOTION_OAUTH_CLIENT_SECRET are required for http mode.')
   }
+
+  const handle = await runHttpServer(() => createMCPServer(notionClientFactory) as unknown as McpServer, {
+    serverName: SERVER_NAME,
+    port,
+    host,
+    delegatedOAuth: {
+      flow: 'redirect',
+      upstream: {
+        authorizeUrl: 'https://api.notion.com/v1/oauth/authorize',
+        tokenUrl: 'https://api.notion.com/v1/oauth/token',
+        clientId,
+        clientSecret,
+        scopes: []
+      },
+      onTokenReceived: (tokens: Record<string, unknown>) => {
+        const accessToken = String(tokens.access_token ?? '')
+        const sub = String((tokens as { owner_user_id?: string }).owner_user_id ?? 'default')
+        if (accessToken) tokenStore.save(sub, accessToken)
+        // Return sub so mcp-core (>=1.6.2) propagates it into the bearer
+        // JWT's `sub` claim, which `authScope` below then matches back
+        // to the stored Notion token.
+        return sub
+      }
+    },
+    authScope: async (claims: { sub?: unknown }, next: () => Promise<void>) => {
+      const sub = typeof claims.sub === 'string' ? claims.sub : 'default'
+      await subjectContext.run({ sub }, next)
+    }
+  })
+
+  // The server is fully configured once OAuth client credentials are
+  // validated; per-user Notion tokens live in `tokenStore` keyed by JWT
+  // sub. Mark state=configured so `config(action=status)` reflects
+  // server readiness.
+  setState('configured')
+  // Route `getSubjectToken()` to the per-user store so
+  // `config(action=status).has_token` reflects whether THIS caller has
+  // authorized.
+  setSubjectTokenResolver(() => {
+    const ctx = subjectContext.getStore()
+    return ctx ? (tokenStore.get(ctx.sub) ?? null) : null
+  })
+  console.error(`[${SERVER_NAME}] http mode on http://${handle.host}:${handle.port}/mcp`)
 
   await new Promise<void>((resolve) => {
     const shutdown = async (): Promise<void> => {


### PR DESCRIPTION
## Summary

Per spec `2026-05-01-stdio-pure-http-multiuser.md` S5.2.1.

- Flip `init-server.ts` default to **stdio** (was HTTP); HTTP via `--http`/`MCP_TRANSPORT=http`/`TRANSPORT_MODE=http` opt-in
- Delete `triggerRelaySetup` function + all callsites + `LocalServerHandle`/`runLocalServer` imports
- Refactor `transports/http.ts`: drop `MCP_MODE` flavor (was `local-relay` vs `remote-oauth`) -> single `remote-oauth` always-multi-user; rename `runLocalServer` -> `runHttpServer`
- Add stdio missing-cred handler in `main.ts` `startServer('stdio')`: exit 1 with clear stderr message when `NOTION_TOKEN` not set (TDD test added)
- Update `buildOpenRelayHandler` to new options-object signature (`{ serverName, publicUrl }`)
- Bump `@n24q02m/mcp-core` to `1.13.0-beta.4` (smart-stdio removed)

## Test plan

- [x] `bun run check` passes (biome + tsc)
- [x] `bun run test` passes 734/734
- [x] `bun run build` succeeds
- [x] Pre-commit hooks (gitleaks, biome, tsc, vitest) all green