### PR TITLE
⚡ Bolt: Extract inline regexes to module constants for parsing optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - URL Delimiter Parsing Optimization
 **Learning:** In JavaScript, using an unescaped `/` within a regex literal `/[/?#]/` causes a `SyntaxError` (Invalid regular expression: missing /), even within character classes. Also, placing regex literals inside functions on hot paths like URL validation causes slight overhead from repeated regex object creation.
 **Action:** When finding the first occurrence of multiple characters, consolidate multiple `.indexOf` calls into a single regex `.search()` pass (e.g. `URL_DELIMITER_REGEX.search(str)`), but always ensure slashes are properly escaped (or avoided via instantiation constraints) and ALWAYS declare regexes at the module level outside functions.
+## 2025-02-12 - Safe Regex Hoisting
+**Learning:** Python scripts using `string.replace()` provide a safer and more maintainable alternative to `sed` for precise, multi-line string replacements in source code files. Avoid `re.sub()` when the replacement string contains literal backslashes (e.g., regex constants) to prevent 'bad escape' sequence errors from the regex engine evaluating the replacement.
+**Action:** When extracting multiple inline regexes to module-level constants to prevent object recreation overhead on hot paths, use Python with `string.replace()` for the modifications.

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -67,6 +67,12 @@ const BULLETED_LIST_REGEX = /^[-*]\s/
 const NUMBERED_LIST_REGEX = /^\d+\.\s/
 const DIVIDER_REGEX = /^[-*]{3,}$/
 
+const PAGE_ID_REGEX = /([a-f0-9]{32})/
+const TABLE_SEPARATOR_REGEX = /^[-:]+$/
+const INLINE_SUMMARY_REGEX = /^<details>\s*<summary>(.*?)<\/summary>(.*?)(<\/details>)?$/
+const SUMMARY_REGEX = /<summary>(.*?)<\/summary>/
+const COLUMN_REGEX = /^:::column(?:\{width=([\d.]+)\})?$/
+
 /**
  * Convert markdown string to Notion blocks
  */
@@ -500,7 +506,7 @@ class InlineParser {
           const mentionTarget = this.text.slice(closeBracket + 2, closeParen)
 
           // Extract 32-char hex page ID from Notion URL or use as-is
-          const idMatch = mentionTarget.match(/([a-f0-9]{32})/)
+          const idMatch = mentionTarget.match(PAGE_ID_REGEX)
           const pageId = idMatch ? idMatch[1] : mentionTarget
 
           this.richText.push(
@@ -777,7 +783,7 @@ function parseTable(lines: string[], startIndex: number): TableParseResult | nul
 
   if (parsedRows.length >= 2) {
     const possibleSeparator = parsedRows[1]
-    const isSeparator = possibleSeparator.every((cell: string) => /^[-:]+$/.test(cell.trim()))
+    const isSeparator = possibleSeparator.every((cell: string) => TABLE_SEPARATOR_REGEX.test(cell.trim()))
 
     if (isSeparator) {
       hasHeader = true
@@ -817,7 +823,7 @@ function parseToggle(lines: string[], startIndex: number): ToggleParseResult {
   const detailsLine = lines[i].trim()
 
   // Try to extract <summary>...</summary> from the <details> line itself
-  const inlineSummaryMatch = detailsLine.match(/^<details>\s*<summary>(.*?)<\/summary>(.*?)(<\/details>)?$/)
+  const inlineSummaryMatch = detailsLine.match(INLINE_SUMMARY_REGEX)
 
   if (inlineSummaryMatch) {
     // All-on-one-line or inline summary: <details><summary>Title</summary>[Content][</details>]
@@ -846,7 +852,7 @@ function parseToggle(lines: string[], startIndex: number): ToggleParseResult {
 
     // Look for <summary>...</summary> on the next line
     if (i < lines.length) {
-      const summaryMatch = lines[i].match(/<summary>(.*?)<\/summary>/)
+      const summaryMatch = lines[i].match(SUMMARY_REGEX)
       if (summaryMatch) {
         title = summaryMatch[1]
         i++
@@ -910,7 +916,7 @@ function parseColumns(lines: string[], startIndex: number): ColumnParseResult {
       break
     }
 
-    const columnMatch = line.match(/^:::column(?:\{width=([\d.]+)\})?$/)
+    const columnMatch = line.match(COLUMN_REGEX)
     if (columnMatch) {
       // Flush previous column (even if empty)
       if (inColumn) {


### PR DESCRIPTION
💡 What: Extracted multiple inline regular expressions from within the parsing logic functions of `src/tools/helpers/markdown.ts` into module-level constants.

🎯 Why: In JavaScript, defining regex literals inside functions causes the engine to recreate the RegExp objects upon every function call, adding overhead and increasing garbage collection pressure. This is particularly problematic in a recursive descent or loop-based markdown parser where functions like `parseToggle`, `parseColumns`, and mentions extraction run frequently.

📊 Impact: Reduces intermediate object allocations and garbage collection pressure by preventing redundant RegExp object recreation during hot path markdown parsing. This should incrementally improve throughput on large markdown documents.

🔬 Measurement: Run a large markdown processing test or benchmark suite and observe memory usage/profiling overhead. The unit tests ensure all logic paths remain strictly correct.

---
*PR created automatically by Jules for task [16693651228391601860](https://jules.google.com/task/16693651228391601860) started by @n24q02m*