### PR TITLE
⚡ Bolt: Extract callout maps to module scope

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - URL Delimiter Parsing Optimization
 **Learning:** In JavaScript, using an unescaped `/` within a regex literal `/[/?#]/` causes a `SyntaxError` (Invalid regular expression: missing /), even within character classes. Also, placing regex literals inside functions on hot paths like URL validation causes slight overhead from repeated regex object creation.
 **Action:** When finding the first occurrence of multiple characters, consolidate multiple `.indexOf` calls into a single regex `.search()` pass (e.g. `URL_DELIMITER_REGEX.search(str)`), but always ensure slashes are properly escaped (or avoided via instantiation constraints) and ALWAYS declare regexes at the module level outside functions.
+
+## 2024-05-18 - Extract module-level constants
+**Learning:** Recreating static map objects inside frequently called functions (like markdown parsing helpers) causes unnecessary object allocation and garbage collection overhead.
+**Action:** Always move static, read-only map objects to module-level constants outside of functions, especially on hot paths like text parsing.

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -939,45 +939,50 @@ function parseColumns(lines: string[], startIndex: number): ColumnParseResult {
 // Callout helpers
 // ============================================================
 
+// ⚡ Bolt: Extracted callout maps to module-level constants to prevent object allocation
+// and garbage collection overhead on every function call during markdown parsing.
+const CALLOUT_ICONS: Record<string, string> = {
+  NOTE: '\u2139\ufe0f',
+  TIP: '\u{1f4a1}',
+  IMPORTANT: '\u2757',
+  WARNING: '\u26a0\ufe0f',
+  CAUTION: '\u{1f6d1}',
+  INFO: '\u2139\ufe0f',
+  SUCCESS: '\u2705',
+  ERROR: '\u274c'
+}
+
+const CALLOUT_COLORS: Record<string, string> = {
+  NOTE: 'blue_background',
+  TIP: 'green_background',
+  IMPORTANT: 'purple_background',
+  WARNING: 'yellow_background',
+  CAUTION: 'red_background',
+  INFO: 'blue_background',
+  SUCCESS: 'green_background',
+  ERROR: 'red_background'
+}
+
+const CALLOUT_TYPE_MAP: Record<string, string> = {
+  '\u2139\ufe0f': 'NOTE',
+  '\u{1f4a1}': 'TIP',
+  '\u2757': 'IMPORTANT',
+  '\u26a0\ufe0f': 'WARNING',
+  '\u{1f6d1}': 'CAUTION',
+  '\u2705': 'SUCCESS',
+  '\u274c': 'ERROR'
+}
+
 function getCalloutIcon(type: string): string {
-  const icons: Record<string, string> = {
-    NOTE: '\u2139\ufe0f',
-    TIP: '\u{1f4a1}',
-    IMPORTANT: '\u2757',
-    WARNING: '\u26a0\ufe0f',
-    CAUTION: '\u{1f6d1}',
-    INFO: '\u2139\ufe0f',
-    SUCCESS: '\u2705',
-    ERROR: '\u274c'
-  }
-  return icons[type] || '\u2139\ufe0f'
+  return CALLOUT_ICONS[type] || '\u2139\ufe0f'
 }
 
 function getCalloutColor(type: string): string {
-  const colors: Record<string, string> = {
-    NOTE: 'blue_background',
-    TIP: 'green_background',
-    IMPORTANT: 'purple_background',
-    WARNING: 'yellow_background',
-    CAUTION: 'red_background',
-    INFO: 'blue_background',
-    SUCCESS: 'green_background',
-    ERROR: 'red_background'
-  }
-  return colors[type] || 'gray_background'
+  return CALLOUT_COLORS[type] || 'gray_background'
 }
 
 function getCalloutTypeFromIcon(icon: string): string {
-  const iconMap: Record<string, string> = {
-    '\u2139\ufe0f': 'NOTE',
-    '\u{1f4a1}': 'TIP',
-    '\u2757': 'IMPORTANT',
-    '\u26a0\ufe0f': 'WARNING',
-    '\u{1f6d1}': 'CAUTION',
-    '\u2705': 'SUCCESS',
-    '\u274c': 'ERROR'
-  }
-  return iconMap[icon] || 'NOTE'
+  return CALLOUT_TYPE_MAP[icon] || 'NOTE'
 }
 
 // ============================================================


### PR DESCRIPTION
💡 What
Extracted internal map objects (`CALLOUT_ICONS`, `CALLOUT_COLORS`, and `CALLOUT_TYPE_MAP`) from `getCalloutIcon`, `getCalloutColor`, and `getCalloutTypeFromIcon` to module-level constants in `src/tools/helpers/markdown.ts`.

🎯 Why
Since markdown parsing is on a hot path, repeatedly calling these helper functions re-allocates their internal map literal objects on every invocation. Moving them to the module scope avoids this unnecessary object allocation and reduces garbage collection pressure.

📊 Impact
Saves the V8 engine from doing frequent object instantiations and subsequent GC sweeps, offering a small but noticeable performance win on heavy markdown inputs.

🔬 Measurement
Verify the changes by running `bun run check` and `bun run test` to confirm regressions aren't introduced in markdown serialization. Measure heap allocation counts or CPU profiles during heavy markdown parsing workloads.

---
*PR created automatically by Jules for task [12515154986081926916](https://jules.google.com/task/12515154986081926916) started by @n24q02m*