### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,15 @@
   "name": "better-notion-mcp",
   "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
   "version": "2.31.0",
+  "userConfig": {
+    "NOTION_TOKEN": {
+      "type": "string",
+      "title": "Notion integration token",
+      "description": "From https://www.notion.so/my-integrations (starts with ntn_)",
+      "sensitive": true,
+      "required": true
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -11,7 +20,10 @@
     "better-notion-mcp": {
       "command": "npx",
       "args": ["--yes", "@n24q02m/better-notion-mcp@latest"],
-      "env": { "MCP_TRANSPORT": "stdio" }
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "NOTION_TOKEN": "${user_config.NOTION_TOKEN}"
+      }
     }
   }
 }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -27,18 +27,32 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode** with `NOTION_TOKEN` env var. No daemon-bridge, no auto-spawn, no relay form.
 
+### Step 0: Credential prompt
+
+When you run `/plugin install better-notion-mcp@n24q02m-plugins`, Claude Code prompts for the credentials declared in the plugin's `userConfig` schema:
+
+| Field | Required | Sensitive | Notes |
+|:------|:---------|:----------|:------|
+| `NOTION_TOKEN` | Yes | Yes | Notion integration token (`ntn_...`) |
+
+Sensitive values are stored in the system keychain (or `~/.claude/.credentials.json` fallback) and persist across `/plugin update`. You do **not** need to manually edit the `env` block in `settings.json` -- Claude Code substitutes the value via `${user_config.NOTION_TOKEN}` declared in `plugin.json`.
+
+### Steps
+
 1. Create a Notion integration token:
    - Go to https://www.notion.so/my-integrations
    - Click "New integration", name it (e.g. "Better Notion MCP"), select your workspace
    - Copy the "Internal Integration Secret" (starts with `ntn_`)
    - **Share pages with the integration**: open a Notion page > "..." > Connections > select your integration. Repeat for each page or database you want accessible.
 2. Open Claude Code in your terminal
-3. Install the plugin:
+3. Install the plugin (Claude Code prompts for `NOTION_TOKEN` -- paste the secret you copied above):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install better-notion-mcp@n24q02m-plugins
    ```
-4. Set `NOTION_TOKEN` in the plugin config when prompted (or in your Claude Code settings).
+4. Restart Claude Code. The plugin auto-loads with your token injected via `${user_config.NOTION_TOKEN}`.
+
+> **HTTP transport (Method 3)** is a separate install path. The `userConfig` prompt only covers stdio Method 1; HTTP self-host still requires manual `mcpServers` config per Method 3 below.
 
 ## Method 2: Docker stdio (fallback)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -24,19 +24,33 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode** with `NOTION_TOKEN` env var. No daemon-bridge, no auto-spawn, no relay form.
 
+### Step 0: Credential prompt
+
+When you run `/plugin install better-notion-mcp@n24q02m-plugins`, Claude Code prompts for the values declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive |
+|:------|:---------|:----------|
+| `NOTION_TOKEN` | Yes | Yes (stored in keychain) |
+
+The plugin manifest substitutes the value into the `mcpServers` env block via `${user_config.NOTION_TOKEN}` -- you do not edit `env` manually. The value persists across `/plugin update`.
+
+### Steps
+
 1. Create a Notion integration token:
    - Go to https://www.notion.so/my-integrations
    - Click "New integration", name it, select your workspace
    - Copy the "Internal Integration Secret" (starts with `ntn_`)
    - Share pages/databases with the integration: open page > "..." > Connections > select your integration
-2. Install the plugin:
+2. Install the plugin (Claude Code prompts for `NOTION_TOKEN`):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install better-notion-mcp@n24q02m-plugins
    ```
-3. Set `NOTION_TOKEN` in the plugin config (or your Claude Code settings).
+3. Restart Claude Code -- the plugin auto-loads with your token.
 
 This installs the server with skills: `/organize-database`, `/bulk-update`.
+
+> **HTTP transport (Option 3)** is a separate install path; the `userConfig` prompt does not apply, and you manually configure `mcpServers` for HTTP per Option 3 below.
 
 ## Option 2: Docker stdio (fallback)
 


### PR DESCRIPTION
## Summary

- Add `userConfig.NOTION_TOKEN` (sensitive, required) to `.claude-plugin/plugin.json` so `/plugin install better-notion-mcp@n24q02m-plugins` prompts for the Notion integration token at install time.
- Substitute the value via `${user_config.NOTION_TOKEN}` into `mcpServers.better-notion-mcp.env` per [Claude Code plugin reference](https://code.claude.com/docs/en/plugins-reference.md#user-configuration).
- Update `docs/setup-manual.md` and `docs/setup-with-agent.md` Method 1 with a Step 0 section explaining the credential prompt and clarifying that HTTP transport (Method 3) remains a separate manual `mcpServers` override path.

## Test plan
- [ ] CI green (biome, tsc, vitest)
- [ ] After merge + claude-plugins sync, `/plugin install better-notion-mcp@n24q02m-plugins` prompts for `NOTION_TOKEN`
- [ ] Tool calls succeed with the token injected via `${user_config.NOTION_TOKEN}`

Generated with [Claude Code](https://claude.com/claude-code)