### PR TITLE
⚡ Bolt: Extract static dictionaries in callout parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - URL Delimiter Parsing Optimization
 **Learning:** In JavaScript, using an unescaped `/` within a regex literal `/[/?#]/` causes a `SyntaxError` (Invalid regular expression: missing /), even within character classes. Also, placing regex literals inside functions on hot paths like URL validation causes slight overhead from repeated regex object creation.
 **Action:** When finding the first occurrence of multiple characters, consolidate multiple `.indexOf` calls into a single regex `.search()` pass (e.g. `URL_DELIMITER_REGEX.search(str)`), but always ensure slashes are properly escaped (or avoided via instantiation constraints) and ALWAYS declare regexes at the module level outside functions.
+
+## 2025-02-12 - Extract Static Objects from Hot Paths
+**Learning:** In `src/tools/helpers/markdown.ts`, dictionary maps for callout icons, colors, and types were being re-created on every single function invocation. On hot paths like markdown parsing, recreating static objects repeatedly causes unnecessary memory allocation and garbage collection overhead.
+**Action:** Always extract static, read-only objects (like dictionaries, sets, or configurations) into module-level constants outside of functions, especially those called frequently within loops or parsers.

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -939,45 +939,48 @@ function parseColumns(lines: string[], startIndex: number): ColumnParseResult {
 // Callout helpers
 // ============================================================
 
+const CALLOUT_ICONS: Record<string, string> = {
+  NOTE: '\u2139\ufe0f',
+  TIP: '\u{1f4a1}',
+  IMPORTANT: '\u2757',
+  WARNING: '\u26a0\ufe0f',
+  CAUTION: '\u{1f6d1}',
+  INFO: '\u2139\ufe0f',
+  SUCCESS: '\u2705',
+  ERROR: '\u274c'
+}
+
 function getCalloutIcon(type: string): string {
-  const icons: Record<string, string> = {
-    NOTE: '\u2139\ufe0f',
-    TIP: '\u{1f4a1}',
-    IMPORTANT: '\u2757',
-    WARNING: '\u26a0\ufe0f',
-    CAUTION: '\u{1f6d1}',
-    INFO: '\u2139\ufe0f',
-    SUCCESS: '\u2705',
-    ERROR: '\u274c'
-  }
-  return icons[type] || '\u2139\ufe0f'
+  return CALLOUT_ICONS[type] || '\u2139\ufe0f'
+}
+
+const CALLOUT_COLORS: Record<string, string> = {
+  NOTE: 'blue_background',
+  TIP: 'green_background',
+  IMPORTANT: 'purple_background',
+  WARNING: 'yellow_background',
+  CAUTION: 'red_background',
+  INFO: 'blue_background',
+  SUCCESS: 'green_background',
+  ERROR: 'red_background'
 }
 
 function getCalloutColor(type: string): string {
-  const colors: Record<string, string> = {
-    NOTE: 'blue_background',
-    TIP: 'green_background',
-    IMPORTANT: 'purple_background',
-    WARNING: 'yellow_background',
-    CAUTION: 'red_background',
-    INFO: 'blue_background',
-    SUCCESS: 'green_background',
-    ERROR: 'red_background'
-  }
-  return colors[type] || 'gray_background'
+  return CALLOUT_COLORS[type] || 'gray_background'
+}
+
+const CALLOUT_TYPES: Record<string, string> = {
+  '\u2139\ufe0f': 'NOTE',
+  '\u{1f4a1}': 'TIP',
+  '\u2757': 'IMPORTANT',
+  '\u26a0\ufe0f': 'WARNING',
+  '\u{1f6d1}': 'CAUTION',
+  '\u2705': 'SUCCESS',
+  '\u274c': 'ERROR'
 }
 
 function getCalloutTypeFromIcon(icon: string): string {
-  const iconMap: Record<string, string> = {
-    '\u2139\ufe0f': 'NOTE',
-    '\u{1f4a1}': 'TIP',
-    '\u2757': 'IMPORTANT',
-    '\u26a0\ufe0f': 'WARNING',
-    '\u{1f6d1}': 'CAUTION',
-    '\u2705': 'SUCCESS',
-    '\u274c': 'ERROR'
-  }
-  return iconMap[icon] || 'NOTE'
+  return CALLOUT_TYPES[icon] || 'NOTE'
 }
 
 // ============================================================


### PR DESCRIPTION
💡 **What:** Extracted the callout mapping objects (`CALLOUT_ICONS`, `CALLOUT_COLORS`, `CALLOUT_TYPES`) into module-level constants in `src/tools/helpers/markdown.ts`.

🎯 **Why:** Previously, functions like `getCalloutIcon` recreated mapping dictionaries on every invocation. In markdown block conversions, this happens very frequently. By hoisting these into module scope, we eliminate repeated memory allocation and garbage collection overhead on hot paths. 

📊 **Impact:** Reduces object allocation overhead linearly with the number of callouts processed during parsing.

🔬 **Measurement:** Can be verified with local benchmarks executing `markdownToBlocks` over callout-heavy markdown documents, measuring GC and parse-time overhead.

---
*PR created automatically by Jules for task [5474891390862767922](https://jules.google.com/task/5474891390862767922) started by @n24q02m*