### PR TITLE
feat: document userConfig credential prompts per plugin

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -27,15 +27,13 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode** with `NOTION_TOKEN` env var. No daemon-bridge, no auto-spawn, no relay form.
 
-### Step 0: Credential prompt
+### Credential prompts at install
 
-When you run `/plugin install better-notion-mcp@n24q02m-plugins`, Claude Code prompts for the credentials declared in the plugin's `userConfig` schema:
+When you run `/plugin install`, Claude Code prompts you for the following credentials (declared in `userConfig` per CC docs). Sensitive values are stored in your system keychain and persist across `/plugin update`:
 
-| Field | Required | Sensitive | Notes |
-|:------|:---------|:----------|:------|
-| `NOTION_TOKEN` | Yes | Yes | Notion integration token (`ntn_...`) |
-
-Sensitive values are stored in the system keychain (or `~/.claude/.credentials.json` fallback) and persist across `/plugin update`. You do **not** need to manually edit the `env` block in `settings.json` -- Claude Code substitutes the value via `${user_config.NOTION_TOKEN}` declared in `plugin.json`.
+| Field | Required | Where to obtain |
+|---|---|---|
+| `NOTION_TOKEN` | Required | https://www.notion.so/my-integrations (starts with `ntn_`) |
 
 ### Steps
 
@@ -51,8 +49,6 @@ Sensitive values are stored in the system keychain (or `~/.claude/.credentials.j
    /plugin install better-notion-mcp@n24q02m-plugins
    ```
 4. Restart Claude Code. The plugin auto-loads with your token injected via `${user_config.NOTION_TOKEN}`.
-
-> **HTTP transport (Method 3)** is a separate install path. The `userConfig` prompt only covers stdio Method 1; HTTP self-host still requires manual `mcpServers` config per Method 3 below.
 
 ## Method 2: Docker stdio (fallback)
 
@@ -94,6 +90,8 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background work, scheduled agents, or webhook listeners.
 
 ## Method 3: Docker HTTP (recommended)
+
+> **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 
 ### 3.1. Hosted (n24q02m.com)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -24,15 +24,13 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode** with `NOTION_TOKEN` env var. No daemon-bridge, no auto-spawn, no relay form.
 
-### Step 0: Credential prompt
+### Credential prompts at install
 
-When you run `/plugin install better-notion-mcp@n24q02m-plugins`, Claude Code prompts for the values declared in `plugin.json` `userConfig`:
+When you run `/plugin install`, Claude Code prompts you for the following credentials (declared in `userConfig` per CC docs). Sensitive values are stored in your system keychain and persist across `/plugin update`:
 
-| Field | Required | Sensitive |
-|:------|:---------|:----------|
-| `NOTION_TOKEN` | Yes | Yes (stored in keychain) |
-
-The plugin manifest substitutes the value into the `mcpServers` env block via `${user_config.NOTION_TOKEN}` -- you do not edit `env` manually. The value persists across `/plugin update`.
+| Field | Required | Where to obtain |
+|---|---|---|
+| `NOTION_TOKEN` | Required | https://www.notion.so/my-integrations (starts with `ntn_`) |
 
 ### Steps
 
@@ -49,8 +47,6 @@ The plugin manifest substitutes the value into the `mcpServers` env block via `$
 3. Restart Claude Code -- the plugin auto-loads with your token.
 
 This installs the server with skills: `/organize-database`, `/bulk-update`.
-
-> **HTTP transport (Option 3)** is a separate install path; the `userConfig` prompt does not apply, and you manually configure `mcpServers` for HTTP per Option 3 below.
 
 ## Option 2: Docker stdio (fallback)
 
@@ -83,6 +79,8 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background work, scheduled agents, or webhook listeners.
 
 ## Option 3: Docker HTTP (recommended)
+
+> **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 
 ### 3.1. Hosted (n24q02m.com)
 


### PR DESCRIPTION
## Summary
- Replace ad-hoc `Step 0: Credential prompt` paragraph in `docs/setup-manual.md` + `docs/setup-with-agent.md` with a canonical `Credential prompts at install` table per spec V9.
- Table columns: `Field | Required | Where to obtain` — lists every key declared in `plugin.json` `userConfig` together with the upstream URL or value-format hint.
- Add a 2-sentence note inside Method 3 / Option 3 (HTTP recommended) clarifying that HTTP transport is selected by overriding `mcpServers` in client settings, not via `userConfig` (which only feeds stdio mode).
- Drops the legacy `> **HTTP transport (Method 3)** is a separate install path` blockquote at the end of Method 1 / Option 1 since the new credential block + Method 3 note now carry that pointer.

## Test plan
- [x] `plugin.json` userConfig keys match the documented table 1:1
- [x] pre-commit passes (lint, type, JSON, diacritics, secret scan)
- [ ] CI green
- [ ] Marketplace install UX prompts match the documented fields

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>