### PR TITLE
feat: clarify Method 1 vs Method 3 mutually exclusive (CC scope-by-endpoint)

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -18,7 +18,7 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
-> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace — both would load and create duplicate entries (plugin's stdio + your HTTP override). Plugin matching is by **endpoint** (URL or command) per CC docs, not by name, so name-collision does NOT suppress the duplicate. Trade-off: choosing Method 3 (HTTP) means you lose this plugin's skills/agents/hooks/commands (those only ship with the plugin install). For full plugin features, use Method 1 (stdio) with `userConfig` credentials prompted at install time.
+> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 2 (Docker stdio override) OR Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace. Both load simultaneously and create duplicate entries in `/mcp` dialog (plugin's stdio + your override). Plugin matching is by **endpoint** (URL or command string) per CC docs, not by name — and `npx`/`uvx` ≠ `docker` ≠ HTTP URL, so all three are distinct endpoints. Trade-off: choosing Method 2 or Method 3 means you lose this plugin's skills/agents/hooks/commands. For full plugin features, use Method 1 (default plugin install) with `userConfig` credentials prompted at install time.
 
 ## Prerequisites
 
@@ -52,9 +52,13 @@ When you run `/plugin install`, Claude Code prompts you for the following creden
    ```
 4. Restart Claude Code. The plugin auto-loads with your token injected via `${user_config.NOTION_TOKEN}`.
 
-> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use HTTP transport (Method 3 below), DO NOT `/plugin install` this plugin — pick Method 3 instead. The two methods are mutually exclusive (see Method overview).
+> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use Method 2 (Docker stdio) or Method 3 (HTTP) below, DO NOT `/plugin install` this plugin — pick Method 2 or Method 3 instead. All three methods are mutually exclusive (see Method overview).
 
 ## Method 2: Docker stdio (fallback)
+
+> **⚠️ Before adding the Docker stdio override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-notion-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's `npx`/`uvx` stdio + your `docker run` stdio) will load simultaneously since plugin matches by endpoint (command string), not by name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. Use Method 1 instead if you want full plugin features.
 
 1. Pull the image:
    ```bash

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -18,6 +18,8 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
+> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace — both would load and create duplicate entries (plugin's stdio + your HTTP override). Plugin matching is by **endpoint** (URL or command) per CC docs, not by name, so name-collision does NOT suppress the duplicate. Trade-off: choosing Method 3 (HTTP) means you lose this plugin's skills/agents/hooks/commands (those only ship with the plugin install). For full plugin features, use Method 1 (stdio) with `userConfig` credentials prompted at install time.
+
 ## Prerequisites
 
 - **Node.js** >= 24.14.1
@@ -49,6 +51,8 @@ When you run `/plugin install`, Claude Code prompts you for the following creden
    /plugin install better-notion-mcp@n24q02m-plugins
    ```
 4. Restart Claude Code. The plugin auto-loads with your token injected via `${user_config.NOTION_TOKEN}`.
+
+> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use HTTP transport (Method 3 below), DO NOT `/plugin install` this plugin — pick Method 3 instead. The two methods are mutually exclusive (see Method overview).
 
 ## Method 2: Docker stdio (fallback)
 
@@ -90,6 +94,10 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background work, scheduled agents, or webhook listeners.
 
 ## Method 3: Docker HTTP (recommended)
+
+> **⚠️ Before adding the HTTP override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-notion-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's stdio + your HTTP override) will load simultaneously since plugin matches by endpoint, not name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. For example, the `better-notion-mcp:organize-database` skill will no longer be available. Use Method 1 instead if you want full plugin features.
 
 > **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -20,6 +20,8 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
+> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace — both would load and create duplicate entries (plugin's stdio + your HTTP override). Plugin matching is by **endpoint** (URL or command) per CC docs, not by name, so name-collision does NOT suppress the duplicate. Trade-off: choosing Method 3 (HTTP) means you lose this plugin's skills/agents/hooks/commands (those only ship with the plugin install). For full plugin features, use Method 1 (stdio) with `userConfig` credentials prompted at install time.
+
 ## Option 1: Claude Code Plugin (Recommended)
 
 Plugin marketplace install runs the server in **pure stdio mode** with `NOTION_TOKEN` env var. No daemon-bridge, no auto-spawn, no relay form.
@@ -47,6 +49,8 @@ When you run `/plugin install`, Claude Code prompts you for the following creden
 3. Restart Claude Code -- the plugin auto-loads with your token.
 
 This installs the server with skills: `/organize-database`, `/bulk-update`.
+
+> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use HTTP transport (Option 3 below), DO NOT `/plugin install` this plugin — pick Option 3 instead. The two methods are mutually exclusive (see Method overview).
 
 ## Option 2: Docker stdio (fallback)
 
@@ -79,6 +83,10 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background work, scheduled agents, or webhook listeners.
 
 ## Option 3: Docker HTTP (recommended)
+
+> **⚠️ Before adding the HTTP override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-notion-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's stdio + your HTTP override) will load simultaneously since plugin matches by endpoint, not name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. For example, the `better-notion-mcp:organize-database` skill will no longer be available. Use Option 1 instead if you want full plugin features.
 
 > **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -20,7 +20,7 @@ This plugin supports 3 install methods. Pick the one that matches your use case:
 
 All MCP servers across this stack share this priority hierarchy. Note: 2 plugins (`better-godot-mcp` and `better-code-review-graph`) only support Method 1 (stdio) -- they need direct host access to project files / repo paths and don't ship Docker / HTTP variants.
 
-> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace — both would load and create duplicate entries (plugin's stdio + your HTTP override). Plugin matching is by **endpoint** (URL or command) per CC docs, not by name, so name-collision does NOT suppress the duplicate. Trade-off: choosing Method 3 (HTTP) means you lose this plugin's skills/agents/hooks/commands (those only ship with the plugin install). For full plugin features, use Method 1 (stdio) with `userConfig` credentials prompted at install time.
+> **⚠️ Mutually exclusive — pick ONE per plugin**: If you choose Method 2 (Docker stdio override) OR Method 3 (HTTP), do NOT also `/plugin install` this plugin via marketplace. Both load simultaneously and create duplicate entries in `/mcp` dialog (plugin's stdio + your override). Plugin matching is by **endpoint** (URL or command string) per CC docs, not by name — and `npx`/`uvx` ≠ `docker` ≠ HTTP URL, so all three are distinct endpoints. Trade-off: choosing Method 2 or Method 3 means you lose this plugin's skills/agents/hooks/commands. For full plugin features, use Method 1 (default plugin install) with `userConfig` credentials prompted at install time.
 
 ## Option 1: Claude Code Plugin (Recommended)
 
@@ -50,9 +50,13 @@ When you run `/plugin install`, Claude Code prompts you for the following creden
 
 This installs the server with skills: `/organize-database`, `/bulk-update`.
 
-> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use HTTP transport (Option 3 below), DO NOT `/plugin install` this plugin — pick Option 3 instead. The two methods are mutually exclusive (see Method overview).
+> **Note**: This installs the full plugin (skills + agents + hooks + commands + stdio MCP server). If you'd rather use Option 2 (Docker stdio) or Option 3 (HTTP) below, DO NOT `/plugin install` this plugin — pick Option 2 or Option 3 instead. All three methods are mutually exclusive (see Method overview).
 
 ## Option 2: Docker stdio (fallback)
+
+> **⚠️ Before adding the Docker stdio override below, ensure this plugin is NOT installed via marketplace**: Run `/plugin uninstall better-notion-mcp@n24q02m-plugins` first if you previously ran `/plugin install`. Otherwise both entries (plugin's `npx`/`uvx` stdio + your `docker run` stdio) will load simultaneously since plugin matches by endpoint (command string), not by name.
+>
+> **Trade-off accepted**: Choosing this method means you lose this plugin's skills/agents/hooks/commands. Use Option 1 instead if you want full plugin features.
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Plugin matching is by **endpoint** (URL or command) per CC docs, not name. User `mcpServers` HTTP entry and plugin's stdio command are different endpoints, so both load simultaneously creating duplicate entries.
- Document mutual exclusivity in 3 places of `setup-manual.md` + `setup-with-agent.md`:
  - Method overview: warning callout under priority table
  - Method 1: trade-off note pointing to Method 3 alternative
  - Method 3: uninstall-first warning + skill loss trade-off

## Test plan

- [x] Read both updated docs end-to-end for prose flow
- [x] Pre-commit hooks pass (gitleaks, whitespace)
- [ ] CI green before admin merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)