### PR TITLE
[TEST] Missing Error Path Test in Users Tool

### DIFF
--- a/src/tools/composite/users.test.ts
+++ b/src/tools/composite/users.test.ts
@@ -90,10 +90,31 @@ describe('users', () => {
       })
     })
 
-    it('should rethrow non-permission errors', async () => {
+    it('should handle rate_limited error', async () => {
+      mockNotion.users.list.mockRejectedValue({ code: 'rate_limited', message: 'Too many requests' })
+
+      await expect(users(mockNotion as any, { action: 'list' })).rejects.toMatchObject({
+        code: 'RATE_LIMITED',
+        message: 'Too many requests to Notion API'
+      })
+    })
+
+    it('should handle unknown Notion error code', async () => {
+      mockNotion.users.list.mockRejectedValue({ code: 'internal_server_error', message: 'Something went wrong' })
+
+      await expect(users(mockNotion as any, { action: 'list' })).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Something went wrong'
+      })
+    })
+
+    it('should handle generic network errors', async () => {
       mockNotion.users.list.mockRejectedValue(new Error('network error'))
 
-      await expect(users(mockNotion as any, { action: 'list' })).rejects.toThrow('network error')
+      await expect(users(mockNotion as any, { action: 'list' })).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'network error'
+      })
     })
 
     it('should default name to Unknown when missing', async () => {


### PR DESCRIPTION
## 💡 What
Added comprehensive error path tests for the `users` tool's `list` action in `src/tools/composite/users.test.ts`.

## 🎯 Why
The original tests achieved high line coverage but didn't explicitly assert the `NotionMCPError` format and details for various error scenarios (like rate limiting or unknown Notion error codes) in the `list` action.

## 📊 Impact
- Improved test robustness for the `users` tool.
- Verified that error handling transformations correctly map Notion API errors to standardized MCP errors with appropriate messages and codes.
- Maintained 100% statement/branch coverage for `src/tools/composite/users.ts`.

## 🔬 Measurement
- Ran `bun x vitest --coverage --run src/tools/composite/users.test.ts` to verify coverage.
- Ran `bun run test` to ensure no regressions across the codebase (736 tests passing).

---
*PR created automatically by Jules for task [14837713745664198121](https://jules.google.com/task/14837713745664198121) started by @n24q02m*