### PR TITLE
[TEST] Missing Edge Case Test for extractPageProperties

### DIFF
--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -690,4 +690,10 @@ describe('extractPageProperties', () => {
     }
     expect(extractPageProperties(props)).toEqual({})
   })
+
+  it('handles null, undefined or empty input', () => {
+    expect(extractPageProperties(null)).toEqual({})
+    expect(extractPageProperties(undefined)).toEqual({})
+    expect(extractPageProperties({})).toEqual({})
+  })
 })

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -124,6 +124,7 @@ export function convertToNotionProperties(
  * creating thousands of intermediate arrays during large `.map()` chains.
  */
 export function extractPageProperties(pageProperties: any): any {
+  if (!pageProperties) return {}
   const properties: any = {}
 
   const keys = Object.keys(pageProperties)


### PR DESCRIPTION
This PR adds a guard clause to the `extractPageProperties` function to safely handle `null` or `undefined` inputs, which previously caused a `TypeError`. It also adds comprehensive test coverage for these edge cases (null, undefined, and empty objects) in the corresponding test file.

Changes:
- Added `if (!pageProperties) return {}` to `src/tools/helpers/properties.ts`.
- Added new test cases to `src/tools/helpers/properties.test.ts`.

---
*PR created automatically by Jules for task [13504036954983236075](https://jules.google.com/task/13504036954983236075) started by @n24q02m*