### PR TITLE
[FIX] Remove explicit 'any' cast for properties in pages tool

### DIFF
--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -156,7 +156,7 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
   const normalizedId = input.parent_id.replace(/-/g, '')
 
   // Auto-detect parent type
-  let parent: any
+  let parent: Record<string, any>
   if (input.properties && Object.keys(input.properties).length > 0) {
     parent = { type: 'database_id', database_id: normalizedId }
   } else {
@@ -164,7 +164,7 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
   }
 
   // Prepare properties
-  let properties: any = {}
+  let properties: Record<string, any> = {}
   if (parent.database_id) {
     properties = convertToNotionProperties(input.properties || {})
     if (!properties.title && !properties.Name && !properties.Title) {
@@ -174,7 +174,7 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
     properties = { title: { title: [RichText.text(input.title)] } }
   }
 
-  const pageData: any = { parent, properties }
+  const pageData: Record<string, any> = { parent, properties }
   if (input.icon) pageData.icon = formatIcon(input.icon)
   if (input.cover) pageData.cover = formatCover(input.cover)
 
@@ -338,7 +338,7 @@ async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePage
     throw new NotionMCPError('page_id is required for update action', 'VALIDATION_ERROR', 'Provide page_id')
   }
 
-  const updates: any = {}
+  const updates: Record<string, any> = {}
 
   // Update metadata
   if (input.icon) updates.icon = formatIcon(input.icon)


### PR DESCRIPTION
Variables initialized as empty objects should be typed appropriately, like Record<string, any>. This PR replaces the explicit 'any' type for several variables in the pages tool to improve type safety while maintaining compatibility with the Notion SDK.

Changes:
- In \`createPage\`, \`parent\`, \`properties\`, and \`pageData\` now use \`Record<string, any>\` instead of \`any\`.
- In \`updatePage\`, \`updates\` now uses \`Record<string, any>\` instead of \`any\`.
- Verified changes with existing tests and linting.

---
*PR created automatically by Jules for task [14528622402904010307](https://jules.google.com/task/14528622402904010307) started by @n24q02m*