### PR TITLE
[FIX] Resolve TODO for unchecked checkbox parsing

### DIFF
--- a/src/tools/helpers/markdown.test.ts
+++ b/src/tools/helpers/markdown.test.ts
@@ -97,6 +97,14 @@ describe('markdownToBlocks', () => {
       expect(getRichTextContent(blocks[0])).toBe('First')
       expect(getRichTextContent(blocks[1])).toBe('Second')
     })
+    it('should parse indented bulleted items', () => {
+      const blocks = markdownToBlocks('  - First\n    - Second')
+      expect(blocks).toHaveLength(2)
+      expect(blocks[0].type).toBe('bulleted_list_item')
+      expect(blocks[1].type).toBe('bulleted_list_item')
+      expect(getRichTextContent(blocks[0])).toBe('First')
+      expect(getRichTextContent(blocks[1])).toBe('Second')
+    })
 
     it('should parse asterisk-prefixed items', () => {
       const blocks = markdownToBlocks('* Item A\n* Item B')
@@ -115,6 +123,12 @@ describe('markdownToBlocks', () => {
       }
       expect(getRichTextContent(blocks[0])).toBe('First')
       expect(getRichTextContent(blocks[2])).toBe('Third')
+    })
+    it('should parse indented numbered items', () => {
+      const blocks = markdownToBlocks('  1. One\n    2. Two')
+      expect(blocks).toHaveLength(2)
+      expect(blocks[0].type).toBe('numbered_list_item')
+      expect(blocks[1].type).toBe('numbered_list_item')
     })
   })
 
@@ -145,6 +159,35 @@ describe('markdownToBlocks', () => {
       expect(blocks).toHaveLength(2)
       expect(blocks[0].to_do.checked).toBe(false)
       expect(blocks[1].to_do.checked).toBe(true)
+    })
+    it('should parse todo item with plus bullet', () => {
+      const blocks = markdownToBlocks('+ [ ] Plus todo')
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].type).toBe('to_do')
+      expect(blocks[0].to_do.checked).toBe(false)
+      expect(getRichTextContent(blocks[0])).toBe('Plus todo')
+    })
+
+    it('should parse indented todo item', () => {
+      const blocks = markdownToBlocks('  - [ ] Indented')
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].type).toBe('to_do')
+      expect(getRichTextContent(blocks[0])).toBe('Indented')
+    })
+
+    it('should parse todo item without text', () => {
+      const blocks = markdownToBlocks('- [ ]')
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].type).toBe('to_do')
+      expect(getRichTextContent(blocks[0])).toBe('')
+    })
+
+    it('should parse todo item with asterisk bullet', () => {
+      const blocks = markdownToBlocks('* [x] Asterisk')
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].type).toBe('to_do')
+      expect(blocks[0].to_do.checked).toBe(true)
+      expect(getRichTextContent(blocks[0])).toBe('Asterisk')
     })
   })
 

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -62,9 +62,9 @@ function createMention(
 const CALLOUT_REGEX = /^>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|INFO|SUCCESS|ERROR)\]\s*(.*)/i
 const IMAGE_REGEX = /^!\[([^\]]*)\]\(([^)]+)\)$/
 const BOOKMARK_REGEX = /^\[(bookmark|embed)\]\(([^)]+)\)$/i
-const CHECKED_LIST_REGEX = /^[-*]\s\[([ xX])\]\s/
-const BULLETED_LIST_REGEX = /^[-*]\s/
-const NUMBERED_LIST_REGEX = /^\d+\.\s/
+const CHECKED_LIST_REGEX = /^\s*[-*+]\s\[([ xX])\](?:\s|$)/
+const BULLETED_LIST_REGEX = /^\s*[-*+]\s/
+const NUMBERED_LIST_REGEX = /^\s*\d+\.\s/
 const DIVIDER_REGEX = /^[-*]{3,}$/
 
 /**
@@ -208,7 +208,8 @@ class MarkdownParser {
 
     // Task list / Checkbox list - [ ] or - [x]
     else if (CHECKED_LIST_REGEX.test(line)) {
-      const checked = line[3] !== ' '
+      const match = line.match(CHECKED_LIST_REGEX)
+      const checked = match ? match[1].toLowerCase() === 'x' : false
       const text = line.replace(CHECKED_LIST_REGEX, '')
       this.currentListType = 'bulleted'
       this.currentList.push(createTodoItem(text, checked))
@@ -1230,5 +1231,5 @@ function createBreadcrumb(): NotionBlock {
 }
 
 function isListItem(line: string): boolean {
-  return BULLETED_LIST_REGEX.test(line) || NUMBERED_LIST_REGEX.test(line)
+  return CHECKED_LIST_REGEX.test(line) || BULLETED_LIST_REGEX.test(line) || NUMBERED_LIST_REGEX.test(line)
 }


### PR DESCRIPTION
Improved markdown parsing for checkboxes and lists to support indentation, '+' bullets, and empty checkboxes.

Specific changes:
- Updated `CHECKED_LIST_REGEX` to support optional leading whitespace, `+` bullets, and checkboxes without trailing text.
- Updated `BULLETED_LIST_REGEX` and `NUMBERED_LIST_REGEX` to support indentation.
- Improved checkbox parsing logic in `MarkdownParser` to correctly handle indentation and different markers (x, X, space).
- Updated `isListItem` to include checkbox lines.
- Added comprehensive tests in `src/tools/helpers/markdown.test.ts` for indented lists, `+` bullets, and empty checkboxes.

---
*PR created automatically by Jules for task [1693392819262052479](https://jules.google.com/task/1693392819262052479) started by @n24q02m*