### PR TITLE
[CLEANUP] Potential Path Traversal in Documentation Reading

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -470,8 +470,13 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
       )
     }
 
+    const fullPath = join(DOCS_DIR, basename(resource.file))
+    if (!fullPath.startsWith(DOCS_DIR)) {
+      throw new NotionMCPError('Path traversal attempt detected', 'SECURITY_ERROR', 'Invalid resource file')
+    }
+
     try {
-      const content = await readFile(join(DOCS_DIR, basename(resource.file)), 'utf-8')
+      const content = await readFile(fullPath, 'utf-8')
       return {
         contents: [{ uri, mimeType: 'text/markdown', text: content }]
       }


### PR DESCRIPTION
This PR hardens the documentation resource reading against potential path traversal.

### Changes
- Added a defensive `fullPath.startsWith(DOCS_DIR)` check to the `ReadResourceRequestSchema` handler in `src/tools/registry.ts`.
- This ensures that even if the hardcoded `RESOURCES` list is modified or if `basename()` fails in unexpected ways, the file reading remains confined to the `DOCS_DIR`.
- The reported issue in the `help` tool was already fixed in the current codebase; this change applies the same security pattern consistently.

### Verification
- Ran `bun x vitest run src/tools/registry.test.ts` - All 38 tests passed.
- Ran `bun run check:fix` - Linting and type-checking passed.

---
*PR created automatically by Jules for task [2929455386028427359](https://jules.google.com/task/2929455386028427359) started by @n24q02m*