### PR TITLE
[FIX] Refactor overly permissive 'any' return type in formatIcon

### DIFF
--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -4,9 +4,9 @@
  */
 
 import type { Client } from '@notionhq/client'
-import { formatCover } from '../helpers/covers.js'
+import { formatCover, type NotionCover } from '../helpers/covers.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
-import { formatIcon } from '../helpers/icons.js'
+import { formatIcon, type NotionIcon } from '../helpers/icons.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'
@@ -26,8 +26,8 @@ export interface GetPageResult {
   created_time: string
   last_edited_time: string
   archived: boolean
-  icon: any
-  cover: any
+  icon: NotionIcon | null
+  cover: NotionCover | null
   properties: Record<string, any>
   content: string
   block_count: number

--- a/src/tools/helpers/covers.ts
+++ b/src/tools/helpers/covers.ts
@@ -81,13 +81,16 @@ const COVER_CATALOG: Record<string, string> = {
   rijksmuseum_rembrandt_1642: `${NOTION_COVER_BASE}/rijksmuseum_rembrandt_1642.jpg`
 }
 
+/** Notion cover object (external image) */
+export type NotionCover = { type: 'external'; external: { url: string } }
+
 /**
  * Format a cover value into the Notion API cover object.
  * Accepts:
  * - Full URL (http/https) -> external cover
  * - Shorthand name (e.g., "gradient_8", "solid_blue") -> resolved to Notion CDN URL
  */
-export function formatCover(value: string): { type: 'external'; external: { url: string } } {
+export function formatCover(value: string): NotionCover {
   // Full URL (with safety check against javascript:, data:, etc.)
   if (value.startsWith('http://') || value.startsWith('https://')) {
     if (!isSafeUrl(value)) {

--- a/src/tools/helpers/icons.ts
+++ b/src/tools/helpers/icons.ts
@@ -28,6 +28,9 @@ function isNotionIconShorthand(value: string): boolean {
   return NOTION_ICON_COLORS.has(color)
 }
 
+/** Notion icon object (emoji or external image) */
+export type NotionIcon = { type: 'emoji'; emoji: string } | { type: 'external'; external: { url: string } }
+
 /**
  * Format an icon value for the Notion API.
  * Accepts:
@@ -35,7 +38,7 @@ function isNotionIconShorthand(value: string): boolean {
  * - External URL: "https://..." -> { type: "external", external: { url } }
  * - Notion built-in shorthand: "document:gray" -> { type: "external", external: { url: "https://www.notion.so/icons/document_gray.svg" } }
  */
-export function formatIcon(value: string): { type: string; [key: string]: any } {
+export function formatIcon(value: string): NotionIcon {
   if (!value) {
     throw new NotionMCPError(
       'Icon value cannot be empty. Provide an emoji, a valid URL, or a built-in shorthand (name:color).',


### PR DESCRIPTION
Refactored formatIcon and formatCover helpers to use specific union types instead of any. Updated GetPageResult interface in src/tools/composite/pages.ts to leverage these types for improved safety and developer experience. Verified with tests and type-checking.

---
*PR created automatically by Jules for task [4522748231191751378](https://jules.google.com/task/4522748231191751378) started by @n24q02m*