### PR TITLE
[FIX] Address known API bug returning 404 for existing comments

### DIFF
--- a/src/tools/composite/comments.ts
+++ b/src/tools/composite/comments.ts
@@ -51,7 +51,7 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
           }
         } catch (error: any) {
           if (error.code === 'object_not_found') {
-            // Distinguish between a real 404 and the known Notion API limitation (OAuth 404)
+            // Distinguish between a real 404 and the known Notion API bug (OAuth 404)
             // by checking if the block/page actually exists.
             let blockExists = false
             try {
@@ -65,11 +65,11 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
             }
 
             if (blockExists) {
-              // If retrieve succeeds, it's the known API limitation
+              // If retrieve succeeds, it's the known API bug
               throw new NotionMCPError(
                 'Cannot list comments for this page',
                 'COMMENTS_LIST_UNAVAILABLE',
-                'This is a known Notion API limitation with OAuth integrations (API version 2025-09-03). The comments.list endpoint may return 404 even when the page exists and has comments. Workaround: use action="get" with a specific comment_id, or use action="create" which works normally.'
+                'This is a known Notion API bug with OAuth integrations (API version 2025-09-03). The comments.list endpoint may return 404 even when the page exists and has comments. Workaround: use action="get" with a specific comment_id, or use action="create" which works normally.'
               )
             }
             // If it's a real 404 (block retrieve also failed with object_not_found),


### PR DESCRIPTION
This PR addresses a known Notion API bug where the `comments.list` endpoint returns a 404 (object_not_found) error even when the page exists and has comments, specifically with OAuth integrations (API version 2025-09-03).

The implementation already included a workaround that checks for page existence when a 404 is encountered, but it referred to this as a "limitation". This change updates the terminology to "bug" in both code comments and the user-facing error message to accurately reflect the nature of the issue.

### Changes:
- Updated `src/tools/composite/comments.ts` to replace "limitation" with "bug" in the `comments.list` error handling block.
- Verified that all 19 tests in `src/tools/composite/comments.test.ts` pass.
- Ran `bun run check:fix` to ensure linting and type checking pass.

---
*PR created automatically by Jules for task [375703749512105047](https://jules.google.com/task/375703749512105047) started by @n24q02m*