### PR TITLE
[FIX] Resolve Notion API Bug: comments.list returns 404

### DIFF
--- a/src/docs/comments.md
+++ b/src/docs/comments.md
@@ -35,3 +35,12 @@ Retrieve a single comment by its ID.
 - `comment_id` - Comment ID (for get action)
 - `discussion_id` - Discussion ID (for replies)
 - `content` - Comment content
+
+## Known Limitations
+
+### comments.list returns 404 (OAuth Bug)
+As of 2025-09-03, the Notion API may return a 404 error when attempting to list comments using an OAuth token, even if the page exists and has comments. This is a known issue with the Notion API itself.
+
+**Workarounds:**
+1. **Use action: "get"** - If you have a specific `comment_id`, you can still retrieve it directly.
+2. **Use action: "create"** - Creating new comments or replying to discussions via `discussion_id` is unaffected and works as expected.

--- a/src/tools/composite/comments.test.ts
+++ b/src/tools/composite/comments.test.ts
@@ -105,7 +105,7 @@ describe('commentsManage', () => {
         })
       ).rejects.toMatchObject({
         code: 'COMMENTS_LIST_UNAVAILABLE',
-        message: 'Cannot list comments for this page'
+        message: 'The comments.list API is currently unavailable for this page due to a known Notion OAuth limitation.'
       })
       expect(mockNotion.blocks.retrieve).toHaveBeenCalledWith({ block_id: 'page-1' })
     })

--- a/src/tools/composite/comments.ts
+++ b/src/tools/composite/comments.ts
@@ -67,9 +67,8 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
             if (blockExists) {
               // If retrieve succeeds, it's the known API limitation
               throw new NotionMCPError(
-                'Cannot list comments for this page',
-                'COMMENTS_LIST_UNAVAILABLE',
-                'This is a known Notion API limitation with OAuth integrations (API version 2025-09-03). The comments.list endpoint may return 404 even when the page exists and has comments. Workaround: use action="get" with a specific comment_id, or use action="create" which works normally.'
+                'The comments.list API is currently unavailable for this page due to a known Notion OAuth limitation.',
+                'COMMENTS_LIST_UNAVAILABLE'
               )
             }
             // If it's a real 404 (block retrieve also failed with object_not_found),

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -251,20 +251,21 @@ describe('aiReadableMessage', () => {
     expect(msg).toBe('Error: Page not found\n\nSuggestion: Check the ID')
   })
 
-  it('should format error without suggestion', () => {
+  it('should format error with fallback suggestions when no explicit suggestion provided', () => {
     const error = new NotionMCPError('Something failed', 'UNKNOWN')
     const msg = aiReadableMessage(error)
 
-    expect(msg).toBe('Error: Something failed')
-    expect(msg).not.toContain('Suggestion')
+    expect(msg).toContain('Error: Something failed')
+    expect(msg).toContain('Suggestion:')
+    expect(msg).toContain('Check Notion API status')
   })
 
-  it('should format error with details', () => {
+  it('should format error with details and fallback suggestions', () => {
     const error = new NotionMCPError('Bad input', 'VALIDATION_ERROR', undefined, { field: 'title' })
     const msg = aiReadableMessage(error)
 
     expect(msg).toContain('Error: Bad input')
-    expect(msg).not.toContain('Suggestion')
+    expect(msg).toContain('Suggestion:')
     expect(msg).toContain('Details:')
     expect(msg).toContain('"field": "title"')
   })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -240,8 +240,10 @@ export function findClosestMatch(input: string, validOptions: string[]): string 
 export function aiReadableMessage(error: NotionMCPError): string {
   let message = `Error: ${error.message}`
 
-  if (error.suggestion) {
-    message += `\n\nSuggestion: ${error.suggestion}`
+  // Use explicit suggestion if present, otherwise fallback to suggestFixes()
+  const suggestion = error.suggestion || suggestFixes(error).join('\n- ')
+  if (suggestion) {
+    message += `\n\nSuggestion: ${error.suggestion ? suggestion : `\n- ${suggestion}`}`
   }
 
   if (error.details) {
@@ -281,6 +283,11 @@ const _ERROR_SUGGESTIONS_MAP: Record<string, string[]> = {
     'Reduce request frequency',
     'Implement exponential backoff retry logic',
     'Batch multiple operations together'
+  ],
+  COMMENTS_LIST_UNAVAILABLE: [
+    'Use action="get" with a specific comment_id if known',
+    'Use action="create" to add a new comment (this endpoint is unaffected)',
+    'This is a known Notion API limitation with OAuth tokens as of 2025-09-03'
   ]
 }
 
@@ -294,46 +301,7 @@ const _DEFAULT_SUGGESTIONS = [
  * Suggest fixes based on error
  */
 export function suggestFixes(error: NotionMCPError): string[] {
-  const suggestions: string[] = []
-
-  switch (error.code) {
-    case 'UNAUTHORIZED':
-      suggestions.push('Check that NOTION_TOKEN is set in your environment')
-      suggestions.push('Verify token at https://www.notion.so/my-integrations')
-      suggestions.push('Create a new integration token if needed')
-      break
-
-    case 'RESTRICTED_RESOURCE':
-      suggestions.push('Open the page/database in Notion')
-      suggestions.push('Click "..." menu → Add connections → Select your integration')
-      suggestions.push('Grant access to parent pages if needed')
-      break
-
-    case 'NOT_FOUND':
-      suggestions.push('Verify the page/database ID is correct')
-      suggestions.push('Check that the resource was not deleted')
-      suggestions.push('Ensure you have access permissions')
-      break
-
-    case 'VALIDATION_ERROR':
-      suggestions.push('Check parameter types and formats')
-      suggestions.push('Review required vs optional parameters')
-      suggestions.push('Verify property names match database schema')
-      break
-
-    case 'RATE_LIMITED':
-      suggestions.push('Reduce request frequency')
-      suggestions.push('Implement exponential backoff retry logic')
-      suggestions.push('Batch multiple operations together')
-      break
-
-    default:
-      suggestions.push('Check Notion API status at https://status.notion.so')
-      suggestions.push('Review request parameters')
-      suggestions.push('Try again in a few moments')
-  }
-
-  return suggestions
+  return _ERROR_SUGGESTIONS_MAP[error.code] || _DEFAULT_SUGGESTIONS
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR addresses the known Notion API limitation where `comments.list` returns a 404 error when using OAuth tokens (as of 2025-09-03). 

## Changes
- **Error Handling Enhancement**:
  - Added `COMMENTS_LIST_UNAVAILABLE` to the global error mapping in `src/tools/helpers/errors.ts`.
  - Refactored `suggestFixes` to use a more performant and maintainable lookup map.
  - Updated `aiReadableMessage` to automatically append suggestions from `suggestFixes` when no explicit suggestion is provided, ensuring AI agents always receive actionable guidance.
- **Tool Workaround Refinement**:
  - Updated the `comments` tool in `src/tools/composite/comments.ts` to use the improved error code and a more concise message.
- **Documentation**:
  - Added a 'Known Limitations' section to `src/docs/comments.md` to formally document the `comments.list` 404 issue and provide guidance on alternative actions.

## Verification
- Ran `bun run test src/tools/helpers/errors.test.ts src/tools/composite/comments.test.ts`.
- All 66 tests passed, confirming both the refactor and the new error behavior are correct.

---
*PR created automatically by Jules for task [11414630935529966298](https://jules.google.com/task/11414630935529966298) started by @n24q02m*