### PR TITLE
⚡ Bolt: Cache property lookup in extractPageProperties

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-05-06 - normalizeId Fast Path Optimization
 **Learning:** Using `id.replace(/-/g, '')` directly on strings that are already clean (do not contain hyphens) incurs unnecessary regex evaluation overhead on hot paths, adding ~10-20x extra time compared to checking for the target character first.
 **Action:** When a replacement string is commonly already correctly formatted, apply an early return check using `indexOf` (e.g., `if (id.indexOf('-') === -1) return id`) to bypass the regex engine.
+
+## 2025-05-19 - Object Property Lookups in Tight Loops
+**Learning:** In V8 and other JS engines, repeatedly accessing the same object property (`p.type`) across a long `if/else if` chain of conditional branches adds measurable overhead due to property lookup mechanics, particularly in tight loops processing large heterogeneous JSON arrays (like Notion API responses).
+**Action:** When evaluating the same property multiple times inside a loop (especially for type-checking branches), cache it into a local `const` variable (e.g., `const type = p.type`) before the conditional chain to reduce property access latency and improve overall throughput.

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -131,61 +131,64 @@ export function extractPageProperties(pageProperties: any): any {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const p = pageProperties[key] as any
+    // ⚡ Bolt: Cache property lookup to avoid repeated V8 engine access overhead
+    // in this tight loop with multiple conditional branches.
+    const type = p.type
 
-    if (p.type === 'title' && p.title) {
+    if (type === 'title' && p.title) {
       let str = ''
       for (let j = 0; j < p.title.length; j++) str += p.title[j].plain_text || ''
       properties[key] = str
-    } else if (p.type === 'rich_text' && p.rich_text) {
+    } else if (type === 'rich_text' && p.rich_text) {
       let str = ''
       for (let j = 0; j < p.rich_text.length; j++) str += p.rich_text[j].plain_text || ''
       properties[key] = str
-    } else if (p.type === 'select' && p.select) {
+    } else if (type === 'select' && p.select) {
       properties[key] = p.select.name
-    } else if (p.type === 'multi_select' && p.multi_select) {
+    } else if (type === 'multi_select' && p.multi_select) {
       const arr = new Array(p.multi_select.length)
       for (let j = 0; j < p.multi_select.length; j++) arr[j] = p.multi_select[j].name
       properties[key] = arr
-    } else if (p.type === 'number') {
+    } else if (type === 'number') {
       properties[key] = p.number
-    } else if (p.type === 'checkbox') {
+    } else if (type === 'checkbox') {
       properties[key] = p.checkbox
-    } else if (p.type === 'url') {
+    } else if (type === 'url') {
       properties[key] = p.url
-    } else if (p.type === 'email') {
+    } else if (type === 'email') {
       properties[key] = p.email
-    } else if (p.type === 'phone_number') {
+    } else if (type === 'phone_number') {
       properties[key] = p.phone_number
-    } else if (p.type === 'date' && p.date) {
+    } else if (type === 'date' && p.date) {
       properties[key] = p.date.start + (p.date.end ? ` to ${p.date.end}` : '')
-    } else if (p.type === 'relation' && p.relation) {
+    } else if (type === 'relation' && p.relation) {
       const arr = new Array(p.relation.length)
       for (let j = 0; j < p.relation.length; j++) arr[j] = p.relation[j].id
       properties[key] = arr
-    } else if (p.type === 'rollup' && p.rollup) {
+    } else if (type === 'rollup' && p.rollup) {
       properties[key] = p.rollup
-    } else if (p.type === 'people' && p.people) {
+    } else if (type === 'people' && p.people) {
       const arr = new Array(p.people.length)
       for (let j = 0; j < p.people.length; j++) arr[j] = p.people[j].name || p.people[j].id
       properties[key] = arr
-    } else if (p.type === 'files' && p.files) {
+    } else if (type === 'files' && p.files) {
       const arr = new Array(p.files.length)
       for (let j = 0; j < p.files.length; j++)
         arr[j] = p.files[j].file?.url || p.files[j].external?.url || p.files[j].name
       properties[key] = arr
-    } else if (p.type === 'formula' && p.formula) {
+    } else if (type === 'formula' && p.formula) {
       properties[key] = p.formula.type ? (p.formula[p.formula.type] ?? null) : null
-    } else if (p.type === 'created_time') {
+    } else if (type === 'created_time') {
       properties[key] = p.created_time
-    } else if (p.type === 'last_edited_time') {
+    } else if (type === 'last_edited_time') {
       properties[key] = p.last_edited_time
-    } else if (p.type === 'created_by' && p.created_by) {
+    } else if (type === 'created_by' && p.created_by) {
       properties[key] = p.created_by?.name || p.created_by?.id
-    } else if (p.type === 'last_edited_by' && p.last_edited_by) {
+    } else if (type === 'last_edited_by' && p.last_edited_by) {
       properties[key] = p.last_edited_by?.name || p.last_edited_by?.id
-    } else if (p.type === 'status' && p.status) {
+    } else if (type === 'status' && p.status) {
       properties[key] = p.status?.name
-    } else if (p.type === 'unique_id' && p.unique_id) {
+    } else if (type === 'unique_id' && p.unique_id) {
       properties[key] = p.unique_id.prefix ? `${p.unique_id.prefix}-${p.unique_id.number}` : p.unique_id.number
     }
   }


### PR DESCRIPTION
💡 What: Cached the object property lookup `const type = p.type` inside a long conditional chain in `extractPageProperties`.
🎯 Why: In V8, repeating property lookups inside tight loops across many `if/else if` statements incurs latency and overhead. Caching it reduces this execution time overhead for large Notion JSON payloads.
📊 Impact: Minor speed boost during iteration over dynamic heterogenous API objects.
🔬 Measurement: Verified via unit test suite that behaviour remains identical.

---
*PR created automatically by Jules for task [13168209201730352305](https://jules.google.com/task/13168209201730352305) started by @n24q02m*