### PR TITLE
🛡️ Sentinel: [HIGH] Fix XPIA vulnerability in file_uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** In `tests/test-oauth-mcp.mjs`, the `_openBrowser` function was using `execFile('cmd', ['/c', 'start', url])` to open authorization URLs on Windows. This allowed any unsanitized `url` payload containing shell metacharacters (like `&` or `|`) to bypass protections and trigger arbitrary code execution, as `cmd.exe` parses and executes them before running the internal `start` command.
 **Learning:** `child_process.execFile` only guarantees safe parameter passing to the binary being invoked. If the binary is a shell (like `cmd.exe`), it applies its own parsing rules to the passed arguments, re-introducing shell injection risks even when using the ostensibly safe `execFile`.
 **Prevention:** When programmatic interaction requires opening URLs on Windows without shell intervention, utilize OS-level file protocol handlers directly via `execFile('rundll32', ['url.dll,FileProtocolHandler', url])` to avoid `cmd.exe` parsing entirely.
+
+## 2024-05-21 - [Prevent Indirect Prompt Injection (XPIA) in file_uploads]
+**Vulnerability:** Newly added tools that fetch external content, like `file_uploads`, were missing from `EXTERNAL_CONTENT_TOOLS`, leaving them vulnerable to XPIA attacks where malicious file contents could alter agent behavior.
+**Learning:** Any MCP tool returning data from external, untrusted sources (especially file content/metadata) must have its output wrapped in security markers to ensure the AI treats it strictly as data.
+**Prevention:** Whenever a new tool interacting with external content is introduced, it must be explicitly added to `EXTERNAL_CONTENT_TOOLS` in `src/tools/helpers/security.ts` to inherit safety wrappers.

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -96,7 +96,7 @@ describe('Security Utilities', () => {
 
   describe('wrapToolResult', () => {
     it('should wrap external content tools with safety markers', () => {
-      const externalTools = ['pages', 'blocks', 'comments', 'databases', 'users', 'workspace']
+      const externalTools = ['pages', 'blocks', 'comments', 'databases', 'users', 'workspace', 'file_uploads']
       const jsonText = '{"data": "some untrusted data"}'
 
       for (const tool of externalTools) {

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -5,7 +5,15 @@
  */
 
 /** Tools that return content from external Notion sources (untrusted) */
-const EXTERNAL_CONTENT_TOOLS = new Set(['pages', 'blocks', 'comments', 'databases', 'users', 'workspace'])
+const EXTERNAL_CONTENT_TOOLS = new Set([
+  'pages',
+  'blocks',
+  'comments',
+  'databases',
+  'users',
+  'workspace',
+  'file_uploads'
+])
 
 // Pre-compiled regex for URL validation hot path
 const URL_DELIMITER_REGEX = /[/?#]/

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -471,7 +471,8 @@ describe('registerTools', () => {
       })
 
       expect(fileUploads).toHaveBeenCalledWith(expect.any(Object), { action: 'list' })
-      expect(result.content[0].text).toBe(JSON.stringify(mockResult, null, 2))
+      expect(result.content[0].text).toContain(JSON.stringify(mockResult, null, 2))
+      expect(result.content[0].text).toContain('<untrusted_notion_content>')
     })
 
     it('should route help tool and read documentation file', async () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `file_uploads` tool, which retrieves external and potentially untrusted content, was missing from `EXTERNAL_CONTENT_TOOLS`. This exposed the system to Indirect Prompt Injection (XPIA) attacks, as the content could be interpreted by the AI as instructions rather than raw data.
🎯 Impact: Malicious file uploads could manipulate agent behavior or prompt it to perform unintended actions based on the uploaded content.
🔧 Fix: Added `file_uploads` to the `EXTERNAL_CONTENT_TOOLS` set in `src/tools/helpers/security.ts`. This ensures that any data retrieved by this tool is safely wrapped in `<untrusted_notion_content>` markers, treating it strictly as data. Corresponding tests were updated to reflect these wrappers.
✅ Verification: Ran `bun test` ensuring the file_uploads endpoint correctly applies the `<untrusted_notion_content>` markers to its responses. Checked using `run_in_bash_session`.

---
*PR created automatically by Jules for task [11582764371494833094](https://jules.google.com/task/11582764371494833094) started by @n24q02m*