### PR TITLE
Perf & security: optimize property extraction, redact headers case-insensitively

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-notion-mcp",
-  "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
-  "version": "2.33.0",
+  "description": "Comprehensive Notion API integration \u2014 9 composite tools, ~95% coverage",
+  "version": "2.34.0-beta.1",
   "userConfig": {
     "NOTION_TOKEN": {
       "type": "string",
@@ -19,7 +19,10 @@
   "mcpServers": {
     "better-notion-mcp": {
       "command": "npx",
-      "args": ["--yes", "@n24q02m/better-notion-mcp@latest"],
+      "args": [
+        "--yes",
+        "@n24q02m/better-notion-mcp@latest"
+      ],
       "env": {
         "MCP_TRANSPORT": "stdio",
         "NOTION_TOKEN": "${user_config.NOTION_TOKEN}"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-notion-mcp",
-  "description": "Comprehensive Notion API integration \u2014 9 composite tools, ~95% coverage",
+  "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
   "version": "2.34.0-beta.1",
   "userConfig": {
     "NOTION_TOKEN": {
@@ -19,10 +19,7 @@
   "mcpServers": {
     "better-notion-mcp": {
       "command": "npx",
-      "args": [
-        "--yes",
-        "@n24q02m/better-notion-mcp@latest"
-      ],
+      "args": ["--yes", "@n24q02m/better-notion-mcp@latest"],
       "env": {
         "MCP_TRANSPORT": "stdio",
         "NOTION_TOKEN": "${user_config.NOTION_TOKEN}"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "codex",
     "opencode"
   ],
-  "version": "2.33.0",
+  "version": "2.34.0-beta.1",
   "license": "MIT",
   "type": "module",
   "packageManager": "bun@1.2.21",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/n24q02m/better-notion-mcp.git",
     "source": "github"
   },
-  "version": "2.33.0",
+  "version": "2.34.0-beta.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@n24q02m/better-notion-mcp",
-      "version": "2.33.0",
+      "version": "2.34.0-beta.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -69,4 +69,66 @@ describe('Security: Error Handling', () => {
       expect(enhanced.details.request._headers).not.toHaveProperty('authorization')
     }
   })
+
+  it('strips Authorization headers regardless of casing (case-insensitive redaction)', () => {
+    // Upstream HTTP libraries differ on header-name casing. The redactor must
+    // catch every variant or we leak the bearer token from the source error
+    // object (whose reference may be retained elsewhere -- e.g. error logger).
+    const errorWithMixedCase: any = {
+      message: 'Failed to fetch',
+      headers: {
+        AUTHORIZATION: 'Bearer ntn_uppercase',
+        'X-Api-Key': 'ntn_apikey',
+        'Content-Type': 'application/json'
+      },
+      response: {
+        headers: {
+          Authorization: 'Bearer ntn_response',
+          'Set-Cookie': 'session=secret'
+        }
+      },
+      config: {
+        headers: {
+          AuThOrIzAtIoN: 'Bearer ntn_mixedcase'
+        }
+      }
+    }
+
+    enhanceError(errorWithMixedCase)
+
+    // enhanceError mutates the input in place via stripSensitiveFields --
+    // the original object should no longer contain any of the sensitive
+    // header values, regardless of original casing.
+    expect(errorWithMixedCase.headers).not.toHaveProperty('AUTHORIZATION')
+    expect(errorWithMixedCase.headers).not.toHaveProperty('X-Api-Key')
+    expect(errorWithMixedCase.headers).toHaveProperty('Content-Type')
+    expect(errorWithMixedCase.response.headers).not.toHaveProperty('Authorization')
+    expect(errorWithMixedCase.response.headers).not.toHaveProperty('Set-Cookie')
+    expect(errorWithMixedCase.config.headers).not.toHaveProperty('AuThOrIzAtIoN')
+
+    // Hard guarantee: no leaked bearer/api-key value anywhere in the tree.
+    const json = JSON.stringify(errorWithMixedCase)
+    expect(json).not.toContain('ntn_uppercase')
+    expect(json).not.toContain('ntn_apikey')
+    expect(json).not.toContain('ntn_response')
+    expect(json).not.toContain('ntn_mixedcase')
+    expect(json).not.toContain('session=secret')
+  })
+
+  it('strips Proxy-Authorization, Cookie and X-Auth-Token headers regardless of casing', () => {
+    const error: any = {
+      message: 'Failed',
+      headers: {
+        'Proxy-Authorization': 'Basic abc',
+        Cookie: 'session=xyz',
+        'X-Auth-Token': 'tok123',
+        'set-COOKIE': 'second=def'
+      }
+    }
+    enhanceError(error)
+    expect(error.headers).not.toHaveProperty('Proxy-Authorization')
+    expect(error.headers).not.toHaveProperty('Cookie')
+    expect(error.headers).not.toHaveProperty('X-Auth-Token')
+    expect(error.headers).not.toHaveProperty('set-COOKIE')
+  })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -62,6 +62,36 @@ function sanitizeErrorDetails(error: any): any {
   return safe
 }
 
+/**
+ * Header names to redact whenever they appear inside an error/details object.
+ * Compared case-insensitively against the actual property names so that
+ * `Authorization`, `authorization`, `AUTHORIZATION`, `Proxy-Authorization`,
+ * etc. are all stripped.
+ */
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'x-auth-token',
+  'cookie',
+  'set-cookie'
+])
+
+/**
+ * Remove sensitive headers from a headers-shaped object regardless of the
+ * casing the upstream library happened to use. Notion's SDK normalises
+ * `Authorization` but third-party axios/fetch wrappers may surface
+ * `authorization`, `AUTHORIZATION`, or `X-API-Key`.
+ */
+function redactHeaderMap(headers: any): void {
+  if (!headers || typeof headers !== 'object') return
+  for (const key of Object.keys(headers)) {
+    if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
+      delete headers[key]
+    }
+  }
+}
+
 function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
   if (!obj || typeof obj !== 'object') return
   if (seen.has(obj)) return
@@ -71,12 +101,20 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
   delete obj.internal_config
   delete obj.user_email
 
-  // Also strip authorization headers to prevent leaking tokens
-  if (obj.headers?.Authorization) delete obj.headers.Authorization
-  if (obj.headers?.authorization) delete obj.headers.authorization
-  if (obj.request?._headers?.authorization) delete obj.request._headers.authorization
-  if (obj.config?.headers?.Authorization) delete obj.config.headers.Authorization
-  if (obj.config?.headers?.authorization) delete obj.config.headers.authorization
+  // Strip authorization-style headers from the common error-shape locations
+  // (response interceptors copy them onto multiple parent objects).
+  redactHeaderMap(obj.headers)
+  redactHeaderMap(obj._headers)
+  if (obj.request) {
+    redactHeaderMap(obj.request.headers)
+    redactHeaderMap(obj.request._headers)
+  }
+  if (obj.config) {
+    redactHeaderMap(obj.config.headers)
+  }
+  if (obj.response) {
+    redactHeaderMap(obj.response.headers)
+  }
 
   for (const key of Object.keys(obj)) {
     if (typeof obj[key] === 'object' && obj[key] !== null) {

--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -696,4 +696,63 @@ describe('extractPageProperties', () => {
     expect(extractPageProperties(undefined)).toEqual({})
     expect(extractPageProperties({})).toEqual({})
   })
+
+  it('only reads p.type once per iteration (uses cached local)', () => {
+    // Define a getter for `type` that counts accesses. The optimized
+    // extractor caches the value into a local on the first read, so the
+    // remaining 20+ branches in the if/else chain don't trigger the getter.
+    let typeReads = 0
+    const props: any = {
+      Name: new Proxy(
+        { title: [{ plain_text: 'X' }], _type: 'title' },
+        {
+          get(target, prop) {
+            if (prop === 'type') {
+              typeReads++
+              return target._type
+            }
+            return (target as any)[prop]
+          }
+        }
+      )
+    }
+    expect(extractPageProperties(props)).toEqual({ Name: 'X' })
+    expect(typeReads).toBe(1)
+  })
+
+  it('extracts files with mixed file/external/name shapes', () => {
+    const props = {
+      Files: {
+        type: 'files',
+        files: [
+          { file: { url: 'https://internal/file1.pdf' }, name: 'A' },
+          { external: { url: 'https://external/file2.png' }, name: 'B' },
+          { name: 'just-a-name.txt' }
+        ]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({
+      Files: ['https://internal/file1.pdf', 'https://external/file2.png', 'just-a-name.txt']
+    })
+  })
+
+  it('extracts people with names + ids fallback', () => {
+    const props = {
+      Owners: {
+        type: 'people',
+        people: [{ name: 'Alice', id: 'u1' }, { id: 'u2' }]
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Owners: ['Alice', 'u2'] })
+  })
+
+  it('extracts date range', () => {
+    const props = {
+      Window: {
+        type: 'date',
+        date: { start: '2026-01-01', end: '2026-01-31' }
+      }
+    }
+    expect(extractPageProperties(props)).toEqual({ Window: '2026-01-01 to 2026-01-31' })
+  })
 })

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -131,62 +131,76 @@ export function extractPageProperties(pageProperties: any): any {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const p = pageProperties[key] as any
+    // Cache p.type once per iteration -- avoids ~20 redundant property
+    // lookups in the if/else-if chain on every Notion page row.
+    const type = p.type as string | undefined
 
-    if (p.type === 'title' && p.title) {
+    if (type === 'title' && p.title) {
       let str = ''
-      for (let j = 0; j < p.title.length; j++) str += p.title[j].plain_text || ''
+      const title = p.title
+      for (let j = 0; j < title.length; j++) str += title[j].plain_text || ''
       properties[key] = str
-    } else if (p.type === 'rich_text' && p.rich_text) {
+    } else if (type === 'rich_text' && p.rich_text) {
       let str = ''
-      for (let j = 0; j < p.rich_text.length; j++) str += p.rich_text[j].plain_text || ''
+      const richText = p.rich_text
+      for (let j = 0; j < richText.length; j++) str += richText[j].plain_text || ''
       properties[key] = str
-    } else if (p.type === 'select' && p.select) {
+    } else if (type === 'select' && p.select) {
       properties[key] = p.select.name
-    } else if (p.type === 'multi_select' && p.multi_select) {
-      const arr = new Array(p.multi_select.length)
-      for (let j = 0; j < p.multi_select.length; j++) arr[j] = p.multi_select[j].name
+    } else if (type === 'multi_select' && p.multi_select) {
+      const ms = p.multi_select
+      const arr = new Array(ms.length)
+      for (let j = 0; j < ms.length; j++) arr[j] = ms[j].name
       properties[key] = arr
-    } else if (p.type === 'number') {
+    } else if (type === 'number') {
       properties[key] = p.number
-    } else if (p.type === 'checkbox') {
+    } else if (type === 'checkbox') {
       properties[key] = p.checkbox
-    } else if (p.type === 'url') {
+    } else if (type === 'url') {
       properties[key] = p.url
-    } else if (p.type === 'email') {
+    } else if (type === 'email') {
       properties[key] = p.email
-    } else if (p.type === 'phone_number') {
+    } else if (type === 'phone_number') {
       properties[key] = p.phone_number
-    } else if (p.type === 'date' && p.date) {
-      properties[key] = p.date.start + (p.date.end ? ` to ${p.date.end}` : '')
-    } else if (p.type === 'relation' && p.relation) {
-      const arr = new Array(p.relation.length)
-      for (let j = 0; j < p.relation.length; j++) arr[j] = p.relation[j].id
+    } else if (type === 'date' && p.date) {
+      const d = p.date
+      properties[key] = d.start + (d.end ? ` to ${d.end}` : '')
+    } else if (type === 'relation' && p.relation) {
+      const rel = p.relation
+      const arr = new Array(rel.length)
+      for (let j = 0; j < rel.length; j++) arr[j] = rel[j].id
       properties[key] = arr
-    } else if (p.type === 'rollup' && p.rollup) {
+    } else if (type === 'rollup' && p.rollup) {
       properties[key] = p.rollup
-    } else if (p.type === 'people' && p.people) {
-      const arr = new Array(p.people.length)
-      for (let j = 0; j < p.people.length; j++) arr[j] = p.people[j].name || p.people[j].id
+    } else if (type === 'people' && p.people) {
+      const ppl = p.people
+      const arr = new Array(ppl.length)
+      for (let j = 0; j < ppl.length; j++) arr[j] = ppl[j].name || ppl[j].id
       properties[key] = arr
-    } else if (p.type === 'files' && p.files) {
-      const arr = new Array(p.files.length)
-      for (let j = 0; j < p.files.length; j++)
-        arr[j] = p.files[j].file?.url || p.files[j].external?.url || p.files[j].name
+    } else if (type === 'files' && p.files) {
+      const files = p.files
+      const arr = new Array(files.length)
+      for (let j = 0; j < files.length; j++) {
+        const f = files[j]
+        arr[j] = f.file?.url || f.external?.url || f.name
+      }
       properties[key] = arr
-    } else if (p.type === 'formula' && p.formula) {
-      properties[key] = p.formula.type ? (p.formula[p.formula.type] ?? null) : null
-    } else if (p.type === 'created_time') {
+    } else if (type === 'formula' && p.formula) {
+      const f = p.formula
+      properties[key] = f.type ? (f[f.type] ?? null) : null
+    } else if (type === 'created_time') {
       properties[key] = p.created_time
-    } else if (p.type === 'last_edited_time') {
+    } else if (type === 'last_edited_time') {
       properties[key] = p.last_edited_time
-    } else if (p.type === 'created_by' && p.created_by) {
+    } else if (type === 'created_by' && p.created_by) {
       properties[key] = p.created_by?.name || p.created_by?.id
-    } else if (p.type === 'last_edited_by' && p.last_edited_by) {
+    } else if (type === 'last_edited_by' && p.last_edited_by) {
       properties[key] = p.last_edited_by?.name || p.last_edited_by?.id
-    } else if (p.type === 'status' && p.status) {
+    } else if (type === 'status' && p.status) {
       properties[key] = p.status?.name
-    } else if (p.type === 'unique_id' && p.unique_id) {
-      properties[key] = p.unique_id.prefix ? `${p.unique_id.prefix}-${p.unique_id.number}` : p.unique_id.number
+    } else if (type === 'unique_id' && p.unique_id) {
+      const u = p.unique_id
+      properties[key] = u.prefix ? `${u.prefix}-${u.number}` : u.number
     }
   }
   return properties

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -108,6 +108,18 @@ describe('Security Utilities', () => {
       }
     })
 
+    it('should wrap file_uploads output with safety markers (XPIA defense)', () => {
+      // file_uploads returns attachment URLs / filenames / metadata that may
+      // originate from an untrusted upstream Notion workspace -- wrap them
+      // the same as pages/blocks responses.
+      const jsonText = '{"file_uploads": [{"name": "evil.pdf", "url": "https://attacker.example/doc.pdf"}]}'
+      const result = wrapToolResult('file_uploads', jsonText)
+      expect(result).toContain('<untrusted_notion_content>')
+      expect(result).toContain('</untrusted_notion_content>')
+      expect(result).toContain(jsonText)
+      expect(result).toContain('[SECURITY:')
+    })
+
     it('should not wrap internal/safe tools', () => {
       const internalTools = ['search', 'other_tool', 'safe_tool']
       const jsonText = '{"data": "some safe data"}'
@@ -116,6 +128,14 @@ describe('Security Utilities', () => {
         const result = wrapToolResult(tool, jsonText)
         expect(result).toBe(jsonText)
         expect(result).not.toContain('<untrusted_notion_content>')
+      }
+    })
+
+    it('should not wrap content_convert / config / help / setup (no external Notion data)', () => {
+      const localTools = ['content_convert', 'config', 'help', 'setup']
+      const jsonText = '{"markdown": "# Title\\n\\nlocal content"}'
+      for (const tool of localTools) {
+        expect(wrapToolResult(tool, jsonText)).toBe(jsonText)
       }
     })
   })

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -4,8 +4,22 @@
  * Indirect Prompt Injection (XPIA) attacks.
  */
 
-/** Tools that return content from external Notion sources (untrusted) */
-const EXTERNAL_CONTENT_TOOLS = new Set(['pages', 'blocks', 'comments', 'databases', 'users', 'workspace'])
+/**
+ * Tools that return content from external Notion sources (untrusted).
+ *
+ * `file_uploads` is included because its response includes attachment URLs,
+ * filenames, and free-text metadata that can come from an untrusted upstream
+ * Notion workspace. Treat that payload the same as `pages`/`blocks` content.
+ */
+const EXTERNAL_CONTENT_TOOLS = new Set([
+  'pages',
+  'blocks',
+  'comments',
+  'databases',
+  'users',
+  'workspace',
+  'file_uploads'
+])
 
 // Pre-compiled regex for URL validation hot path
 const URL_DELIMITER_REGEX = /[/?#]/

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -461,7 +461,7 @@ describe('registerTools', () => {
       expect(tool.inputSchema.additionalProperties).toBe(false)
     })
 
-    it('should route file_uploads tool correctly', async () => {
+    it('should route file_uploads tool correctly and wrap response with XPIA safety markers', async () => {
       const handler = server.getHandler(3)
       const mockResult = { action: 'list', uploads: [] }
       vi.mocked(fileUploads).mockResolvedValue(mockResult)
@@ -471,7 +471,14 @@ describe('registerTools', () => {
       })
 
       expect(fileUploads).toHaveBeenCalledWith(expect.any(Object), { action: 'list' })
-      expect(result.content[0].text).toBe(JSON.stringify(mockResult, null, 2))
+      // file_uploads is now treated as external/untrusted content -- the
+      // JSON payload must be wrapped in <untrusted_notion_content> tags so
+      // downstream LLM prompts treat it as data, not instructions.
+      const text = result.content[0].text
+      expect(text).toContain('<untrusted_notion_content>')
+      expect(text).toContain(JSON.stringify(mockResult, null, 2))
+      expect(text).toContain('</untrusted_notion_content>')
+      expect(text).toContain('[SECURITY:')
     })
 
     it('should route help tool and read documentation file', async () => {


### PR DESCRIPTION
## Description

This PR improves performance and security across the codebase:

1. **Performance**: Optimizes `extractPageProperties()` to cache `p.type` once per iteration and intermediate array/object references, eliminating ~20 redundant property lookups per Notion page row.

2. **Security**: Hardens header redaction in error handling to strip sensitive headers (`Authorization`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`, `Cookie`, `Set-Cookie`) case-insensitively across all error object locations, preventing token leaks from upstream HTTP libraries that vary header casing.

3. **XPIA Defense**: Adds `file_uploads` to the set of external/untrusted content tools, wrapping its response with `<untrusted_notion_content>` markers to prevent Cross-Tool Prompt Injection attacks.

## Changes

- **src/tools/helpers/properties.ts**: Cache `p.type` and intermediate array/object references in the property extraction loop to reduce property access overhead
- **src/tools/helpers/errors.ts**: Introduce `redactHeaderMap()` helper and `SENSITIVE_HEADER_NAMES` set for case-insensitive header redaction; apply to all error object locations (headers, _headers, request, config, response)
- **src/tools/helpers/security.ts**: Add `file_uploads` to `EXTERNAL_CONTENT_TOOLS` set with documentation explaining why attachment metadata is untrusted
- **src/tools/helpers/errors.security.test.ts**: Add comprehensive tests for case-insensitive header redaction across mixed-case variants
- **src/tools/helpers/properties.test.ts**: Add tests verifying single `p.type` read per iteration and edge cases (files with mixed shapes, people with name/id fallback, date ranges)
- **src/tools/registry.test.ts**: Update `file_uploads` test to verify XPIA safety marker wrapping
- **src/tools/security.test.ts**: Add tests for `file_uploads` wrapping and local tools (content_convert, config, help, setup) that don't wrap
- **Version bump**: 2.33.0 → 2.34.0-beta.1

## Type of Change

- [x] Bug fix (security: case-insensitive header redaction, XPIA defense)
- [x] Performance improvement (property extraction caching)

## Testing

- [x] Existing tests pass
- [x] Added new tests for case-insensitive header redaction (2 new test cases)
- [x] Added new tests for property extraction optimization (3 new test cases)
- [x] Added new tests for file_uploads XPIA wrapping (2 updated/new test cases)
- [x] Added new tests for local tools exclusion (1 new test case)

All changes are covered by unit tests that verify:
- Header redaction works regardless of casing (AUTHORIZATION, Authorization, AuThOrIzAtIoN)
- No sensitive values leak into JSON stringification
- Property type is read exactly once per iteration (verified via Proxy getter count)
- file_uploads response is wrapped with untrusted content markers
- Local tools (content_convert, config, help, setup) are not wrapped

## Checklist

- [x] Code follows project's coding standards (ESM imports, TypeScript strict mode)
- [x] Comments added explaining optimization rationale and security intent
- [x] No new warnings generated
- [x] Version updated in package.json, server.json, and plugin.json

https://claude.ai/code/session_01TVUJS4wA7jdHouYn1grzvd