### PR TITLE
[CLEANUP] Use of any type

### DIFF
--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -1,6 +1,10 @@
 import type { BlockObjectResponse, Client } from '@notionhq/client'
 
-type RecursiveBlock = BlockObjectResponse & { [key: string]: any }
+type RecursiveBlock = BlockObjectResponse & {
+  [K in BlockObjectResponse['type']]?: {
+    children?: RecursiveBlock[]
+  }
+}
 
 /**
  * Pagination Helper
@@ -129,8 +133,10 @@ export async function fetchChildrenRecursive(
     const children = queue ? await queue.run(() => fetchChildren(block.id)) : await fetchChildren(block.id)
 
     // Attach children to the correct property based on block type
-    if (block[block.type]) {
-      block[block.type].children = children
+    // We cast to any because TS cannot correlate block.type with the property key on the union
+    const blockData = (block as any)[block.type]
+    if (blockData) {
+      blockData.children = children
     }
 
     // Recurse into children


### PR DESCRIPTION
Refactor `RecursiveBlock` type in `src/tools/helpers/pagination.ts` to replace `any` with a mapped type based on `BlockObjectResponse['type']`. This improves type safety and clarifies the expected data structure for recursive block children.

Key changes:
- Defined `RecursiveBlock` using a mapped type: `type RecursiveBlock = BlockObjectResponse & { [K in BlockObjectResponse['type']]?: { children?: RecursiveBlock[] } }`.
- Updated `fetchAndRecurse` implementation to use a localized type assertion `(block as any)[block.type]` when assigning children, resolving a TypeScript limitation with correlated union types while keeping the overall structure type-safe.
- Verified changes with `bun run check` and `bun test src/tools/helpers/pagination.test.ts`.

---
*PR created automatically by Jules for task [13203418292966429691](https://jules.google.com/task/13203418292966429691) started by @n24q02m*