### PR TITLE
[FIX] Sensitive data logged to console

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -224,7 +224,7 @@ describe('main.ts', () => {
 
       await bootstrap('stdio')
 
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to start server:', expect.any(Error))
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to start server:', 'Test failure')
       expect(exitSpy).toHaveBeenCalledWith(1)
 
       consoleSpy.mockRestore()

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,7 +126,7 @@ export async function bootstrap(selectedMode: string = mode) {
   try {
     await startServer(selectedMode)
   } catch (error) {
-    console.error('Failed to start server:', error)
+    console.error('Failed to start server:', error instanceof Error ? error.message : String(error))
     process.exit(1)
   }
 }


### PR DESCRIPTION
This PR addresses a security concern where the full error object was being logged to the console in the `bootstrap` function of `src/main.ts`.

### 💡 What
Replaced `console.error('Failed to start server:', error)` with `console.error('Failed to start server:', error instanceof Error ? error.message : String(error))`.

### 🎯 Why
Raw error objects can sometimes contain sensitive information such as environment variables, API tokens (if attached to the error by a library), or internal configuration details. Logging only the message ensures that we still get useful diagnostic information without risking exposure of credentials in logs.

### 🔬 Measurement
- Updated `src/main.test.ts` to verify that only the error message is logged.
- Ran the full test suite (`bun run test`) and verified that all 765 tests passed.
- Verified with `bun run check` that there are no linting or type errors.

---
*PR created automatically by Jules for task [7821339912316538588](https://jules.google.com/task/7821339912316538588) started by @n24q02m*