### PR TITLE
🛡️ Sentinel: [security improvement] Add tests for isSafeWebUrl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,3 +20,13 @@
 **Vulnerability:** Untrusted content tools were protected against XPIA using a closing tag replacement regex (`/<\/untrusted_notion_content>/gi`). However, this regex was strict and failed to match whitespace-padded payloads (e.g., `</untrusted_notion_content >`), allowing an attacker to bypass the sanitization and execute prompt injection.
 **Learning:** XML/HTML parsers (including LLMs parsing pseudo-XML tags) often tolerate whitespace before the closing angle bracket. A strict exact-match regex sanitization is insufficient for tag-based wrappers, as attackers can pad their payload to break out of the wrapper while still satisfying parser leniency.
 **Prevention:** Always use regex quantifiers for optional whitespace (e.g., `\s*`) when matching or sanitizing closing tags to handle evasion tactics effectively.
+
+## 2026-05-28 - Improve Security Coverage for isSafeWebUrl
+**Vulnerability:** N/A (Testing Task)
+**Learning:** The  function provides a stricter validation layer for opening URLs in external browsers compared to , specifically by enforcing standard web protocols (HTTP/HTTPS) and preventing shell flag injection (URLs starting with ).
+**Prevention:** Ensure all security-critical utility functions have comprehensive unit test coverage, specifically targeting edge cases like protocol obfuscation, shell injection vectors, and malformed URL handling.
+
+## 2026-05-28 - Improve Security Coverage for isSafeWebUrl
+**Vulnerability:** N/A (Testing Task)
+**Learning:** The function isSafeWebUrl provides a stricter validation layer for opening URLs in external browsers compared to isSafeUrl, specifically by enforcing standard web protocols (HTTP/HTTPS) and preventing shell flag injection (URLs starting with dash).
+**Prevention:** Ensure all security-critical utility functions have comprehensive unit test coverage, specifically targeting edge cases like protocol obfuscation, shell injection vectors, and malformed URL handling.

--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafeUrl, wrapToolResult } from './security'
+import { isSafeUrl, isSafeWebUrl, wrapToolResult } from './security'
 
 describe('Security Utilities', () => {
   describe('isSafeUrl', () => {
@@ -166,6 +166,51 @@ describe('Security Utilities', () => {
       for (const tool of localTools) {
         expect(wrapToolResult(tool, jsonText)).toBe(jsonText)
       }
+    })
+  })
+
+  describe('isSafeWebUrl', () => {
+    it('should allow valid http and https URLs', () => {
+      expect(isSafeWebUrl('https://example.com')).toBe(true)
+      expect(isSafeWebUrl('http://example.com')).toBe(true)
+    })
+
+    it('should reject other protocols like mailto, tel, javascript', () => {
+      expect(isSafeWebUrl('mailto:user@example.com')).toBe(false)
+      expect(isSafeWebUrl('tel:+1234567890')).toBe(false)
+      expect(isSafeWebUrl('javascript:alert(1)')).toBe(false)
+      expect(isSafeWebUrl('data:text/html,abc')).toBe(false)
+    })
+
+    it('should reject empty or non-string inputs', () => {
+      expect(isSafeWebUrl('')).toBe(false)
+
+      expect(isSafeWebUrl(null as unknown as string)).toBe(false)
+    })
+
+    it('should reject URLs with whitespace or control characters', () => {
+      expect(isSafeWebUrl(' https://example.com')).toBe(false)
+      expect(isSafeWebUrl('https://example.com ')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\n')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\r')).toBe(false)
+      expect(isSafeWebUrl('https://example.com\t')).toBe(false)
+    })
+
+    it('should reject URLs starting with a dash to prevent flag injection', () => {
+      expect(isSafeWebUrl('-https://example.com')).toBe(false)
+      expect(isSafeWebUrl('--url=https://example.com')).toBe(false)
+    })
+
+    it('should reject relative URLs', () => {
+      expect(isSafeWebUrl('/path/to/resource')).toBe(false)
+      expect(isSafeWebUrl('relative/path')).toBe(false)
+      expect(isSafeWebUrl('file.html')).toBe(false)
+    })
+
+    it('should reject malformed URLs', () => {
+      expect(isSafeWebUrl('http://[')).toBe(false)
+      expect(isSafeWebUrl('not-a-url')).toBe(false)
+      expect(isSafeWebUrl('://')).toBe(false)
     })
   })
 })


### PR DESCRIPTION
💡 What: Added comprehensive unit tests for the `isSafeWebUrl` export in `src/tools/helpers/security.ts`.

🎯 Why: The function was previously untested. It provides critical security validation for opening URLs in external browsers by enforcing standard web protocols (HTTP/HTTPS) and preventing shell flag injection.

📊 Impact: Increases test coverage for security utilities and ensures robust validation against protocol obfuscation and injection attacks.

🔬 Measurement: Verified that all 25 tests in `src/tools/helpers/security.test.ts` pass, including new test cases for `isSafeWebUrl` covering:
- Valid http/https URLs
- Invalid protocols (mailto, tel, javascript, data)
- Empty or non-string inputs
- Whitespace and control character obfuscation
- Shell flag injection (URLs starting with -)
- Relative URLs (rejected as stricter validation)
- Malformed URLs

---
*PR created automatically by Jules for task [11820339710092201005](https://jules.google.com/task/11820339710092201005) started by @n24q02m*