### PR TITLE
[CLEANUP] Use of any type

### DIFF
--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -26,15 +26,15 @@ describe('Security: Error Handling', () => {
     expect(enhanced.code).toBe('VALIDATION_ERROR')
 
     // Check that safe fields are present
-    expect(enhanced.details).toBeDefined()
-    expect(enhanced.details.message).toBe('Invalid property value')
-    expect(enhanced.details.object).toBe('error')
-    expect(enhanced.details.status).toBe(400)
+    expect(enhanced.details as any).toBeDefined()
+    expect((enhanced.details as any).message).toBe('Invalid property value')
+    expect((enhanced.details as any).object).toBe('error')
+    expect((enhanced.details as any).status).toBe(400)
 
     // Check that sensitive fields are REMOVED
-    expect(enhanced.details).not.toHaveProperty('sensitive_token')
-    expect(enhanced.details).not.toHaveProperty('internal_config')
-    expect(enhanced.details).not.toHaveProperty('user_email')
+    expect(enhanced.details as any).not.toHaveProperty('sensitive_token')
+    expect(enhanced.details as any).not.toHaveProperty('internal_config')
+    expect(enhanced.details as any).not.toHaveProperty('user_email')
   })
 
   it('should not leak Authorization headers in error objects', () => {
@@ -57,16 +57,16 @@ describe('Security: Error Handling', () => {
     }
 
     const enhanced = enhanceError(errorWithAuth)
-    expect(enhanced.details).toBeDefined()
-    if (enhanced.details?.headers) {
-      expect(enhanced.details.headers).not.toHaveProperty('Authorization')
-      expect(enhanced.details.headers).toHaveProperty('Content-Type')
+    expect(enhanced.details as any).toBeDefined()
+    if ((enhanced.details as any)?.headers) {
+      expect((enhanced.details as any).headers).not.toHaveProperty('Authorization')
+      expect((enhanced.details as any).headers).toHaveProperty('Content-Type')
     }
-    if (enhanced.details?.config?.headers) {
-      expect(enhanced.details.config.headers).not.toHaveProperty('authorization')
+    if ((enhanced.details as any)?.config?.headers) {
+      expect((enhanced.details as any).config.headers).not.toHaveProperty('authorization')
     }
-    if (enhanced.details?.request?._headers) {
-      expect(enhanced.details.request._headers).not.toHaveProperty('authorization')
+    if ((enhanced.details as any)?.request?._headers) {
+      expect((enhanced.details as any).request._headers).not.toHaveProperty('authorization')
     }
   })
 

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -232,13 +232,13 @@ describe('enhanceError', () => {
       const enhanced = enhanceError(sensitiveError)
 
       // Expectation of SECURE behavior
-      expect(enhanced.details).toBeDefined()
-      expect(enhanced.details.message).toBe('Something went wrong')
+      expect(enhanced.details as any).toBeDefined()
+      expect((enhanced.details as any).message).toBe('Something went wrong')
 
       // Verify secret is NOT leaked
-      expect(JSON.stringify(enhanced.details)).not.toContain('secret-token')
-      expect(enhanced.details.config).toBeUndefined()
-      expect(enhanced.details.request).toBeUndefined()
+      expect(JSON.stringify(enhanced.details as any)).not.toContain('secret-token')
+      expect((enhanced.details as any).config).toBeUndefined()
+      expect((enhanced.details as any).request).toBeUndefined()
     })
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -6,7 +6,7 @@ export class NotionMCPError extends Error {
     public message: string,
     public code: string,
     public suggestion?: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message)
     this.name = 'NotionMCPError'
@@ -26,16 +26,16 @@ export class NotionMCPError extends Error {
 /**
  * Sanitize validation error body to remove sensitive information
  */
-function sanitizeValidationBody(body: any): any {
+function sanitizeValidationBody(body: unknown): unknown {
   if (!body || typeof body !== 'object') return body
 
   // whitelist safe properties from Notion API validation_error responses
-  const safe: any = {}
+  const safe: Record<string, unknown> = {}
   const safeFields = ['message', 'object', 'code', 'status', 'request_id', 'path']
 
   for (const field of safeFields) {
-    if (field in body) {
-      safe[field] = body[field]
+    if (field in (body as Record<string, unknown>)) {
+      safe[field] = (body as Record<string, unknown>)[field]
     }
   }
 
@@ -45,19 +45,20 @@ function sanitizeValidationBody(body: any): any {
 /**
  * Sanitize error object to remove sensitive information
  */
-function sanitizeErrorDetails(error: any): any {
+function sanitizeErrorDetails(error: unknown): unknown {
   if (!error || typeof error !== 'object') return error
 
   // whitelist safe properties
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
+  const safe: Record<string, unknown> = {
+    message: (error as Record<string, unknown>).message as string,
+    name: (error as Record<string, unknown>).name as string,
+    code: (error as Record<string, unknown>).code as string
   }
 
   // Add status if available (common in HTTP errors)
-  if (error.status) safe.status = error.status
-  if (error.response?.status) safe.status = error.response.status
+  if ((error as Record<string, unknown>).status) safe.status = (error as Record<string, unknown>).status
+  if (((error as Record<string, unknown>).response as Record<string, unknown>)?.status)
+    safe.status = ((error as Record<string, unknown>).response as Record<string, unknown>).status
 
   return safe
 }
@@ -83,42 +84,42 @@ const SENSITIVE_HEADER_NAMES = new Set([
  * `Authorization` but third-party axios/fetch wrappers may surface
  * `authorization`, `AUTHORIZATION`, or `X-API-Key`.
  */
-function redactHeaderMap(headers: any): void {
+function redactHeaderMap(headers: unknown): void {
   if (!headers || typeof headers !== 'object') return
-  for (const key of Object.keys(headers)) {
+  for (const key of Object.keys(headers as Record<string, unknown>)) {
     if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
-      delete headers[key]
+      delete (headers as Record<string, unknown>)[key]
     }
   }
 }
 
-function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
+function stripSensitiveFields(obj: unknown, seen = new WeakSet()): void {
   if (!obj || typeof obj !== 'object') return
   if (seen.has(obj)) return
   seen.add(obj)
 
-  delete obj.sensitive_token
-  delete obj.internal_config
-  delete obj.user_email
+  delete (obj as Record<string, unknown>).sensitive_token
+  delete (obj as Record<string, unknown>).internal_config
+  delete (obj as Record<string, unknown>).user_email
 
   // Strip authorization-style headers from the common error-shape locations
   // (response interceptors copy them onto multiple parent objects).
-  redactHeaderMap(obj.headers)
-  redactHeaderMap(obj._headers)
-  if (obj.request) {
-    redactHeaderMap(obj.request.headers)
-    redactHeaderMap(obj.request._headers)
+  redactHeaderMap((obj as Record<string, unknown>).headers)
+  redactHeaderMap((obj as Record<string, unknown>)._headers)
+  if ((obj as Record<string, unknown>).request) {
+    redactHeaderMap(((obj as Record<string, unknown>).request as Record<string, unknown>).headers)
+    redactHeaderMap(((obj as Record<string, unknown>).request as Record<string, unknown>)._headers)
   }
-  if (obj.config) {
-    redactHeaderMap(obj.config.headers)
+  if ((obj as Record<string, unknown>).config) {
+    redactHeaderMap(((obj as Record<string, unknown>).config as Record<string, unknown>).headers)
   }
-  if (obj.response) {
-    redactHeaderMap(obj.response.headers)
+  if ((obj as Record<string, unknown>).response) {
+    redactHeaderMap(((obj as Record<string, unknown>).response as Record<string, unknown>).headers)
   }
 
-  for (const key of Object.keys(obj)) {
-    if (typeof obj[key] === 'object' && obj[key] !== null) {
-      stripSensitiveFields(obj[key], seen)
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (typeof (obj as Record<string, unknown>)[key] === 'object' && (obj as Record<string, unknown>)[key] !== null) {
+      stripSensitiveFields((obj as Record<string, unknown>)[key], seen)
     }
   }
 }
@@ -126,8 +127,11 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
 /**
  * Map network-related errors
  */
-function mapNetworkError(error: any): NotionMCPError | null {
-  if (error.message?.includes('ECONNREFUSED') || error.message?.includes('ENOTFOUND')) {
+function mapNetworkError(error: unknown): NotionMCPError | null {
+  if (
+    ((error as Record<string, unknown>).message as string)?.includes('ECONNREFUSED') ||
+    ((error as Record<string, unknown>).message as string)?.includes('ENOTFOUND')
+  ) {
     return new NotionMCPError(
       'Cannot connect to Notion API',
       'NETWORK_ERROR',
@@ -140,10 +144,11 @@ function mapNetworkError(error: any): NotionMCPError | null {
 /**
  * Handle validation_error separately as it has dynamic suggestions
  */
-function mapValidationError(error: any): NotionMCPError | null {
-  if (error.code !== 'validation_error') return null
+function mapValidationError(error: unknown): NotionMCPError | null {
+  if ((error as Record<string, unknown>).code !== 'validation_error') return null
 
-  const bodyMessage: string = error.body?.message || ''
+  const bodyMessage: string =
+    (((error as Record<string, unknown>).body as Record<string, unknown>)?.message as string) || ''
   let suggestion = 'Check the API documentation for valid parameter formats'
 
   // Detect common property format mistakes and provide specific guidance
@@ -159,7 +164,7 @@ function mapValidationError(error: any): NotionMCPError | null {
     bodyMessage || 'Invalid request parameters',
     'VALIDATION_ERROR',
     suggestion,
-    sanitizeValidationBody(error.body)
+    sanitizeValidationBody((error as Record<string, unknown>).body)
   )
 }
 
@@ -205,14 +210,14 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
 /**
  * Map Notion API errors
  */
-function mapNotionError(error: any): NotionMCPError | null {
-  if (!error.code) return null
+function mapNotionError(error: unknown): NotionMCPError | null {
+  if (!(error as Record<string, unknown>).code) return null
 
   const validationError = mapValidationError(error)
   if (validationError) return validationError
 
-  const code = error.code
-  const message = error.message || 'Unknown Notion API error'
+  const code = (error as Record<string, unknown>).code as string
+  const message = ((error as Record<string, unknown>).message as string) || 'Unknown Notion API error'
   const mapping = NOTION_ERROR_MAP[code]
 
   if (mapping) {
@@ -225,9 +230,9 @@ function mapNotionError(error: any): NotionMCPError | null {
 /**
  * Map all other errors
  */
-function mapGenericError(error: any): NotionMCPError {
+function mapGenericError(error: unknown): NotionMCPError {
   return new NotionMCPError(
-    error.message || 'Unknown error occurred',
+    ((error as Record<string, unknown>).message as string) || 'Unknown error occurred',
     'UNKNOWN_ERROR',
     'Please check your request and try again',
     sanitizeErrorDetails(error)
@@ -237,7 +242,7 @@ function mapGenericError(error: any): NotionMCPError {
 /**
  * Enhance Notion API error with helpful context
  */
-export function enhanceError(error: any): NotionMCPError {
+export function enhanceError(error: unknown): NotionMCPError {
   // Already a NotionMCPError — pass through unchanged
   if (error instanceof NotionMCPError) return error
 
@@ -387,17 +392,20 @@ export async function retryWithBackoff<T>(
 ): Promise<T> {
   const { maxRetries = 3, initialDelay = 1000, maxDelay = 10000, backoffMultiplier = 2 } = options
 
-  let lastError: any
+  let lastError: unknown
   let delay = initialDelay
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn()
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error
 
       // Don't retry on certain errors
-      if (error.code === 'UNAUTHORIZED' || error.code === 'NOT_FOUND') {
+      if (
+        (error as Record<string, unknown>).code === 'UNAUTHORIZED' ||
+        (error as Record<string, unknown>).code === 'NOT_FOUND'
+      ) {
         throw enhanceError(error)
       }
 


### PR DESCRIPTION
Replaced 'any' with 'unknown' in src/tools/helpers/errors.ts to improve type safety. Added necessary type assertions (as Record<string, unknown>) for safe property access. Updated tests to handle the type change in NotionMCPError.details.

---
*PR created automatically by Jules for task [6603379058124551620](https://jules.google.com/task/6603379058124551620) started by @n24q02m*