### PR TITLE
[CLEANUP] Use of any type

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2025-05-26 - Array.includes() vs Set.has() for O(1) Lookups
 **Learning:** Checking for membership in an array using `['a', 'b', ...].includes(value)` within hot paths requires an O(N) scan. This can become an issue when iterating or repeatedly checking values.
 **Action:** Replace `Array.includes()` with `Set.has()` by extracting the array into a module-level `Set`. This improves lookup times significantly to O(1).
+
+## 2026-05-28 - Type Safety: Replacing 'any' with 'unknown'
+**Learning:** Using 'any' in error handling logic masks potential property access issues and reduces type safety. Replacing it with 'unknown' combined with specific interfaces (e.g., 'NotionApiError') and type guards ensures more robust code. However, it requires updating test suites to handle the 'unknown' type, typically through safe casting to 'Record<string, unknown>' or similar.
+**Action:** Always prefer 'unknown' or a specific interface over 'any'. Use type guards (typeof, instanceof, 'field' in object) or safe casting (as Record<string, unknown>) when property access is required on 'unknown' types.

--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -27,9 +27,10 @@ describe('Security: Error Handling', () => {
 
     // Check that safe fields are present
     expect(enhanced.details).toBeDefined()
-    expect(enhanced.details.message).toBe('Invalid property value')
-    expect(enhanced.details.object).toBe('error')
-    expect(enhanced.details.status).toBe(400)
+    const details = enhanced.details as Record<string, unknown>
+    expect(details.message).toBe('Invalid property value')
+    expect(details.object).toBe('error')
+    expect(details.status).toBe(400)
 
     // Check that sensitive fields are REMOVED
     expect(enhanced.details).not.toHaveProperty('sensitive_token')
@@ -58,15 +59,16 @@ describe('Security: Error Handling', () => {
 
     const enhanced = enhanceError(errorWithAuth)
     expect(enhanced.details).toBeDefined()
-    if (enhanced.details?.headers) {
-      expect(enhanced.details.headers).not.toHaveProperty('Authorization')
-      expect(enhanced.details.headers).toHaveProperty('Content-Type')
+    const details = enhanced.details as Record<string, any>
+    if (details?.headers) {
+      expect(details.headers).not.toHaveProperty('Authorization')
+      expect(details.headers).toHaveProperty('Content-Type')
     }
-    if (enhanced.details?.config?.headers) {
-      expect(enhanced.details.config.headers).not.toHaveProperty('authorization')
+    if (details?.config?.headers) {
+      expect(details.config.headers).not.toHaveProperty('authorization')
     }
-    if (enhanced.details?.request?._headers) {
-      expect(enhanced.details.request._headers).not.toHaveProperty('authorization')
+    if (details?.request?._headers) {
+      expect(details.request._headers).not.toHaveProperty('authorization')
     }
   })
 

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -233,12 +233,13 @@ describe('enhanceError', () => {
 
       // Expectation of SECURE behavior
       expect(enhanced.details).toBeDefined()
-      expect(enhanced.details.message).toBe('Something went wrong')
+      const details = enhanced.details as Record<string, unknown>
+      expect(details.message).toBe('Something went wrong')
 
       // Verify secret is NOT leaked
       expect(JSON.stringify(enhanced.details)).not.toContain('secret-token')
-      expect(enhanced.details.config).toBeUndefined()
-      expect(enhanced.details.request).toBeUndefined()
+      expect(details.config).toBeUndefined()
+      expect(details.request).toBeUndefined()
     })
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -6,7 +6,7 @@ export class NotionMCPError extends Error {
     public message: string,
     public code: string,
     public suggestion?: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message)
     this.name = 'NotionMCPError'
@@ -26,16 +26,33 @@ export class NotionMCPError extends Error {
 /**
  * Sanitize validation error body to remove sensitive information
  */
-function sanitizeValidationBody(body: any): any {
+
+interface NotionApiError {
+  code?: string
+  message?: string
+  name?: string
+  status?: number
+  response?: {
+    status?: number
+    headers?: Record<string, string>
+  }
+  body?: {
+    message?: string
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+function sanitizeValidationBody(body: unknown): Record<string, unknown> | unknown {
   if (!body || typeof body !== 'object') return body
 
   // whitelist safe properties from Notion API validation_error responses
-  const safe: any = {}
+  const safe: Record<string, unknown> = {}
   const safeFields = ['message', 'object', 'code', 'status', 'request_id', 'path']
 
   for (const field of safeFields) {
-    if (field in body) {
-      safe[field] = body[field]
+    if (typeof body === 'object' && body !== null && field in body) {
+      safe[field] = (body as Record<string, unknown>)[field]
     }
   }
 
@@ -45,19 +62,20 @@ function sanitizeValidationBody(body: any): any {
 /**
  * Sanitize error object to remove sensitive information
  */
-function sanitizeErrorDetails(error: any): any {
+function sanitizeErrorDetails(error: unknown): Record<string, unknown> | unknown {
   if (!error || typeof error !== 'object') return error
 
   // whitelist safe properties
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
+  const err = error as NotionApiError
+  const safe: Record<string, unknown> = {
+    message: err.message,
+    name: err.name,
+    code: err.code
   }
 
   // Add status if available (common in HTTP errors)
-  if (error.status) safe.status = error.status
-  if (error.response?.status) safe.status = error.response.status
+  if (err.status) safe.status = err.status
+  if (err.response?.status) safe.status = err.response.status
 
   return safe
 }
@@ -83,42 +101,48 @@ const SENSITIVE_HEADER_NAMES = new Set([
  * `Authorization` but third-party axios/fetch wrappers may surface
  * `authorization`, `AUTHORIZATION`, or `X-API-Key`.
  */
-function redactHeaderMap(headers: any): void {
+function redactHeaderMap(headers: unknown): void {
   if (!headers || typeof headers !== 'object') return
-  for (const key of Object.keys(headers)) {
+  const h = headers as Record<string, unknown>
+  for (const key of Object.keys(h)) {
     if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
-      delete headers[key]
+      delete h[key]
     }
   }
 }
 
-function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
+function stripSensitiveFields(obj: unknown, seen = new WeakSet<object>()): void {
   if (!obj || typeof obj !== 'object') return
   if (seen.has(obj)) return
   seen.add(obj)
 
-  delete obj.sensitive_token
-  delete obj.internal_config
-  delete obj.user_email
+  const o = obj as Record<string, unknown>
+  delete o.sensitive_token
+  delete o.internal_config
+  delete o.user_email
 
   // Strip authorization-style headers from the common error-shape locations
   // (response interceptors copy them onto multiple parent objects).
-  redactHeaderMap(obj.headers)
-  redactHeaderMap(obj._headers)
-  if (obj.request) {
-    redactHeaderMap(obj.request.headers)
-    redactHeaderMap(obj.request._headers)
+  redactHeaderMap(o.headers)
+  redactHeaderMap(o._headers)
+  if (o.request && typeof o.request === 'object') {
+    const req = o.request as Record<string, unknown>
+    redactHeaderMap(req.headers)
+    redactHeaderMap(req._headers)
   }
-  if (obj.config) {
-    redactHeaderMap(obj.config.headers)
+  if (o.config && typeof o.config === 'object') {
+    const config = o.config as Record<string, unknown>
+    redactHeaderMap(config.headers)
   }
-  if (obj.response) {
-    redactHeaderMap(obj.response.headers)
+  if (o.response && typeof o.response === 'object') {
+    const response = o.response as Record<string, unknown>
+    redactHeaderMap(response.headers)
   }
 
-  for (const key of Object.keys(obj)) {
-    if (typeof obj[key] === 'object' && obj[key] !== null) {
-      stripSensitiveFields(obj[key], seen)
+  for (const key of Object.keys(o)) {
+    const val = o[key]
+    if (typeof val === 'object' && val !== null) {
+      stripSensitiveFields(val, seen)
     }
   }
 }
@@ -126,8 +150,9 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
 /**
  * Map network-related errors
  */
-function mapNetworkError(error: any): NotionMCPError | null {
-  if (error.message?.includes('ECONNREFUSED') || error.message?.includes('ENOTFOUND')) {
+function mapNetworkError(error: unknown): NotionMCPError | null {
+  const err = error as Error
+  if (err.message?.includes('ECONNREFUSED') || err.message?.includes('ENOTFOUND')) {
     return new NotionMCPError(
       'Cannot connect to Notion API',
       'NETWORK_ERROR',
@@ -140,10 +165,11 @@ function mapNetworkError(error: any): NotionMCPError | null {
 /**
  * Handle validation_error separately as it has dynamic suggestions
  */
-function mapValidationError(error: any): NotionMCPError | null {
-  if (error.code !== 'validation_error') return null
+function mapValidationError(error: unknown): NotionMCPError | null {
+  const err = error as NotionApiError
+  if (err.code !== 'validation_error') return null
 
-  const bodyMessage: string = error.body?.message || ''
+  const bodyMessage: string = err.body?.message || ''
   let suggestion = 'Check the API documentation for valid parameter formats'
 
   // Detect common property format mistakes and provide specific guidance
@@ -159,7 +185,7 @@ function mapValidationError(error: any): NotionMCPError | null {
     bodyMessage || 'Invalid request parameters',
     'VALIDATION_ERROR',
     suggestion,
-    sanitizeValidationBody(error.body)
+    sanitizeValidationBody(err.body)
   )
 }
 
@@ -205,14 +231,15 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
 /**
  * Map Notion API errors
  */
-function mapNotionError(error: any): NotionMCPError | null {
-  if (!error.code) return null
+function mapNotionError(error: unknown): NotionMCPError | null {
+  const err = error as NotionApiError
+  if (!err.code) return null
 
-  const validationError = mapValidationError(error)
+  const validationError = mapValidationError(err)
   if (validationError) return validationError
 
-  const code = error.code
-  const message = error.message || 'Unknown Notion API error'
+  const code = err.code as string
+  const message = err.message || 'Unknown Notion API error'
   const mapping = NOTION_ERROR_MAP[code]
 
   if (mapping) {
@@ -225,9 +252,9 @@ function mapNotionError(error: any): NotionMCPError | null {
 /**
  * Map all other errors
  */
-function mapGenericError(error: any): NotionMCPError {
+function mapGenericError(error: unknown): NotionMCPError {
   return new NotionMCPError(
-    error.message || 'Unknown error occurred',
+    (error as Error).message || 'Unknown error occurred',
     'UNKNOWN_ERROR',
     'Please check your request and try again',
     sanitizeErrorDetails(error)
@@ -237,7 +264,7 @@ function mapGenericError(error: any): NotionMCPError {
 /**
  * Enhance Notion API error with helpful context
  */
-export function enhanceError(error: any): NotionMCPError {
+export function enhanceError(error: unknown): NotionMCPError {
   // Already a NotionMCPError — pass through unchanged
   if (error instanceof NotionMCPError) return error
 
@@ -387,17 +414,18 @@ export async function retryWithBackoff<T>(
 ): Promise<T> {
   const { maxRetries = 3, initialDelay = 1000, maxDelay = 10000, backoffMultiplier = 2 } = options
 
-  let lastError: any
+  let lastError: unknown
   let delay = initialDelay
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn()
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error
 
       // Don't retry on certain errors
-      if (error.code === 'UNAUTHORIZED' || error.code === 'NOT_FOUND') {
+      const err = error as NotionApiError
+      if (err.code === 'UNAUTHORIZED' || err.code === 'NOT_FOUND') {
         throw enhanceError(error)
       }
 


### PR DESCRIPTION
💡 What
- Refactored \`src/tools/helpers/errors.ts\` to replace \`any\` types with \`unknown\` for parameters and \`details\` property.
- Introduced internal \`NotionApiError\` interface for Notion SDK error shapes.
- Added type guards and safe casting to \`Record<string, unknown>\` or \`NotionApiError\` to ensure type safety.
- Updated \`src/tools/helpers/errors.test.ts\` and \`src/tools/helpers/errors.security.test.ts\` with necessary type assertions to pass type-checking.

🎯 Why
- Replacing 'any' with 'unknown' or specific types improves type safety and prevents potential runtime errors.
- It forces explicit handling of the data shape, making the code more robust and self-documenting.

📊 Impact
- Improved code quality and static analysis for the core error handling logic.
- No functional regressions, as verified by the full test suite.

🔬 Measurement
- \`bun run check\` (including biome and tsc) passes without errors.
- Full test suite passed (765 tests passed).

---
*PR created automatically by Jules for task [2749543725216224030](https://jules.google.com/task/2749543725216224030) started by @n24q02m*