### PR TITLE
[CLEANUP] Use of any type

### DIFF
--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -27,9 +27,9 @@ describe('Security: Error Handling', () => {
 
     // Check that safe fields are present
     expect(enhanced.details).toBeDefined()
-    expect(enhanced.details.message).toBe('Invalid property value')
-    expect(enhanced.details.object).toBe('error')
-    expect(enhanced.details.status).toBe(400)
+    expect((enhanced.details as Record<string, unknown>).message).toBe('Invalid property value')
+    expect((enhanced.details as Record<string, unknown>).object).toBe('error')
+    expect((enhanced.details as Record<string, unknown>).status).toBe(400)
 
     // Check that sensitive fields are REMOVED
     expect(enhanced.details).not.toHaveProperty('sensitive_token')
@@ -58,15 +58,19 @@ describe('Security: Error Handling', () => {
 
     const enhanced = enhanceError(errorWithAuth)
     expect(enhanced.details).toBeDefined()
-    if (enhanced.details?.headers) {
-      expect(enhanced.details.headers).not.toHaveProperty('Authorization')
-      expect(enhanced.details.headers).toHaveProperty('Content-Type')
+    if ((enhanced.details as Record<string, unknown>)?.headers) {
+      expect((enhanced.details as Record<string, unknown>).headers).not.toHaveProperty('Authorization')
+      expect((enhanced.details as Record<string, unknown>).headers).toHaveProperty('Content-Type')
     }
-    if (enhanced.details?.config?.headers) {
-      expect(enhanced.details.config.headers).not.toHaveProperty('authorization')
+    if (((enhanced.details as Record<string, unknown>)?.config as Record<string, unknown>)?.headers) {
+      expect(
+        ((enhanced.details as Record<string, unknown>).config as Record<string, unknown>).headers
+      ).not.toHaveProperty('authorization')
     }
-    if (enhanced.details?.request?._headers) {
-      expect(enhanced.details.request._headers).not.toHaveProperty('authorization')
+    if (((enhanced.details as Record<string, unknown>)?.request as Record<string, unknown>)?._headers) {
+      expect(
+        ((enhanced.details as Record<string, unknown>).request as Record<string, unknown>)._headers
+      ).not.toHaveProperty('authorization')
     }
   })
 

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -92,7 +92,10 @@ describe('enhanceError', () => {
 
       expect(result.code).toBe('VALIDATION_ERROR')
       expect(result.message).toBe('title is required')
-      expect(result.details).toEqual({ message: 'title is required', path: '/properties/title' })
+      expect(result.details as Record<string, unknown>).toEqual({
+        message: 'title is required',
+        path: '/properties/title'
+      })
     })
 
     it('should handle validation_error without body', () => {
@@ -116,7 +119,10 @@ describe('enhanceError', () => {
 
       expect(result.code).toBe('VALIDATION_ERROR')
       expect(result.message).toBe('title is required')
-      expect(result.details).toEqual({ message: 'title is required', path: '/properties/title' })
+      expect(result.details as Record<string, unknown>).toEqual({
+        message: 'title is required',
+        path: '/properties/title'
+      })
       expect(JSON.stringify(result.details)).not.toContain('secret_token')
       expect(JSON.stringify(result.details)).not.toContain('sk-12345')
     })
@@ -199,7 +205,7 @@ describe('enhanceError', () => {
         status: 502
       })
 
-      expect(result.details).toEqual({
+      expect(result.details as Record<string, unknown>).toEqual({
         message: 'oops',
         name: 'SomeError',
         code: undefined,
@@ -233,12 +239,12 @@ describe('enhanceError', () => {
 
       // Expectation of SECURE behavior
       expect(enhanced.details).toBeDefined()
-      expect(enhanced.details.message).toBe('Something went wrong')
+      expect((enhanced.details as Record<string, unknown>).message).toBe('Something went wrong')
 
       // Verify secret is NOT leaked
       expect(JSON.stringify(enhanced.details)).not.toContain('secret-token')
-      expect(enhanced.details.config).toBeUndefined()
-      expect(enhanced.details.request).toBeUndefined()
+      expect((enhanced.details as Record<string, unknown>).config).toBeUndefined()
+      expect((enhanced.details as Record<string, unknown>).request).toBeUndefined()
     })
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -6,7 +6,7 @@ export class NotionMCPError extends Error {
     public message: string,
     public code: string,
     public suggestion?: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message)
     this.name = 'NotionMCPError'
@@ -26,16 +26,17 @@ export class NotionMCPError extends Error {
 /**
  * Sanitize validation error body to remove sensitive information
  */
-function sanitizeValidationBody(body: any): any {
+function sanitizeValidationBody(body: unknown): unknown {
   if (!body || typeof body !== 'object') return body
 
   // whitelist safe properties from Notion API validation_error responses
-  const safe: any = {}
+  const safe: Record<string, unknown> = {}
   const safeFields = ['message', 'object', 'code', 'status', 'request_id', 'path']
+  const bodyObj = body as Record<string, unknown>
 
   for (const field of safeFields) {
-    if (field in body) {
-      safe[field] = body[field]
+    if (field in bodyObj) {
+      safe[field] = bodyObj[field]
     }
   }
 
@@ -45,19 +46,26 @@ function sanitizeValidationBody(body: any): any {
 /**
  * Sanitize error object to remove sensitive information
  */
-function sanitizeErrorDetails(error: any): any {
+function sanitizeErrorDetails(error: unknown): unknown {
   if (!error || typeof error !== 'object') return error
 
+  const errObj = error as Record<string, unknown>
+
   // whitelist safe properties
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
+  const safe: Record<string, unknown> = {
+    message: errObj.message,
+    name: errObj.name,
+    code: errObj.code
   }
 
   // Add status if available (common in HTTP errors)
-  if (error.status) safe.status = error.status
-  if (error.response?.status) safe.status = error.response.status
+  if (errObj.status) safe.status = errObj.status
+
+  const response = errObj.response
+  if (response && typeof response === 'object') {
+    const respObj = response as Record<string, unknown>
+    if (respObj.status) safe.status = respObj.status
+  }
 
   return safe
 }
@@ -83,42 +91,55 @@ const SENSITIVE_HEADER_NAMES = new Set([
  * `Authorization` but third-party axios/fetch wrappers may surface
  * `authorization`, `AUTHORIZATION`, or `X-API-Key`.
  */
-function redactHeaderMap(headers: any): void {
+function redactHeaderMap(headers: unknown): void {
   if (!headers || typeof headers !== 'object') return
-  for (const key of Object.keys(headers)) {
+  const headersObj = headers as Record<string, unknown>
+  for (const key of Object.keys(headersObj)) {
     if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
-      delete headers[key]
+      delete headersObj[key]
     }
   }
 }
 
-function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
-  if (!obj || typeof obj !== 'object') return
+function stripSensitiveFields(obj: unknown, seen = new WeakSet()): void {
+  if (!obj || typeof obj !== 'object' || obj === null) return
   if (seen.has(obj)) return
   seen.add(obj)
 
-  delete obj.sensitive_token
-  delete obj.internal_config
-  delete obj.user_email
+  const record = obj as Record<string, unknown>
+
+  delete record.sensitive_token
+  delete record.internal_config
+  delete record.user_email
 
   // Strip authorization-style headers from the common error-shape locations
   // (response interceptors copy them onto multiple parent objects).
-  redactHeaderMap(obj.headers)
-  redactHeaderMap(obj._headers)
-  if (obj.request) {
-    redactHeaderMap(obj.request.headers)
-    redactHeaderMap(obj.request._headers)
-  }
-  if (obj.config) {
-    redactHeaderMap(obj.config.headers)
-  }
-  if (obj.response) {
-    redactHeaderMap(obj.response.headers)
+  redactHeaderMap(record.headers)
+  redactHeaderMap(record._headers)
+
+  const request = record.request
+  if (request && typeof request === 'object') {
+    const reqObj = request as Record<string, unknown>
+    redactHeaderMap(reqObj.headers)
+    redactHeaderMap(reqObj._headers)
   }
 
-  for (const key of Object.keys(obj)) {
-    if (typeof obj[key] === 'object' && obj[key] !== null) {
-      stripSensitiveFields(obj[key], seen)
+  const config = record.config
+  if (config && typeof config === 'object') {
+    const configObj = config as Record<string, unknown>
+    redactHeaderMap(configObj.headers)
+  }
+
+  const response = record.response
+  if (response && typeof response === 'object') {
+    const respObj = response as Record<string, unknown>
+    redactHeaderMap(respObj.headers)
+  }
+
+  for (const key of Object.keys(record)) {
+    const value = record[key]
+    if (typeof value === 'object' && value !== null) {
+      stripSensitiveFields(value, seen)
     }
   }
 }
@@ -126,8 +147,11 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
 /**
  * Map network-related errors
  */
-function mapNetworkError(error: any): NotionMCPError | null {
-  if (error.message?.includes('ECONNREFUSED') || error.message?.includes('ENOTFOUND')) {
+function mapNetworkError(error: unknown): NotionMCPError | null {
+  if (!error || typeof error !== 'object') return null
+  const errObj = error as Record<string, unknown>
+  const message = errObj.message
+  if (typeof message === 'string' && (message.includes('ECONNREFUSED') || message.includes('ENOTFOUND'))) {
     return new NotionMCPError(
       'Cannot connect to Notion API',
       'NETWORK_ERROR',
@@ -140,10 +164,20 @@ function mapNetworkError(error: any): NotionMCPError | null {
 /**
  * Handle validation_error separately as it has dynamic suggestions
  */
-function mapValidationError(error: any): NotionMCPError | null {
-  if (error.code !== 'validation_error') return null
+function mapValidationError(error: unknown): NotionMCPError | null {
+  if (!error || typeof error !== 'object') return null
+  const errObj = error as Record<string, unknown>
+  if (errObj.code !== 'validation_error') return null
 
-  const bodyMessage: string = error.body?.message || ''
+  const body = errObj.body
+  let bodyMessage = ''
+  if (body && typeof body === 'object') {
+    const bodyObj = body as Record<string, unknown>
+    if (typeof bodyObj.message === 'string') {
+      bodyMessage = bodyObj.message
+    }
+  }
+
   let suggestion = 'Check the API documentation for valid parameter formats'
 
   // Detect common property format mistakes and provide specific guidance
@@ -159,7 +193,7 @@ function mapValidationError(error: any): NotionMCPError | null {
     bodyMessage || 'Invalid request parameters',
     'VALIDATION_ERROR',
     suggestion,
-    sanitizeValidationBody(error.body)
+    sanitizeValidationBody(errObj.body)
   )
 }
 
@@ -205,14 +239,18 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
 /**
  * Map Notion API errors
  */
-function mapNotionError(error: any): NotionMCPError | null {
-  if (!error.code) return null
+function mapNotionError(error: unknown): NotionMCPError | null {
+  if (!error || typeof error !== 'object') return null
+  const errObj = error as Record<string, unknown>
+  if (!errObj.code) return null
 
   const validationError = mapValidationError(error)
   if (validationError) return validationError
 
-  const code = error.code
-  const message = error.message || 'Unknown Notion API error'
+  const code = errObj.code
+  if (typeof code !== 'string') return null
+
+  const message = typeof errObj.message === 'string' ? errObj.message : 'Unknown Notion API error'
   const mapping = NOTION_ERROR_MAP[code]
 
   if (mapping) {
@@ -225,9 +263,16 @@ function mapNotionError(error: any): NotionMCPError | null {
 /**
  * Map all other errors
  */
-function mapGenericError(error: any): NotionMCPError {
+function mapGenericError(error: unknown): NotionMCPError {
+  let message = 'Unknown error occurred'
+  if (error && typeof error === 'object') {
+    const errObj = error as Record<string, unknown>
+    if (typeof errObj.message === 'string') {
+      message = errObj.message
+    }
+  }
   return new NotionMCPError(
-    error.message || 'Unknown error occurred',
+    message,
     'UNKNOWN_ERROR',
     'Please check your request and try again',
     sanitizeErrorDetails(error)
@@ -237,7 +282,7 @@ function mapGenericError(error: any): NotionMCPError {
 /**
  * Enhance Notion API error with helpful context
  */
-export function enhanceError(error: any): NotionMCPError {
+export function enhanceError(error: unknown): NotionMCPError {
   // Already a NotionMCPError — pass through unchanged
   if (error instanceof NotionMCPError) return error
 
@@ -387,18 +432,21 @@ export async function retryWithBackoff<T>(
 ): Promise<T> {
   const { maxRetries = 3, initialDelay = 1000, maxDelay = 10000, backoffMultiplier = 2 } = options
 
-  let lastError: any
+  let lastError: unknown
   let delay = initialDelay
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn()
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error
 
       // Don't retry on certain errors
-      if (error.code === 'UNAUTHORIZED' || error.code === 'NOT_FOUND') {
-        throw enhanceError(error)
+      if (error && typeof error === 'object') {
+        const errObj = error as Record<string, unknown>
+        if (errObj.code === 'UNAUTHORIZED' || errObj.code === 'NOT_FOUND') {
+          throw enhanceError(error)
+        }
       }
 
       // Last attempt


### PR DESCRIPTION
Replaced 'any' with 'unknown' in src/tools/helpers/errors.ts to improve type safety. Implemented type narrowing and safe property access using Record<string, unknown>. Updated associated tests to handle the type change of error details.

---
*PR created automatically by Jules for task [4076191384823193003](https://jules.google.com/task/4076191384823193003) started by @n24q02m*