### PR TITLE
⚡ Bolt: optimize block existence check in comments tool

### DIFF
--- a/src/tools/composite/comments.test.ts
+++ b/src/tools/composite/comments.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { commentsManage } from './comments'
+import { blockExistenceCache, commentsManage } from './comments'
 
 const mockNotion = {
   comments: {
@@ -15,6 +15,7 @@ const mockNotion = {
 describe('commentsManage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    blockExistenceCache.clear()
   })
 
   describe('list', () => {
@@ -206,6 +207,46 @@ describe('commentsManage', () => {
           page_id: 'page-1'
         })
       ).rejects.toThrow('Pagination failed')
+    })
+    it('should cache block existence check', async () => {
+      const notFoundError = new Error('Not found')
+      ;(notFoundError as any).code = 'object_not_found'
+      mockNotion.comments.list.mockRejectedValue(notFoundError)
+      mockNotion.blocks.retrieve.mockResolvedValue({ id: 'page-1' })
+
+      // First call - should call blocks.retrieve
+      await expect(
+        commentsManage(mockNotion as any, {
+          action: 'list',
+          page_id: 'page-1'
+        })
+      ).rejects.toMatchObject({
+        code: 'COMMENTS_LIST_UNAVAILABLE'
+      })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Second call - should use cache and NOT call blocks.retrieve again
+      await expect(
+        commentsManage(mockNotion as any, {
+          action: 'list',
+          page_id: 'page-1'
+        })
+      ).rejects.toMatchObject({
+        code: 'COMMENTS_LIST_UNAVAILABLE'
+      })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(1)
+
+      // Clear cache and try again
+      blockExistenceCache.clear()
+      await expect(
+        commentsManage(mockNotion as any, {
+          action: 'list',
+          page_id: 'page-1'
+        })
+      ).rejects.toMatchObject({
+        code: 'COMMENTS_LIST_UNAVAILABLE'
+      })
+      expect(mockNotion.blocks.retrieve).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/tools/composite/comments.ts
+++ b/src/tools/composite/comments.ts
@@ -16,6 +16,10 @@ export interface CommentsManageInput {
   content?: string // For create action
 }
 
+// Cache for block existence to avoid redundant retrieve calls
+export const blockExistenceCache = new Map<string, { exists: boolean; expiresAt: number }>()
+const BLOCK_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
 /**
  * Manage comments (list, get, create)
  * Maps to: GET /v1/comments, GET /v1/comments/{id}, POST /v1/comments
@@ -51,6 +55,19 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
           }
         } catch (error: any) {
           if (error.code === 'object_not_found') {
+            // Check cache first
+            const cached = blockExistenceCache.get(input.page_id)
+            if (cached && Date.now() < cached.expiresAt) {
+              if (cached.exists) {
+                throw new NotionMCPError(
+                  'The comments.list API is currently unavailable for this page due to a known Notion OAuth limitation.',
+                  'COMMENTS_LIST_UNAVAILABLE'
+                )
+              }
+              // If cached as not existing, let it fall through to re-throw original error
+              throw error
+            }
+
             // Distinguish between a real 404 and the known Notion API limitation (OAuth 404)
             // by checking if the block/page actually exists.
             let blockExists = false
@@ -63,6 +80,12 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
                 throw innerError
               }
             }
+
+            // Update cache
+            blockExistenceCache.set(input.page_id, {
+              exists: blockExists,
+              expiresAt: Date.now() + BLOCK_CACHE_TTL
+            })
 
             if (blockExists) {
               // If retrieve succeeds, it's the known API limitation


### PR DESCRIPTION
💡 What
Implemented a TTL-based cache (5 minutes) for block existence checks in the comments tool.

🎯 Why
When listing comments, the Notion API may return a 404 for certain pages due to OAuth limitations even if the page exists. We currently verify this by calling notion.blocks.retrieve. This optimization caches that check to avoid redundant API calls.

📊 Impact
Reduces unnecessary API calls to blocks.retrieve for subsequent comment list requests on the same page within the TTL window.

🔬 Measurement
Added unit tests to verify that notion.blocks.retrieve is only called once for repeated 404 scenarios within the same page context.

---
*PR created automatically by Jules for task [11491599310875047462](https://jules.google.com/task/11491599310875047462) started by @n24q02m*