### PR TITLE
[CLEANUP] Use of any type

### DIFF
--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { enhanceError, NotionMCPError } from './errors'
+import { enhanceError, isObject, NotionMCPError } from './errors'
 
 describe('Security: Error Handling', () => {
   it('should not leak sensitive fields in validation_error body', () => {
@@ -27,9 +27,9 @@ describe('Security: Error Handling', () => {
 
     // Check that safe fields are present
     expect(enhanced.details).toBeDefined()
-    expect(enhanced.details.message).toBe('Invalid property value')
-    expect(enhanced.details.object).toBe('error')
-    expect(enhanced.details.status).toBe(400)
+    expect((enhanced.details as any).message).toBe('Invalid property value')
+    expect((enhanced.details as any).object).toBe('error')
+    expect((enhanced.details as any).status).toBe(400)
 
     // Check that sensitive fields are REMOVED
     expect(enhanced.details).not.toHaveProperty('sensitive_token')
@@ -58,14 +58,18 @@ describe('Security: Error Handling', () => {
 
     const enhanced = enhanceError(errorWithAuth)
     expect(enhanced.details).toBeDefined()
-    if (enhanced.details?.headers) {
+    if (isObject(enhanced.details) && isObject(enhanced.details.headers)) {
       expect(enhanced.details.headers).not.toHaveProperty('Authorization')
       expect(enhanced.details.headers).toHaveProperty('Content-Type')
     }
-    if (enhanced.details?.config?.headers) {
+    if (isObject(enhanced.details) && isObject(enhanced.details.config) && isObject(enhanced.details.config.headers)) {
       expect(enhanced.details.config.headers).not.toHaveProperty('authorization')
     }
-    if (enhanced.details?.request?._headers) {
+    if (
+      isObject(enhanced.details) &&
+      isObject(enhanced.details.request) &&
+      isObject(enhanced.details.request._headers)
+    ) {
       expect(enhanced.details.request._headers).not.toHaveProperty('authorization')
     }
   })

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -233,12 +233,12 @@ describe('enhanceError', () => {
 
       // Expectation of SECURE behavior
       expect(enhanced.details).toBeDefined()
-      expect(enhanced.details.message).toBe('Something went wrong')
+      expect((enhanced.details as Record<string, unknown>).message).toBe('Something went wrong')
 
       // Verify secret is NOT leaked
       expect(JSON.stringify(enhanced.details)).not.toContain('secret-token')
-      expect(enhanced.details.config).toBeUndefined()
-      expect(enhanced.details.request).toBeUndefined()
+      expect((enhanced.details as Record<string, unknown>).config).toBeUndefined()
+      expect((enhanced.details as Record<string, unknown>).request).toBeUndefined()
     })
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -6,7 +6,7 @@ export class NotionMCPError extends Error {
     public message: string,
     public code: string,
     public suggestion?: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message)
     this.name = 'NotionMCPError'
@@ -24,13 +24,20 @@ export class NotionMCPError extends Error {
 }
 
 /**
+ * Type guard to check if a value is a record-like object
+ */
+export function isObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === 'object' && val !== null
+}
+
+/**
  * Sanitize validation error body to remove sensitive information
  */
-function sanitizeValidationBody(body: any): any {
-  if (!body || typeof body !== 'object') return body
+function sanitizeValidationBody(body: unknown): Record<string, unknown> | unknown {
+  if (!isObject(body)) return body
 
   // whitelist safe properties from Notion API validation_error responses
-  const safe: any = {}
+  const safe: Record<string, unknown> = {}
   const safeFields = ['message', 'object', 'code', 'status', 'request_id', 'path']
 
   for (const field of safeFields) {
@@ -45,19 +52,22 @@ function sanitizeValidationBody(body: any): any {
 /**
  * Sanitize error object to remove sensitive information
  */
-function sanitizeErrorDetails(error: any): any {
-  if (!error || typeof error !== 'object') return error
+function sanitizeErrorDetails(error: unknown): Record<string, unknown> | unknown {
+  if (!isObject(error)) return error
 
   // whitelist safe properties
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
+  const safe: Record<string, unknown> = {
+    message: typeof error.message === 'string' ? error.message : undefined,
+    name: typeof error.name === 'string' ? error.name : undefined,
+    code: typeof error.code === 'string' ? error.code : undefined
   }
 
   // Add status if available (common in HTTP errors)
-  if (error.status) safe.status = error.status
-  if (error.response?.status) safe.status = error.response.status
+  if (typeof error.status === 'number') safe.status = error.status
+  const response = error.response
+  if (isObject(response) && typeof response.status === 'number') {
+    safe.status = response.status
+  }
 
   return safe
 }
@@ -83,8 +93,8 @@ const SENSITIVE_HEADER_NAMES = new Set([
  * `Authorization` but third-party axios/fetch wrappers may surface
  * `authorization`, `AUTHORIZATION`, or `X-API-Key`.
  */
-function redactHeaderMap(headers: any): void {
-  if (!headers || typeof headers !== 'object') return
+function redactHeaderMap(headers: unknown): void {
+  if (!isObject(headers)) return
   for (const key of Object.keys(headers)) {
     if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
       delete headers[key]
@@ -92,8 +102,8 @@ function redactHeaderMap(headers: any): void {
   }
 }
 
-function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
-  if (!obj || typeof obj !== 'object') return
+function stripSensitiveFields(obj: unknown, seen = new WeakSet<object>()): void {
+  if (!isObject(obj)) return
   if (seen.has(obj)) return
   seen.add(obj)
 
@@ -105,20 +115,27 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
   // (response interceptors copy them onto multiple parent objects).
   redactHeaderMap(obj.headers)
   redactHeaderMap(obj._headers)
-  if (obj.request) {
-    redactHeaderMap(obj.request.headers)
-    redactHeaderMap(obj.request._headers)
+
+  const request = obj.request
+  if (isObject(request)) {
+    redactHeaderMap(request.headers)
+    redactHeaderMap(request._headers)
   }
-  if (obj.config) {
-    redactHeaderMap(obj.config.headers)
+
+  const config = obj.config
+  if (isObject(config)) {
+    redactHeaderMap(config.headers)
   }
-  if (obj.response) {
-    redactHeaderMap(obj.response.headers)
+
+  const response = obj.response
+  if (isObject(response)) {
+    redactHeaderMap(response.headers)
   }
 
   for (const key of Object.keys(obj)) {
-    if (typeof obj[key] === 'object' && obj[key] !== null) {
-      stripSensitiveFields(obj[key], seen)
+    const val = obj[key]
+    if (isObject(val)) {
+      stripSensitiveFields(val, seen)
     }
   }
 }
@@ -126,8 +143,11 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
 /**
  * Map network-related errors
  */
-function mapNetworkError(error: any): NotionMCPError | null {
-  if (error.message?.includes('ECONNREFUSED') || error.message?.includes('ENOTFOUND')) {
+function mapNetworkError(error: unknown): NotionMCPError | null {
+  if (!isObject(error)) return null
+
+  const message = typeof error.message === 'string' ? error.message : ''
+  if (message.includes('ECONNREFUSED') || message.includes('ENOTFOUND')) {
     return new NotionMCPError(
       'Cannot connect to Notion API',
       'NETWORK_ERROR',
@@ -140,10 +160,11 @@ function mapNetworkError(error: any): NotionMCPError | null {
 /**
  * Handle validation_error separately as it has dynamic suggestions
  */
-function mapValidationError(error: any): NotionMCPError | null {
-  if (error.code !== 'validation_error') return null
+function mapValidationError(error: unknown): NotionMCPError | null {
+  if (!isObject(error) || error.code !== 'validation_error') return null
 
-  const bodyMessage: string = error.body?.message || ''
+  const body = error.body
+  const bodyMessage: string = isObject(body) && typeof body.message === 'string' ? body.message : ''
   let suggestion = 'Check the API documentation for valid parameter formats'
 
   // Detect common property format mistakes and provide specific guidance
@@ -159,7 +180,7 @@ function mapValidationError(error: any): NotionMCPError | null {
     bodyMessage || 'Invalid request parameters',
     'VALIDATION_ERROR',
     suggestion,
-    sanitizeValidationBody(error.body)
+    sanitizeValidationBody(body)
   )
 }
 
@@ -205,14 +226,14 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
 /**
  * Map Notion API errors
  */
-function mapNotionError(error: any): NotionMCPError | null {
-  if (!error.code) return null
+function mapNotionError(error: unknown): NotionMCPError | null {
+  if (!isObject(error) || typeof error.code !== 'string') return null
 
   const validationError = mapValidationError(error)
   if (validationError) return validationError
 
   const code = error.code
-  const message = error.message || 'Unknown Notion API error'
+  const message = typeof error.message === 'string' ? error.message : 'Unknown Notion API error'
   const mapping = NOTION_ERROR_MAP[code]
 
   if (mapping) {
@@ -225,9 +246,16 @@ function mapNotionError(error: any): NotionMCPError | null {
 /**
  * Map all other errors
  */
-function mapGenericError(error: any): NotionMCPError {
+function mapGenericError(error: unknown): NotionMCPError {
+  let message = 'Unknown error occurred'
+  if (isObject(error) && typeof error.message === 'string') {
+    message = error.message
+  } else if (error instanceof Error) {
+    message = error.message
+  }
+
   return new NotionMCPError(
-    error.message || 'Unknown error occurred',
+    message,
     'UNKNOWN_ERROR',
     'Please check your request and try again',
     sanitizeErrorDetails(error)
@@ -237,7 +265,7 @@ function mapGenericError(error: any): NotionMCPError {
 /**
  * Enhance Notion API error with helpful context
  */
-export function enhanceError(error: any): NotionMCPError {
+export function enhanceError(error: unknown): NotionMCPError {
   // Already a NotionMCPError — pass through unchanged
   if (error instanceof NotionMCPError) return error
 
@@ -387,18 +415,20 @@ export async function retryWithBackoff<T>(
 ): Promise<T> {
   const { maxRetries = 3, initialDelay = 1000, maxDelay = 10000, backoffMultiplier = 2 } = options
 
-  let lastError: any
+  let lastError: unknown
   let delay = initialDelay
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn()
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error
 
       // Don't retry on certain errors
-      if (error.code === 'UNAUTHORIZED' || error.code === 'NOT_FOUND') {
-        throw enhanceError(error)
+      if (isObject(error)) {
+        if (error.code === 'UNAUTHORIZED' || error.code === 'NOT_FOUND') {
+          throw enhanceError(error)
+        }
       }
 
       // Last attempt


### PR DESCRIPTION
Replaced 'any' type with 'unknown' and 'Record<string, unknown>' in src/tools/helpers/errors.ts to improve type safety.
- Added 'isObject' type guard for safe property access on unknown types.
- Updated error mapping and sanitization functions to use stricter types.
- Adjusted test suites (errors.test.ts, errors.security.test.ts) to accommodate type changes.
- Verified with biome linting, tsc type-checking, and vitest suite.

---
*PR created automatically by Jules for task [10064639588337057558](https://jules.google.com/task/10064639588337057558) started by @n24q02m*