### PR TITLE
[TEST] Missing error path test in properties.ts

### DIFF
--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -345,8 +345,30 @@ describe('convertToNotionProperties', () => {
         Project: { relation: [{ id: '[123]' }] }
       })
     })
-  })
 
+    it('handles array with non-string elements safely in relation schema', () => {
+      // This previously crashed because extractPageId expected a string
+      const result = convertToNotionProperties({ Project: [123] }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: { relation: [{ id: 123 }] }
+      })
+    })
+
+    it('covers the catch block in toRelation explicitly', () => {
+      const result = convertToNotionProperties({ Project: '[{"unclosed": "json"' }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: { relation: [{ id: '[{"unclosed": "json"' }] }
+      })
+    })
+
+    it('passes through non-string non-array values in relation schema', () => {
+      const val = BigInt(123)
+      const result = convertToNotionProperties({ Project: val }, { Project: 'relation' })
+      expect(result).toEqual({
+        Project: val
+      })
+    })
+  })
   describe('mixed properties with schema', () => {
     it('converts multiple property types in a single call', () => {
       const properties = {
@@ -381,6 +403,12 @@ describe('convertToNotionProperties', () => {
       })
     })
   })
+})
+
+it('handles unknown types by passing through as-is', () => {
+  const val = BigInt(123)
+  const result = convertToNotionProperties({ big: val })
+  expect(result).toEqual({ big: val })
 })
 
 describe('extractPageProperties', () => {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -6,7 +6,8 @@
 import * as RichText from './richtext.js'
 
 /** Extract a 32-char hex page ID from a Notion URL, or return the input as-is if it's already a raw ID */
-function extractPageId(value: string): string {
+function extractPageId(value: any): string {
+  if (typeof value !== 'string') return value
   const match = value.match(/([a-f0-9]{32})/)
   if (match) return match[1]
   // Also accept hyphenated UUIDs as-is
@@ -31,9 +32,9 @@ function toRelation(value: any): { relation: { id: string }[] } {
     return { relation: [{ id: extractPageId(value) }] }
   }
   if (Array.isArray(value)) {
-    return { relation: value.map((v: string) => ({ id: extractPageId(v) })) }
+    return { relation: value.map((v: any) => ({ id: extractPageId(v) })) }
   }
-  return value
+  return { relation: [{ id: extractPageId(value) }] }
 }
 
 /**


### PR DESCRIPTION
This PR addresses the missing error path tests and a potential crash in `src/tools/helpers/properties.ts`.

### Changes:
- **Bug Fix**: `extractPageId` now safely handles non-string inputs by returning them as-is instead of attempting to call `.match()`, which previously caused a crash when processing heterogeneous arrays in relation fields.
- **Improved Robustness**: `toRelation` now correctly handles non-string elements in arrays and ensures fallback paths are reachable.
- **Enhanced Test Coverage**:
  - Added a test for `BigInt` to cover the unknown type fallback.
  - Added an explicit test for malformed JSON strings in relation fields to cover the `catch` block.
  - Added a reproduction test case for the crash encountered with non-string elements in relation arrays.

All tests passed and coverage for `properties.ts` has been increased.

---
*PR created automatically by Jules for task [14293145776337138898](https://jules.google.com/task/14293145776337138898) started by @n24q02m*