### PR TITLE
[CLEANUP] Use of any type

### DIFF
--- a/src/tools/helpers/errors.security.test.ts
+++ b/src/tools/helpers/errors.security.test.ts
@@ -27,9 +27,9 @@ describe('Security: Error Handling', () => {
 
     // Check that safe fields are present
     expect(enhanced.details).toBeDefined()
-    expect(enhanced.details.message).toBe('Invalid property value')
-    expect(enhanced.details.object).toBe('error')
-    expect(enhanced.details.status).toBe(400)
+    expect((enhanced.details as any).message).toBe('Invalid property value')
+    expect((enhanced.details as any).object).toBe('error')
+    expect((enhanced.details as any).status).toBe(400)
 
     // Check that sensitive fields are REMOVED
     expect(enhanced.details).not.toHaveProperty('sensitive_token')
@@ -58,15 +58,16 @@ describe('Security: Error Handling', () => {
 
     const enhanced = enhanceError(errorWithAuth)
     expect(enhanced.details).toBeDefined()
-    if (enhanced.details?.headers) {
-      expect(enhanced.details.headers).not.toHaveProperty('Authorization')
-      expect(enhanced.details.headers).toHaveProperty('Content-Type')
+    const details = enhanced.details as any
+    if (details?.headers) {
+      expect(details.headers).not.toHaveProperty('Authorization')
+      expect(details.headers).toHaveProperty('Content-Type')
     }
-    if (enhanced.details?.config?.headers) {
-      expect(enhanced.details.config.headers).not.toHaveProperty('authorization')
+    if (details?.config?.headers) {
+      expect(details.config.headers).not.toHaveProperty('authorization')
     }
-    if (enhanced.details?.request?._headers) {
-      expect(enhanced.details.request._headers).not.toHaveProperty('authorization')
+    if (details?.request?._headers) {
+      expect(details.request._headers).not.toHaveProperty('authorization')
     }
   })
 

--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -233,12 +233,12 @@ describe('enhanceError', () => {
 
       // Expectation of SECURE behavior
       expect(enhanced.details).toBeDefined()
-      expect(enhanced.details.message).toBe('Something went wrong')
+      expect((enhanced.details as any).message).toBe('Something went wrong')
 
       // Verify secret is NOT leaked
       expect(JSON.stringify(enhanced.details)).not.toContain('secret-token')
-      expect(enhanced.details.config).toBeUndefined()
-      expect(enhanced.details.request).toBeUndefined()
+      expect((enhanced.details as any).config).toBeUndefined()
+      expect((enhanced.details as any).request).toBeUndefined()
     })
   })
 })

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -6,7 +6,7 @@ export class NotionMCPError extends Error {
     public message: string,
     public code: string,
     public suggestion?: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message)
     this.name = 'NotionMCPError'
@@ -26,16 +26,16 @@ export class NotionMCPError extends Error {
 /**
  * Sanitize validation error body to remove sensitive information
  */
-function sanitizeValidationBody(body: any): any {
+function sanitizeValidationBody(body: unknown): Record<string, unknown> | unknown {
   if (!body || typeof body !== 'object') return body
 
   // whitelist safe properties from Notion API validation_error responses
-  const safe: any = {}
+  const safe: Record<string, unknown> = {}
   const safeFields = ['message', 'object', 'code', 'status', 'request_id', 'path']
 
   for (const field of safeFields) {
-    if (field in body) {
-      safe[field] = body[field]
+    if (body && typeof body === 'object' && field in body) {
+      safe[field] = (body as Record<string, unknown>)[field]
     }
   }
 
@@ -45,19 +45,20 @@ function sanitizeValidationBody(body: any): any {
 /**
  * Sanitize error object to remove sensitive information
  */
-function sanitizeErrorDetails(error: any): any {
+function sanitizeErrorDetails(error: unknown): Record<string, unknown> | unknown {
   if (!error || typeof error !== 'object') return error
 
   // whitelist safe properties
-  const safe: any = {
-    message: error.message,
-    name: error.name,
-    code: error.code
+  const err = error as Record<string, unknown>
+  const safe: Record<string, unknown> = {
+    message: err.message,
+    name: err.name,
+    code: err.code
   }
 
   // Add status if available (common in HTTP errors)
-  if (error.status) safe.status = error.status
-  if (error.response?.status) safe.status = error.response.status
+  if (err.status) safe.status = err.status
+  if ((err.response as Record<string, unknown>)?.status) safe.status = (err.response as Record<string, unknown>).status
 
   return safe
 }
@@ -83,42 +84,45 @@ const SENSITIVE_HEADER_NAMES = new Set([
  * `Authorization` but third-party axios/fetch wrappers may surface
  * `authorization`, `AUTHORIZATION`, or `X-API-Key`.
  */
-function redactHeaderMap(headers: any): void {
+function redactHeaderMap(headers: unknown): void {
   if (!headers || typeof headers !== 'object') return
-  for (const key of Object.keys(headers)) {
+  if (!headers || typeof headers !== 'object') return
+  const h = headers as Record<string, unknown>
+  for (const key of Object.keys(h)) {
     if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
-      delete headers[key]
+      delete h[key]
     }
   }
 }
 
-function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
+function stripSensitiveFields(obj: unknown, seen = new WeakSet()): void {
   if (!obj || typeof obj !== 'object') return
   if (seen.has(obj)) return
-  seen.add(obj)
+  const o = obj as Record<string, unknown>
+  seen.add(o)
 
-  delete obj.sensitive_token
-  delete obj.internal_config
-  delete obj.user_email
+  delete o.sensitive_token
+  delete o.internal_config
+  delete o.user_email
 
   // Strip authorization-style headers from the common error-shape locations
   // (response interceptors copy them onto multiple parent objects).
-  redactHeaderMap(obj.headers)
-  redactHeaderMap(obj._headers)
-  if (obj.request) {
-    redactHeaderMap(obj.request.headers)
-    redactHeaderMap(obj.request._headers)
+  redactHeaderMap(o.headers)
+  redactHeaderMap(o._headers)
+  if (o.request) {
+    redactHeaderMap((o.request as Record<string, unknown>).headers)
+    redactHeaderMap((o.request as Record<string, unknown>)._headers)
   }
-  if (obj.config) {
-    redactHeaderMap(obj.config.headers)
+  if (o.config) {
+    redactHeaderMap((o.config as Record<string, unknown>).headers)
   }
-  if (obj.response) {
-    redactHeaderMap(obj.response.headers)
+  if (o.response) {
+    redactHeaderMap((o.response as Record<string, unknown>).headers)
   }
 
-  for (const key of Object.keys(obj)) {
-    if (typeof obj[key] === 'object' && obj[key] !== null) {
-      stripSensitiveFields(obj[key], seen)
+  for (const key of Object.keys(o)) {
+    if (typeof o[key] === 'object' && o[key] !== null) {
+      stripSensitiveFields(o[key], seen)
     }
   }
 }
@@ -126,8 +130,9 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
 /**
  * Map network-related errors
  */
-function mapNetworkError(error: any): NotionMCPError | null {
-  if (error.message?.includes('ECONNREFUSED') || error.message?.includes('ENOTFOUND')) {
+function mapNetworkError(error: unknown): NotionMCPError | null {
+  const err = error as Record<string, unknown>
+  if (typeof err?.message === 'string' && (err.message.includes('ECONNREFUSED') || err.message.includes('ENOTFOUND'))) {
     return new NotionMCPError(
       'Cannot connect to Notion API',
       'NETWORK_ERROR',
@@ -140,12 +145,12 @@ function mapNetworkError(error: any): NotionMCPError | null {
 /**
  * Handle validation_error separately as it has dynamic suggestions
  */
-function mapValidationError(error: any): NotionMCPError | null {
-  if (error.code !== 'validation_error') return null
+function mapValidationError(error: unknown): NotionMCPError | null {
+  const err = error as Record<string, any>
+  if (!err || typeof err !== 'object' || err.code !== 'validation_error') return null
 
-  const bodyMessage: string = error.body?.message || ''
+  const bodyMessage: string = err.body?.message || ''
   let suggestion = 'Check the API documentation for valid parameter formats'
-
   // Detect common property format mistakes and provide specific guidance
   if (bodyMessage.includes('rich_text') || bodyMessage.includes('title')) {
     suggestion =
@@ -159,7 +164,7 @@ function mapValidationError(error: any): NotionMCPError | null {
     bodyMessage || 'Invalid request parameters',
     'VALIDATION_ERROR',
     suggestion,
-    sanitizeValidationBody(error.body)
+    sanitizeValidationBody(err.body)
   )
 }
 
@@ -205,14 +210,15 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
 /**
  * Map Notion API errors
  */
-function mapNotionError(error: any): NotionMCPError | null {
-  if (!error.code) return null
+function mapNotionError(error: unknown): NotionMCPError | null {
+  if (!error || typeof error !== 'object' || !('code' in error)) return null
 
   const validationError = mapValidationError(error)
   if (validationError) return validationError
 
-  const code = error.code
-  const message = error.message || 'Unknown Notion API error'
+  const err = error as Record<string, any>
+  const code = err.code
+  const message = err.message || 'Unknown Notion API error'
   const mapping = NOTION_ERROR_MAP[code]
 
   if (mapping) {
@@ -225,9 +231,9 @@ function mapNotionError(error: any): NotionMCPError | null {
 /**
  * Map all other errors
  */
-function mapGenericError(error: any): NotionMCPError {
+function mapGenericError(error: unknown): NotionMCPError {
   return new NotionMCPError(
-    error.message || 'Unknown error occurred',
+    (error as Record<string, any>).message || 'Unknown error occurred',
     'UNKNOWN_ERROR',
     'Please check your request and try again',
     sanitizeErrorDetails(error)
@@ -237,7 +243,7 @@ function mapGenericError(error: any): NotionMCPError {
 /**
  * Enhance Notion API error with helpful context
  */
-export function enhanceError(error: any): NotionMCPError {
+export function enhanceError(error: unknown): NotionMCPError {
   // Already a NotionMCPError — pass through unchanged
   if (error instanceof NotionMCPError) return error
 
@@ -387,17 +393,22 @@ export async function retryWithBackoff<T>(
 ): Promise<T> {
   const { maxRetries = 3, initialDelay = 1000, maxDelay = 10000, backoffMultiplier = 2 } = options
 
-  let lastError: any
+  let lastError: unknown
   let delay = initialDelay
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn()
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error
 
       // Don't retry on certain errors
-      if (error.code === 'UNAUTHORIZED' || error.code === 'NOT_FOUND') {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        ((error as Record<string, any>).code === 'UNAUTHORIZED' || (error as Record<string, any>).code === 'NOT_FOUND')
+      ) {
         throw enhanceError(error)
       }
 


### PR DESCRIPTION
This PR replaces the use of the `any` type with `unknown` in the `src/tools/helpers/errors.ts` file to improve type safety.

Key changes:
- Updated `NotionMCPError` class to use `unknown` for the `details` property.
- Refactored `retryWithBackoff` to use `unknown` for the caught error and implemented type guards for safe property access.
- Refactored `enhanceError`, `mapNotionError`, `mapNetworkError`, `mapValidationError`, and `mapGenericError` to accept `unknown` errors.
- Updated sanitization functions (`sanitizeValidationBody`, `sanitizeErrorDetails`, `redactHeaderMap`, `stripSensitiveFields`) to work with `unknown` types using appropriate casting and checks.
- Updated `errors.test.ts` and `errors.security.test.ts` to handle the new `unknown` type of `error.details`.

All tests passed and Biome formatting/checking was performed.

---
*PR created automatically by Jules for task [11711875694278254541](https://jules.google.com/task/11711875694278254541) started by @n24q02m*