### PR TITLE
[TEST] Missing tests for exported entity: isValidNotionId

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -56,6 +56,34 @@ describe('isValidNotionId', () => {
   it('should be case insensitive', () => {
     expect(isValidNotionId('A3802967-3621-4B04-B6AF-BFEF1B7687B3')).toBe(true)
   })
+  it('should reject misplaced hyphens', () => {
+    expect(isValidNotionId('a380296-73621-4b04-b6af-bfef1b7687b3')).toBe(false)
+  })
+
+  it('should reject multiple hyphens in same position', () => {
+    expect(isValidNotionId('a3802967--3621-4b04-b6af-bfef1b7687b3')).toBe(false)
+  })
+
+  it('should reject 31-character hex strings', () => {
+    expect(isValidNotionId('a380296736214b04b6afbfef1b7687b')).toBe(false)
+  })
+
+  it('should reject 33-character hex strings', () => {
+    expect(isValidNotionId('a380296736214b04b6afbfef1b7687b3a')).toBe(false)
+  })
+
+  it('should accept partially hyphenated UUIDs if hyphens are at correct positions', () => {
+    expect(isValidNotionId('a3802967-36214b04b6afbfef1b7687b3')).toBe(true)
+  })
+
+  it('should reject leading or trailing hyphens', () => {
+    expect(isValidNotionId('-a380296736214b04b6afbfef1b7687b3')).toBe(false)
+    expect(isValidNotionId('a380296736214b04b6afbfef1b7687b3-')).toBe(false)
+  })
+
+  it('should reject spaces', () => {
+    expect(isValidNotionId('a3802967 36214b04b6afbfef1b7687b3')).toBe(false)
+  })
 })
 
 describe('formatId', () => {


### PR DESCRIPTION
This PR adds comprehensive test coverage for the `isValidNotionId` utility in `src/tools/helpers/id.ts`. 

It ensures that the function robustly validates Notion UUIDs by adding tests for:
- Misplaced hyphens
- Multiple hyphens in the same position
- Incorrect ID lengths (31 and 33 hex characters)
- Leading and trailing hyphens
- Partial hyphenation (where some valid hyphen positions are used and others are not)
- Invalid characters such as spaces

All tests passed and 100% coverage was confirmed for the modified file.

---
*PR created automatically by Jules for task [5446995144746633969](https://jules.google.com/task/5446995144746633969) started by @n24q02m*