### PR TITLE
[FIX] Deeply nested if in comments error handling

### DIFF
--- a/src/tools/composite/comments.ts
+++ b/src/tools/composite/comments.ts
@@ -20,6 +20,24 @@ export interface CommentsManageInput {
  * Manage comments (list, get, create)
  * Maps to: GET /v1/comments, GET /v1/comments/{id}, POST /v1/comments
  */
+
+/**
+ * Helper to check if a block exists.
+ * Returns true if the block exists, false if it returns object_not_found.
+ * Throws for any other error.
+ */
+async function checkBlockExists(notion: Client, blockId: string): Promise<boolean> {
+  try {
+    await notion.blocks.retrieve({ block_id: blockId })
+    return true
+  } catch (error: any) {
+    if (error.code === 'object_not_found') {
+      return false
+    }
+    throw error
+  }
+}
+
 export async function commentsManage(notion: Client, input: CommentsManageInput): Promise<any> {
   return withErrorHandling(async () => {
     switch (input.action) {
@@ -53,26 +71,12 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
           if (error.code === 'object_not_found') {
             // Distinguish between a real 404 and the known Notion API limitation (OAuth 404)
             // by checking if the block/page actually exists.
-            let blockExists = false
-            try {
-              await notion.blocks.retrieve({ block_id: input.page_id })
-              blockExists = true
-            } catch (innerError: any) {
-              // If we get any error other than 404, we should probably know about it
-              if (innerError.code !== 'object_not_found') {
-                throw innerError
-              }
-            }
-
-            if (blockExists) {
-              // If retrieve succeeds, it's the known API limitation
+            if (await checkBlockExists(notion, input.page_id)) {
               throw new NotionMCPError(
                 'The comments.list API is currently unavailable for this page due to a known Notion OAuth limitation.',
                 'COMMENTS_LIST_UNAVAILABLE'
               )
             }
-            // If it's a real 404 (block retrieve also failed with object_not_found),
-            // re-throw the original error which will be wrapped as NOT_FOUND by withErrorHandling.
           }
           throw error
         }


### PR DESCRIPTION
This PR refactors the error handling in `src/tools/composite/comments.ts` to improve readability by flattening a deeply nested `if` and `try-catch` structure.

Key changes:
- Introduced `checkBlockExists` helper to handle the common logic of verifying block existence.
- Refactored `commentsManage` to use this helper, significantly reducing nesting.
- Verified functionality with existing tests.

---
*PR created automatically by Jules for task [12174746465130231869](https://jules.google.com/task/12174746465130231869) started by @n24q02m*