### PR TITLE
[TEST] Missing tests for exported entity: setState

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -48,6 +48,8 @@ describe('credential-state', () => {
   it('initial state is awaiting_setup', () => {
     expect(getState()).toBe('awaiting_setup')
     expect(getNotionToken()).toBeNull()
+    // Verify default subject token resolver covers the default arrow function
+    expect(getSubjectToken()).toBeNull()
   })
 
   describe('resolveCredentialState', () => {
@@ -92,11 +94,21 @@ describe('credential-state', () => {
       expect(deleteConfig).toHaveBeenCalledWith('better-notion-mcp')
     })
 
-    it('handles deleteConfig failure in resetState', () => {
+    it('handles deleteConfig failure in resetState', async () => {
       vi.mocked(deleteConfig).mockRejectedValue(new Error('delete failed') as never)
       resetState()
+      await Promise.resolve() // Let the catch block arrow function execute
       expect(getState()).toBe('awaiting_setup')
       expect(deleteConfig).toHaveBeenCalled()
+    })
+  })
+
+  describe('setState', () => {
+    it('updates the state correctly', () => {
+      setState('configured')
+      expect(getState()).toBe('configured')
+      setState('awaiting_setup')
+      expect(getState()).toBe('awaiting_setup')
     })
   })
 


### PR DESCRIPTION
This PR adds missing unit tests for the `setState` function in `src/credential-state.ts`. 
Additionally, it improves the test suite to achieve 100% coverage by:
1. Testing the default `_subjectTokenResolver` arrow function.
2. Testing the `catch` block in `resetState` when `deleteConfig` fails.

All tests passed and coverage is verified.

---
*PR created automatically by Jules for task [3001819228066474325](https://jules.google.com/task/3001819228066474325) started by @n24q02m*