### PR TITLE
[TEST] Add tests for splitText in richtext.ts

### DIFF
--- a/src/tools/helpers/richtext.test.ts
+++ b/src/tools/helpers/richtext.test.ts
@@ -360,3 +360,43 @@ it('should handle maxLength smaller than ellipsis length', () => {
   expect(result2[0].text.content).toBe('ab')
   expect(result2[0].text.content.length).toBe(2)
 })
+
+describe('splitText', () => {
+  it('should return a single item if text is within maxLength', () => {
+    const content = 'hello world'
+    const result = RichText.splitText(content, 20)
+    expect(result).toHaveLength(1)
+    expect(result[0].text.content).toBe(content)
+  })
+
+  it('should return a single item if text is exactly maxLength', () => {
+    const content = '12345'
+    const result = RichText.splitText(content, 5)
+    expect(result).toHaveLength(1)
+    expect(result[0].text.content).toBe(content)
+  })
+
+  it('should split text into multiple chunks if it exceeds maxLength', () => {
+    const content = 'abcdefghij' // 10 chars
+    const result = RichText.splitText(content, 3)
+    expect(result).toHaveLength(4)
+    expect(result[0].text.content).toBe('abc')
+    expect(result[1].text.content).toBe('def')
+    expect(result[2].text.content).toBe('ghi')
+    expect(result[3].text.content).toBe('j')
+  })
+
+  it('should handle empty string', () => {
+    const result = RichText.splitText('', 10)
+    expect(result).toHaveLength(1)
+    expect(result[0].text.content).toBe('')
+  })
+
+  it('should use default maxLength of 2000', () => {
+    const longText = 'a'.repeat(2500)
+    const result = RichText.splitText(longText)
+    expect(result).toHaveLength(2)
+    expect(result[0].text.content).toHaveLength(2000)
+    expect(result[1].text.content).toHaveLength(500)
+  })
+})

--- a/src/tools/helpers/richtext.ts
+++ b/src/tools/helpers/richtext.ts
@@ -182,3 +182,27 @@ export function truncate(richText: RichTextItem[], maxLength: number): RichTextI
   const truncated = `${plainText.slice(0, maxLength - 3)}...`
   return [text(truncated)]
 }
+
+/**
+ * Split text into chunks (max 2000 chars per rich text item)
+ * Notion has a 2000 character limit per rich text item content.
+ */
+export function splitText(content: string, maxLength: number = 2000): RichTextItem[] {
+  if (content.length <= maxLength) {
+    return [text(content)]
+  }
+
+  const chunks: RichTextItem[] = []
+  let remaining = content
+
+  while (remaining.length > maxLength) {
+    chunks.push(text(remaining.slice(0, maxLength)))
+    remaining = remaining.slice(maxLength)
+  }
+
+  if (remaining.length > 0) {
+    chunks.push(text(remaining))
+  }
+
+  return chunks
+}


### PR DESCRIPTION
This PR adds the missing `splitText` function implementation to `src/tools/helpers/richtext.ts` and includes comprehensive unit tests in `src/tools/helpers/richtext.test.ts` to verify its behavior with various input sizes and edge cases. `splitText` is crucial for handling strings longer than Notion's 2000-character limit for rich text items.

---
*PR created automatically by Jules for task [15883692980997480725](https://jules.google.com/task/15883692980997480725) started by @n24q02m*