### PR TITLE
[CLEANUP] Potential Unsafe Allocation via Buffer.from without Length Limit Check Prior to Validation

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -150,4 +150,9 @@ describe('isValidBase64', () => {
     expect(isValidBase64('aGVsbG8=')).toBe(false)
     spy.mockRestore()
   })
+  it('should reject string that exceeds maximum length', () => {
+    // MAX_BASE64_LENGTH is 64MB. Let's create a string slightly larger.
+    const largeStr = 'a'.repeat(64 * 1024 * 1024 + 4)
+    expect(isValidBase64(largeStr)).toBe(false)
+  })
 })

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -34,13 +34,16 @@ export function formatId(id: string): string {
   return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20)}`
 }
 
+/** Maximum length for base64 string to prevent OOM during validation (64MB) */
+const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+
 /**
  * Check if a string is valid base64 encoding
  * Used to validate file_content before Buffer.from
  * Implements strict validation by checking character set, length, and canonicality
  */
 export function isValidBase64(str: string): boolean {
-  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0) {
+  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0 || str.length > MAX_BASE64_LENGTH) {
     return false
   }
 


### PR DESCRIPTION
Added a length limit check to the isValidBase64 function in src/tools/helpers/id.ts to prevent potential Out-of-Memory (OOM) crashes by limiting base64 string validation to 64MB.

Changes:
- Defined MAX_BASE64_LENGTH (64MB).
- Added length check in isValidBase64.
- Added unit test in src/tools/helpers/id.test.ts.

---
*PR created automatically by Jules for task [6930552832046985843](https://jules.google.com/task/6930552832046985843) started by @n24q02m*