### PR TITLE
[FIX] Deeply nested conditional in page duplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2025-05-26 - Array.includes() vs Set.has() for O(1) Lookups
 **Learning:** Checking for membership in an array using `['a', 'b', ...].includes(value)` within hot paths requires an O(N) scan. This can become an issue when iterating or repeatedly checking values.
 **Action:** Replace `Array.includes()` with `Set.has()` by extracting the array into a module-level `Set`. This improves lookup times significantly to O(1).
+## 2026-06-04 - [FIX] Deeply nested conditional in page duplication
+**Learning:** Extracting complex object transformation logic into a dedicated helper function significantly improves the readability of the main business logic and makes it easier to maintain and test.
+**Action:** Always look for opportunities to refactor deeply nested conditionals or complex mappings into smaller, focused helper functions.

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -534,33 +534,7 @@ async function duplicatePage(notion: Client, input: PagesInput): Promise<Duplica
 
       // Copy content — strip read-only fields that the create endpoint rejects
       if (originalBlocks.length > 0) {
-        const sanitizedBlocks = originalBlocks.map((block: any) => {
-          const {
-            id,
-            parent,
-            created_time,
-            last_edited_time,
-            created_by,
-            last_edited_by,
-            has_children,
-            archived,
-            in_trash,
-            request_id,
-            object,
-            ...rest
-          } = block
-          // Strip null values inside block type data (e.g., paragraph.icon: null)
-          // Notion API rejects null where it expects object or undefined
-          const blockType = rest.type
-          if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
-            for (const key of Object.keys(rest[blockType])) {
-              if (rest[blockType][key] === null) {
-                delete rest[blockType][key]
-              }
-            }
-          }
-          return rest
-        })
+        const sanitizedBlocks = originalBlocks.map(stripNullValues)
         await notion.blocks.children.append({
           block_id: duplicatedPage.id,
           children: sanitizedBlocks as any
@@ -581,4 +555,37 @@ async function duplicatePage(notion: Client, input: PagesInput): Promise<Duplica
     processed: results.length,
     results
   }
+}
+
+/**
+ * Strip read-only fields and null values from a block object.
+ * Notion API rejects null where it expects object or undefined.
+ */
+function stripNullValues(block: any): any {
+  const {
+    id,
+    parent,
+    created_time,
+    last_edited_time,
+    created_by,
+    last_edited_by,
+    has_children,
+    archived,
+    in_trash,
+    request_id,
+    object,
+    ...rest
+  } = block
+
+  // Strip null values inside block type data (e.g., paragraph.icon: null)
+  const blockType = rest.type
+  if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
+    for (const key of Object.keys(rest[blockType])) {
+      if (rest[blockType][key] === null) {
+        delete rest[blockType][key]
+      }
+    }
+  }
+
+  return rest
 }


### PR DESCRIPTION
This PR refactors the block property cleanup logic in `src/tools/composite/pages.ts` by extracting it into a dedicated helper function `stripNullValues`.

### 💡 What
- Created a private helper function `stripNullValues(block: any)`.
- Refactored the `duplicatePage` function to use this helper via `.map()`.

### 🎯 Why
- The original code had a deeply nested conditional and a manual property deletion loop inside a mapping function, which made the `duplicatePage` function harder to read and maintain.
- Centralizing this logic into a helper function makes the intent clearer and reduces nesting.

### 📊 Impact
- Improved code maintainability and readability.
- No change in functionality.

### 🔬 Measurement
- Ran the full test suite with `bun run test`. All 773 tests passed, including the specific tests for page operations.

---
*PR created automatically by Jules for task [11744328893993664161](https://jules.google.com/task/11744328893993664161) started by @n24q02m*