### PR TITLE
[FIX] Exposure of Token Status in Console Error Logs

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -28,11 +28,8 @@ vi.mock('@n24q02m/mcp-core/storage', () => ({
 }))
 
 describe('credential-state', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>
-
   beforeEach(() => {
     vi.resetAllMocks()
-    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     vi.mocked(deleteConfig).mockResolvedValue(undefined as never)
     vi.mocked(resolveConfig).mockResolvedValue({ config: null, source: null } as never)
@@ -56,7 +53,6 @@ describe('credential-state', () => {
       const state = await resolveCredentialState()
       expect(state).toBe('configured')
       expect(getNotionToken()).toBe('env-token')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('found in environment'))
     })
 
     it('configures when config file has token', async () => {
@@ -67,13 +63,11 @@ describe('credential-state', () => {
       const state = await resolveCredentialState()
       expect(state).toBe('configured')
       expect(getNotionToken()).toBe('file-token')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('loaded from file'))
     })
 
     it('stays in awaiting_setup when nothing found', async () => {
       const state = await resolveCredentialState()
       expect(state).toBe('awaiting_setup')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No Notion token found'))
     })
 
     it('handles config read failure gracefully', async () => {

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -74,7 +74,6 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   if (envToken) {
     _notionToken = envToken
     _state = 'configured'
-    console.error('Notion token found in environment')
     return _state
   }
 
@@ -85,7 +84,6 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     if (result.config !== null) {
       _notionToken = result.config[CREDENTIAL_KEY]
       _state = 'configured'
-      console.error(`Notion config loaded from ${result.source}`)
       return _state
     }
   } catch {
@@ -93,7 +91,6 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   }
 
   // 3. Nothing found
-  console.error('No Notion token found -- server starting in awaiting_setup mode')
   _state = 'awaiting_setup'
   return _state
 }


### PR DESCRIPTION
This PR addresses a security hygiene issue where the server's credential state (presence and source of the Notion token) was being explicitly logged to console.error.

Changes:
1. Removed logs in src/credential-state.ts:
   - 'Notion token found in environment'
   - 'Notion config loaded from ${result.source}'
   - 'No Notion token found -- server starting in awaiting_setup mode'
2. Updated tests in src/credential-state.test.ts:
   - Removed log-related expectations.
   - Cleaned up unused consoleSpy variable to satisfy linting.

Verification:
- All 773 tests passed.
- Biome lint and format checks passed.
- Type check passed.

---
*PR created automatically by Jules for task [9733947034278854892](https://jules.google.com/task/9733947034278854892) started by @n24q02m*