### PR TITLE
[CLEANUP] Potential Data Loss in updatePage

### DIFF
--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -570,7 +570,7 @@ describe('pages', () => {
       expect(callArgs.properties.Status).toEqual({ select: { name: 'Done' } })
     })
 
-    it('replaces content by deleting old blocks and appending new', async () => {
+    it('replaces content by deleting old blocks and appending new when replace is true', async () => {
       mockNotion.pages.update.mockResolvedValue({ id: 'page-1' })
       mockNotion.blocks.children.list
         .mockResolvedValueOnce({
@@ -590,11 +590,30 @@ describe('pages', () => {
         action: 'update',
         page_id: 'page-1',
         title: 'Updated',
-        content: '# New Content'
+        content: '# New Content',
+        replace: true
       })
 
       expect(mockNotion.blocks.delete).toHaveBeenCalledWith({ block_id: 'old-block-1' })
       expect(mockNotion.blocks.delete).toHaveBeenCalledWith({ block_id: 'old-block-2' })
+      expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({
+        block_id: 'page-1',
+        children: expect.any(Array)
+      })
+    })
+
+    it('appends content when content is provided but replace is false/missing', async () => {
+      mockNotion.pages.update.mockResolvedValue({ id: 'page-1' })
+      mockNotion.blocks.children.append.mockResolvedValue({ results: [] })
+
+      await pages(mockNotion as any, {
+        action: 'update',
+        page_id: 'page-1',
+        content: '# Appended Content'
+      })
+
+      expect(mockNotion.blocks.delete).not.toHaveBeenCalled()
+      expect(mockNotion.blocks.children.list).not.toHaveBeenCalled()
       expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({
         block_id: 'page-1',
         children: expect.any(Array)

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -84,7 +84,7 @@ export interface PagesInput {
 
   // Create/Update params
   title?: string
-  content?: string // Markdown
+  content?: string // Markdown (defaults to append, use replace: true to overwrite)
   append_content?: string
   parent_id?: string
   properties?: Record<string, any>
@@ -96,6 +96,7 @@ export interface PagesInput {
 
   // Archive/Restore params
   archived?: boolean
+  replace?: boolean
 }
 
 /**
@@ -370,24 +371,26 @@ async function updatePage(notion: Client, input: PagesInput): Promise<UpdatePage
   // Handle content updates
   if (input.content || input.append_content) {
     if (input.content) {
-      // Replace all content
-      // Optimized: Fetch all blocks using autoPaginate, then delete them in batches.
-      const existingBlocks = await autoPaginate((cursor) =>
-        notion.blocks.children.list({
-          block_id: input.page_id!,
-          page_size: 100,
-          start_cursor: cursor
-        })
-      )
-
-      if (existingBlocks.length > 0) {
-        await processBatches(
-          existingBlocks,
-          async (block) => {
-            await notion.blocks.delete({ block_id: block.id })
-          },
-          { batchSize: 1, concurrency: 5 }
+      // Delete existing content only if replace: true is explicitly set
+      if (input.replace) {
+        // Optimized: Fetch all blocks using autoPaginate, then delete them in batches.
+        const existingBlocks = await autoPaginate((cursor) =>
+          notion.blocks.children.list({
+            block_id: input.page_id!,
+            page_size: 100,
+            start_cursor: cursor
+          })
         )
+
+        if (existingBlocks.length > 0) {
+          await processBatches(
+            existingBlocks,
+            async (block) => {
+              await notion.blocks.delete({ block_id: block.id })
+            },
+            { batchSize: 1, concurrency: 5 }
+          )
+        }
       }
 
       const newBlocks = markdownToBlocks(input.content)


### PR DESCRIPTION
This PR fixes a potential data loss issue in the `updatePage` function of the `pages` composite tool.

Previously, providing `content` in an `update` action would automatically delete all existing blocks on the page before appending the new content. This created a high risk of accidental data loss.

The fix introduces a `replace` flag (boolean) to the `PagesInput`.
- By default, `content` now appends to the existing page content (behaving like `append_content`).
- Existing blocks are only deleted if `replace: true` is explicitly provided.

Changes:
- Added `replace?: boolean` to `PagesInput` interface in `src/tools/composite/pages.ts`.
- Modified `updatePage` logic to gate block deletion behind the `replace` flag.
- Updated `src/tools/composite/pages.test.ts` to verify the new behavior and ensure the `replace: true` flag works as intended.
- Verified all tests pass and project-wide checks (`bun run check`) are clean.

---
*PR created automatically by Jules for task [2787808675707738779](https://jules.google.com/task/2787808675707738779) started by @n24q02m*