### PR TITLE
[TEST] Missing tests for exported entity: extractPageProperties

### DIFF
--- a/src/tools/helpers/properties.test.ts
+++ b/src/tools/helpers/properties.test.ts
@@ -15,6 +15,27 @@ const richText = (content: string) => ({
 })
 
 describe('convertToNotionProperties', () => {
+  it('falls through to default for BigInt', () => {
+    const val = BigInt(123)
+    const props = { Big: val as any }
+    expect(convertToNotionProperties(props)).toEqual({ Big: val })
+  })
+
+  it('toRelation falls through for objects', () => {
+    const obj = { custom: true }
+    const props = { Rel: obj as any }
+    const schema = { Rel: 'relation' }
+    expect(convertToNotionProperties(props, schema)).toEqual({ Rel: obj })
+  })
+
+  it('falls through to default for unknown types like Symbol', () => {
+    const sym = Symbol('test')
+    const props = {
+      Sym: sym as any
+    }
+    expect(convertToNotionProperties(props)).toEqual({ Sym: sym })
+  })
+
   it('returns empty object for empty properties', () => {
     expect(convertToNotionProperties({})).toEqual({})
   })
@@ -754,5 +775,14 @@ describe('extractPageProperties', () => {
       }
     }
     expect(extractPageProperties(props)).toEqual({ Window: '2026-01-01 to 2026-01-31' })
+  })
+
+  it('handles null or undefined property values gracefully', () => {
+    const props = {
+      Valid: { type: 'number', number: 1 },
+      NullProp: null as any,
+      UndefinedProp: undefined as any
+    }
+    expect(extractPageProperties(props)).toEqual({ Valid: 1 })
   })
 })

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -131,6 +131,7 @@ export function extractPageProperties(pageProperties: any): any {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const p = pageProperties[key] as any
+    if (!p) continue
     // Cache p.type once per iteration -- avoids ~20 redundant property
     // lookups in the if/else-if chain on every Notion page row.
     const type = p.type as string | undefined


### PR DESCRIPTION
This PR adds missing test cases for `extractPageProperties` and improves the robustness of the function.

### Changes:
- Added a null check in `extractPageProperties` to gracefully handle cases where a Notion property value is null or undefined.
- Added a unit test in `src/tools/helpers/properties.test.ts` to verify that `extractPageProperties` handles null/undefined property values without crashing.
- Added unit tests to cover previously uncovered fallback branches in `toRelation` and `convertToNotionProperties`.
- Verified 99.36% statement coverage for `src/tools/helpers/properties.ts`.

### Verification:
- Ran `bun run test src/tools/helpers/properties.test.ts` and all 82 tests passed.
- Ran `bun run check` and `bun run lint` to ensure code quality and formatting.
- Verified coverage using `bun run test --coverage`.

---
*PR created automatically by Jules for task [14229982048708017707](https://jules.google.com/task/14229982048708017707) started by @n24q02m*