### PR TITLE
[TEST] Missing tests for exported entity: initServer

### DIFF
--- a/src/init-server.integration.test.ts
+++ b/src/init-server.integration.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const startHttpMock = vi.fn()
+const resolveCredentialStateMock = vi.fn().mockResolvedValue(undefined)
+const setRequestHandlerMock = vi.fn()
+
+vi.mock('./transports/http.js', () => ({
+  startHttp: startHttpMock
+}))
+
+vi.mock('./credential-state.js', () => ({
+  resolveCredentialState: resolveCredentialStateMock,
+  getNotionToken: vi.fn().mockReturnValue('ntn_test_token')
+}))
+
+// Mock MCP SDK and other heavy dependencies
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: class {
+    connect = vi.fn().mockResolvedValue(undefined)
+    setRequestHandler = setRequestHandlerMock
+  }
+}))
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class {}
+}))
+
+vi.mock('@notionhq/client', () => ({
+  Client: class {}
+}))
+
+describe('initServer Integration', () => {
+  const originalEnv = process.env
+  const originalArgv = process.argv
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...originalEnv, NODE_ENV: 'test' }
+    process.argv = [...originalArgv]
+    delete process.env.MCP_TRANSPORT
+    delete process.env.TRANSPORT_MODE
+    delete process.env.NOTION_TOKEN
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    process.argv = originalArgv
+  })
+
+  it('boots the HTTP server correctly via initServer', async () => {
+    process.env.TRANSPORT_MODE = 'http'
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+
+    expect(startHttpMock).toHaveBeenCalled()
+  })
+
+  it('boots the stdio server correctly via initServer', async () => {
+    process.env.NOTION_TOKEN = 'ntn_test_token'
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+
+    expect(resolveCredentialStateMock).toHaveBeenCalled()
+    expect(setRequestHandlerMock).toHaveBeenCalled()
+  })
+})

--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -49,4 +49,18 @@ describe('initServer', () => {
     await initServer()
     expect(startServerMock).toHaveBeenCalledWith('stdio')
   })
+
+  it('prefers --http flag over environment variables', async () => {
+    process.env.MCP_TRANSPORT = 'stdio'
+    process.argv = [process.argv[0], 'main.js', '--http']
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('http')
+  })
+
+  it('propagates errors from startServer', async () => {
+    startServerMock.mockRejectedValue(new Error('Start failed'))
+    const { initServer } = await import('./init-server.js')
+    await expect(initServer()).rejects.toThrow('Start failed')
+  })
 })


### PR DESCRIPTION
This PR adds missing tests for the `initServer` entry point in `src/init-server.ts`.

### Changes:
- **Unit Tests**: Updated `src/init-server.test.ts` to include:
    - Error propagation from `startServer`.
    - Configuration precedence (command-line flags vs environment variables).
- **Integration Tests**: Created `src/init-server.integration.test.ts` to verify the actual boot logic by mocking lower-level dependencies instead of the entire `main.js` module.

### Verification:
- **Test Coverage**: Verified 100% line, branch, and function coverage for `src/init-server.ts`.
- **Test Suite**: All 777 tests in the repository passed.
- **Linting/Formatting**: Passed `bun run check`.

---
*PR created automatically by Jules for task [8703334863502186942](https://jules.google.com/task/8703334863502186942) started by @n24q02m*