### PR TITLE
[FIX] Missing Pagination for User Search

### DIFF
--- a/src/tools/composite/users.test.ts
+++ b/src/tools/composite/users.test.ts
@@ -316,3 +316,61 @@ describe('users', () => {
     })
   })
 })
+
+describe('from_workspace with pagination', () => {
+  it('should scan multiple pages of search results', async () => {
+    mockNotion.search
+      .mockResolvedValueOnce({
+        results: [{ created_by: { id: 'user-1', object: 'user' } }],
+        next_cursor: 'c1',
+        has_more: true
+      })
+      .mockResolvedValueOnce({
+        results: [{ created_by: { id: 'user-2', object: 'user' } }],
+        next_cursor: null,
+        has_more: false
+      })
+
+    const result = await users(mockNotion as any, { action: 'from_workspace', limit: 2 })
+
+    expect(result.total).toBe(2)
+    expect(result.users).toContainEqual(expect.objectContaining({ id: 'user-1' }))
+    expect(result.users).toContainEqual(expect.objectContaining({ id: 'user-2' }))
+    expect(mockNotion.search).toHaveBeenCalledTimes(2)
+  })
+
+  it('should respect custom limit', async () => {
+    mockNotion.search.mockResolvedValue({
+      results: Array(10).fill({ created_by: { id: 'user-1', object: 'user' } }),
+      next_cursor: null,
+      has_more: false
+    })
+
+    await users(mockNotion as any, { action: 'from_workspace', limit: 5 })
+
+    // autoPaginate should be called with limit 5
+    expect(mockNotion.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page_size: 5
+      })
+    )
+  })
+})
+
+describe('list with pagination', () => {
+  it('should respect custom limit', async () => {
+    mockNotion.users.list.mockResolvedValue({
+      results: [],
+      next_cursor: null,
+      has_more: false
+    })
+
+    await users(mockNotion as any, { action: 'list', limit: 10 })
+
+    expect(mockNotion.users.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page_size: 10
+      })
+    )
+  })
+})

--- a/src/tools/composite/users.ts
+++ b/src/tools/composite/users.ts
@@ -10,6 +10,7 @@ import { autoPaginate } from '../helpers/pagination.js'
 export interface UsersInput {
   action: 'list' | 'get' | 'me' | 'from_workspace'
   user_id?: string
+  limit?: number
 }
 
 /**
@@ -21,11 +22,13 @@ export async function users(notion: Client, input: UsersInput): Promise<any> {
     switch (input.action) {
       case 'list': {
         try {
-          const usersList = await autoPaginate((cursor) =>
-            notion.users.list({
-              start_cursor: cursor,
-              page_size: 100
-            })
+          const usersList = await autoPaginate(
+            (cursor, pageSize) =>
+              notion.users.list({
+                start_cursor: cursor,
+                page_size: pageSize
+              }),
+            { limit: input.limit }
           )
 
           return {
@@ -85,13 +88,13 @@ export async function users(notion: Client, input: UsersInput): Promise<any> {
         // Alternative method: Search pages and extract user info from metadata
         // This bypasses the permission issue with direct users.list() call
         const searchResults: any = await autoPaginate(
-          (cursor) =>
+          (cursor, pageSize) =>
             notion.search({
               filter: { property: 'object', value: 'page' },
               start_cursor: cursor,
-              page_size: 100
+              page_size: pageSize
             }),
-          { maxPages: 5 }
+          { limit: input.limit || 500 } // Default to 500 search results to scan
         )
 
         const usersMap = new Map<string, any>()

--- a/src/tools/composite/workspace.ts
+++ b/src/tools/composite/workspace.ts
@@ -112,15 +112,15 @@ export async function workspace(notion: Client, input: WorkspaceInput): Promise<
         }
 
         // Fetch results with pagination
-        const allResults = await autoPaginate((cursor) =>
-          notion.search({
-            ...searchParams,
-            start_cursor: cursor,
-            page_size: 100
-          })
+        const results = await autoPaginate(
+          (cursor, pageSize) =>
+            notion.search({
+              ...searchParams,
+              start_cursor: cursor,
+              page_size: pageSize
+            }),
+          { limit: input.limit }
         )
-
-        const results = input.limit ? allResults.slice(0, input.limit) : allResults
 
         const formattedResults = new Array(results.length)
         for (let i = 0; i < results.length; i++) {

--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -308,3 +308,40 @@ describe('ConcurrencyQueue', () => {
     expect(task2).not.toHaveBeenCalled()
   })
 })
+
+describe('autoPaginate with limit', () => {
+  it('should respect the limit and stop fetching', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({ results: [1, 2], next_cursor: 'c1', has_more: true })
+      .mockResolvedValueOnce({ results: [3, 4], next_cursor: 'c2', has_more: true })
+      .mockResolvedValueOnce({ results: [5, 6], next_cursor: null, has_more: false })
+
+    const results = await autoPaginate(fetchFn, { limit: 3, pageSize: 2 })
+
+    expect(results).toEqual([1, 2, 3])
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    // First call: pageSize 2
+    expect(fetchFn).toHaveBeenNthCalledWith(1, undefined, 2)
+    // Second call: pageSize 1 (remaining 1)
+    expect(fetchFn).toHaveBeenNthCalledWith(2, 'c1', 1)
+  })
+
+  it('should return all results if limit is higher than total', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce({ results: [1, 2], next_cursor: null, has_more: false })
+
+    const results = await autoPaginate(fetchFn, { limit: 10, pageSize: 2 })
+
+    expect(results).toEqual([1, 2])
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle limit of 0 (unlimited)', async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce({ results: [1, 2], next_cursor: null, has_more: false })
+
+    const results = await autoPaginate(fetchFn, { limit: 0, pageSize: 2 })
+
+    expect(results).toEqual([1, 2])
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -19,6 +19,7 @@ export interface PaginatedResponse<T> {
 export interface PaginationOptions {
   maxPages?: number // Max pages to fetch (0 = unlimited, capped by MAX_PAGES_SAFETY)
   pageSize?: number // Items per page (default: 100)
+  limit?: number // Max items to fetch (0 = unlimited)
 }
 
 /**
@@ -28,17 +29,30 @@ export async function autoPaginate<T>(
   fetchFn: (cursor?: string, pageSize?: number) => Promise<PaginatedResponse<T>>,
   options: PaginationOptions = {}
 ): Promise<T[]> {
-  const { maxPages = 0, pageSize = 100 } = options
+  const { maxPages = 0, pageSize = 100, limit = 0 } = options
   const effectiveMax = maxPages > 0 ? Math.min(maxPages, MAX_PAGES_SAFETY) : MAX_PAGES_SAFETY
   const allResults: T[] = []
   let cursor: string | null = null
   let pageCount = 0
 
   do {
-    const response = await fetchFn(cursor || undefined, pageSize)
+    // Adjust page size if a limit is set and we are close to it
+    let currentPageSize = pageSize
+    if (limit > 0) {
+      const remaining = limit - allResults.length
+      if (remaining <= 0) break
+      currentPageSize = Math.min(pageSize, remaining)
+    }
+
+    const response = await fetchFn(cursor || undefined, currentPageSize)
     allResults.push(...response.results)
     cursor = response.next_cursor
     pageCount++
+
+    // Stop if limit reached
+    if (limit > 0 && allResults.length >= limit) {
+      break
+    }
 
     // Stop if max pages reached (user-specified or safety limit)
     if (pageCount >= effectiveMax) {
@@ -46,7 +60,7 @@ export async function autoPaginate<T>(
     }
   } while (cursor !== null)
 
-  return allResults
+  return limit > 0 ? allResults.slice(0, limit) : allResults
 }
 
 /** Block types that need children fetched for proper markdown rendering */


### PR DESCRIPTION
This PR addresses the issue of missing or incomplete pagination in the `users` tool, specifically for the `from_workspace` action which extracts user information from page metadata.

Key changes:
1. **Pagination Helper Enhancement**: Updated `autoPaginate` in `src/tools/helpers/pagination.ts` to support a `limit` parameter. It now dynamically adjusts `pageSize` for the final request and stops fetching once the limit is reached, reducing unnecessary API calls.
2. **Users Tool Update**: 
   - Added `limit` support to the `UsersInput` interface.
   - Updated the `list` action to respect the `limit`.
   - Replaced the hardcoded `maxPages: 5` in the `from_workspace` action with a configurable `limit` (defaulting to scanning 500 pages/results).
3. **Workspace Tool Optimization**: Updated `workspace.search` to pass the `limit` parameter directly to `autoPaginate`, improving performance by avoiding over-fetching.
4. **Testing**: Added new test cases to `src/tools/helpers/pagination.test.ts` and `src/tools/composite/users.test.ts` to verify the `limit` logic and multi-page user extraction.

All 61 tests passed, and code quality checks (Biome, TypeScript) are clean.

---
*PR created automatically by Jules for task [7171498660436727454](https://jules.google.com/task/7171498660436727454) started by @n24q02m*