### PR TITLE
[TEST] Missing tests for exported entity: isMain

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -34,7 +34,10 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
 })
 
 vi.mock('@notionhq/client', () => ({
-  Client: vi.fn().mockImplementation(() => ({}))
+  // biome-ignore lint/complexity/useArrowFunction: constructor
+  Client: vi.fn().mockImplementation(function () {
+    return {}
+  })
 }))
 
 vi.mock('./tools/registry.js', () => ({
@@ -46,12 +49,13 @@ vi.mock('./credential-state.js', () => ({
   getNotionToken: vi.fn().mockReturnValue('ntn_test_token')
 }))
 
-// Mock node:fs to allow spying on realpathSync in ESM
+// Mock node:fs to allow spying on realpathSync and readFileSync in ESM
 vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>()
   return {
     ...original,
-    realpathSync: vi.fn(original.realpathSync)
+    realpathSync: vi.fn(original.realpathSync),
+    readFileSync: vi.fn(original.readFileSync)
   }
 })
 
@@ -140,6 +144,11 @@ describe('main.ts', () => {
 
       expect(isMain(import.meta.url)).toBe(false)
     })
+
+    it('verifies false when fileURLToPath throws (invalid URL)', () => {
+      process.argv[1] = 'somefile.ts'
+      expect(isMain('invalid-url')).toBe(false)
+    })
   })
 
   describe('getTransportMode', () => {
@@ -198,6 +207,33 @@ describe('main.ts', () => {
     it('verifies error propagation from startHttp', async () => {
       startHttpMock.mockRejectedValueOnce(new Error('HTTP failed'))
       await expect(startServer('http')).rejects.toThrow('HTTP failed')
+    })
+
+    it('verifies package version defaults to 0.0.0 when readFileSync fails', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
+      vi.mocked(fs.readFileSync).mockImplementationOnce(() => {
+        throw new Error('Read failed')
+      })
+      await startServer('stdio')
+      expect(stdioServerCtor).toHaveBeenCalledWith(expect.objectContaining({ version: '0.0.0' }), expect.any(Object))
+    })
+
+    it('verifies notionClientFactory in stdio mode', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
+      await startServer('stdio')
+
+      // Extract the factory function passed to registerTools
+      const factory = registerToolsMock.mock.calls[0][1]
+      expect(typeof factory).toBe('function')
+
+      // Test factory with token
+      const client = factory()
+      expect(client).toBeDefined()
+
+      // Test factory without token
+      const { getNotionToken } = await import('./credential-state.js')
+      vi.mocked(getNotionToken).mockReturnValueOnce(null)
+      expect(() => factory()).toThrow('Notion integration token not configured')
     })
   })
 


### PR DESCRIPTION
I have improved the test coverage for `src/main.ts` from 87.75% to 97.95%.

### Changes:
- **`isMain`**: Added a test case for invalid URLs to cover the `catch` block.
- **`getPackageVersion`**: Added a test case that mocks `fs.readFileSync` to throw an error, verifying the fallback to `'0.0.0'`.
- **`notionClientFactory`**: Extracted and tested the internal factory function passed to `registerTools`, verifying it correctly handles presence/absence of `NOTION_TOKEN`.
- **Mocks**: Updated `node:fs` mock to include `readFileSync` and improved the `@notionhq/client` mock to correctly support `new` instantiation in tests.
- **Linting**: Added Biome suppression for the constructor mock and ensured all tests pass lint and type checks.

All 776 tests passed. The only remaining uncovered line is the automatic `bootstrap()` call, which is skipped in test environments.

---
*PR created automatically by Jules for task [8693910669103596158](https://jules.google.com/task/8693910669103596158) started by @n24q02m*