### PR TITLE
🛡️ Sentinel: [MEDIUM] Add length check to Base64 validation to prevent OOM

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,7 @@
 **Vulnerability:** N/A (Testing Task)
 **Learning:** The function isSafeWebUrl provides a stricter validation layer for opening URLs in external browsers compared to isSafeUrl, specifically by enforcing standard web protocols (HTTP/HTTPS) and preventing shell flag injection (URLs starting with dash).
 **Prevention:** Ensure all security-critical utility functions have comprehensive unit test coverage, specifically targeting edge cases like protocol obfuscation, shell injection vectors, and malformed URL handling.
+## 2023-10-27 - Base64 Validation OOM Vulnerability
+**Vulnerability:** The `isValidBase64` function passed its string argument directly to `Buffer.from(str, 'base64')` without an upper bound length check. An attacker could provide a massive payload string, forcing the server to attempt an excessively large memory allocation and crashing the server due to an Out-Of-Memory (OOM) error (Denial of Service).
+**Learning:** Validating user input using buffer allocations or computationally expensive operations (like regexes) on unbound string lengths exposes Node.js services to synchronous blocking or memory exhaustion attacks.
+**Prevention:** Always enforce a maximum length limit on any string inputs before performing validation routines or memory allocations to prevent resource exhaustion attacks.

--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -150,4 +150,13 @@ describe('isValidBase64', () => {
     expect(isValidBase64('aGVsbG8=')).toBe(false)
     spy.mockRestore()
   })
+
+  it('should return false for strings exceeding max length', () => {
+    // MAX_BASE64_LENGTH is 64MB (67108864).
+    // Creating a string of this size is efficient in modern JS engines using repeat.
+    // It's just metadata until mutated.
+    const maxLen = 64 * 1024 * 1024
+    const largeString = 'A'.repeat(maxLen + 4)
+    expect(isValidBase64(largeString)).toBe(false)
+  })
 })

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -34,6 +34,9 @@ export function formatId(id: string): string {
   return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20)}`
 }
 
+// Maximum allowed length for base64 strings to prevent OOM during validation (64MB)
+const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+
 /**
  * Check if a string is valid base64 encoding
  * Used to validate file_content before Buffer.from
@@ -41,6 +44,11 @@ export function formatId(id: string): string {
  */
 export function isValidBase64(str: string): boolean {
   if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0) {
+    return false
+  }
+
+  // Prevent OOM by rejecting excessively large strings before Buffer allocation
+  if (str.length > MAX_BASE64_LENGTH) {
     return false
   }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `isValidBase64` in `src/tools/helpers/id.ts` passes user-supplied strings to `Buffer.from(str, 'base64')` without bounds checking. An attacker could provide a huge payload string, leading to an Out-Of-Memory (OOM) crash and a potential Denial of Service (DoS).
🎯 Impact: An attacker could crash the server by exhausting memory, causing disruption.
🔧 Fix: Added an upper bound check `MAX_BASE64_LENGTH` of 64MB to reject excessively long inputs early, before regex checks and buffer allocation.
✅ Verification: Tested locally via Vitest using string repetition to mock huge payloads, verifying correct rejection without allocating massive memory overhead.

---
*PR created automatically by Jules for task [16676175587395500418](https://jules.google.com/task/16676175587395500418) started by @n24q02m*