### PR TITLE
[TEST] Missing tests for exported entity: isValidNotionId

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -56,6 +56,34 @@ describe('isValidNotionId', () => {
   it('should be case insensitive', () => {
     expect(isValidNotionId('A3802967-3621-4B04-B6AF-BFEF1B7687B3')).toBe(true)
   })
+
+  it('should reject 31-character hex strings', () => {
+    expect(isValidNotionId('a380296736214b04b6afbfef1b7687b')).toBe(false)
+  })
+
+  it('should reject 33-character hex strings', () => {
+    expect(isValidNotionId('a380296736214b04b6afbfef1b7687b3a')).toBe(false)
+  })
+
+  it('should reject leading hyphen', () => {
+    expect(isValidNotionId('-a380296736214b04b6afbfef1b7687b3')).toBe(false)
+  })
+
+  it('should reject trailing hyphen', () => {
+    expect(isValidNotionId('a380296736214b04b6afbfef1b7687b3-')).toBe(false)
+  })
+
+  it('should reject multiple hyphens between groups', () => {
+    expect(isValidNotionId('a3802967--3621-4b04-b6af-bfef1b7687b3')).toBe(false)
+  })
+
+  it('should reject misplaced hyphens', () => {
+    expect(isValidNotionId('a380296-73621-4b04-b6af-bfef1b7687b3')).toBe(false)
+  })
+
+  it('should accept mixed hyphenation', () => {
+    expect(isValidNotionId('a38029673621-4b04-b6afbfef1b7687b3')).toBe(true)
+  })
 })
 
 describe('formatId', () => {


### PR DESCRIPTION
This PR adds comprehensive edge-case tests for the `isValidNotionId` function in `src/tools/helpers/id.ts`.

### Changes:
- Added tests for structural edge cases (31 and 33 character lengths).
- Added tests for invalid hyphen placements (leading, trailing, multiple, or misplaced hyphens).
- Verified support for mixed hyphenation (where some optional hyphens are present and others are not).

These additions ensure that the Notion ID validation is robust and correctly handles various input formats that might be encountered by AI agents.

---
*PR created automatically by Jules for task [7926123061663803311](https://jules.google.com/task/7926123061663803311) started by @n24q02m*