### PR TITLE
[FIX] Exposure of Token Status in Console Error Logs

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -56,7 +56,7 @@ describe('credential-state', () => {
       const state = await resolveCredentialState()
       expect(state).toBe('configured')
       expect(getNotionToken()).toBe('env-token')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('found in environment'))
+      expect(consoleSpy).not.toHaveBeenCalled()
     })
 
     it('configures when config file has token', async () => {
@@ -67,13 +67,13 @@ describe('credential-state', () => {
       const state = await resolveCredentialState()
       expect(state).toBe('configured')
       expect(getNotionToken()).toBe('file-token')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('loaded from file'))
+      expect(consoleSpy).not.toHaveBeenCalled()
     })
 
     it('stays in awaiting_setup when nothing found', async () => {
       const state = await resolveCredentialState()
       expect(state).toBe('awaiting_setup')
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No Notion token found'))
+      expect(consoleSpy).not.toHaveBeenCalled()
     })
 
     it('handles config read failure gracefully', async () => {

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -74,7 +74,6 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   if (envToken) {
     _notionToken = envToken
     _state = 'configured'
-    console.error('Notion token found in environment')
     return _state
   }
 
@@ -85,7 +84,6 @@ export async function resolveCredentialState(): Promise<CredentialState> {
     if (result.config !== null) {
       _notionToken = result.config[CREDENTIAL_KEY]
       _state = 'configured'
-      console.error(`Notion config loaded from ${result.source}`)
       return _state
     }
   } catch {
@@ -93,7 +91,6 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   }
 
   // 3. Nothing found
-  console.error('No Notion token found -- server starting in awaiting_setup mode')
   _state = 'awaiting_setup'
   return _state
 }


### PR DESCRIPTION
This PR addresses a security hygiene issue where the application was logging the presence (or absence) and source of Notion credentials to `console.error`.

### Changes:
- Removed three `console.error` statements in `src/credential-state.ts` within the `resolveCredentialState` function.
- Updated `src/credential-state.test.ts` to replace expectations of these logs with `expect(consoleSpy).not.toHaveBeenCalled()`.

### Rationale:
Explicitly logging the status of sensitive tokens in error logs can lead to information leakage. Removing these logs ensures that the credential resolution process remains silent regarding the token's presence or source.

### Verification:
- Ran `bun run test` and all 773 tests passed, including updated credential state tests.
- Ran `bun run check` to verify linting and type-checking.

---
*PR created automatically by Jules for task [6765347580620844035](https://jules.google.com/task/6765347580620844035) started by @n24q02m*