### PR TITLE
[TEST] Missing tests for exported entity: formatCover

### DIFF
--- a/src/tools/helpers/covers.test.ts
+++ b/src/tools/helpers/covers.test.ts
@@ -96,6 +96,11 @@ describe('formatCover', () => {
       expect(() => formatCover('data:text/html,<script>alert(1)</script>')).toThrow(NotionMCPError)
     })
 
+    it('rejects unsafe http/https URLs', () => {
+      expect(() => formatCover('https://example.com/cover.jpg\n')).toThrow(NotionMCPError)
+      expect(() => formatCover('https://example.com/cover.jpg\n')).toThrow('Unsafe cover URL')
+    })
+
     it('rejects vbscript: URLs', () => {
       expect(() => formatCover('vbscript:msgbox(1)')).toThrow(NotionMCPError)
     })


### PR DESCRIPTION
Added missing test coverage for the `formatCover` function in `src/tools/helpers/covers.ts`.
Specifically, added a test case for unsafe `http`/`https` URLs (containing control characters like newlines) to ensure the validation logic that throws a `NotionMCPError` is correctly exercised.
The changes achieve 100% line and branch coverage for `src/tools/helpers/covers.ts`.

---
*PR created automatically by Jules for task [15451403477715565683](https://jules.google.com/task/15451403477715565683) started by @n24q02m*