### PR TITLE
[CLEANUP] Potential Unsafe Allocation via Buffer.from without Length Limit Check Prior to Validation

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/merge_diff.txt
+++ b/merge_diff.txt
@@ -1,0 +1,29 @@
+<<<<<<< SEARCH
+/**
+ * Check if a string is valid base64 encoding
+ * Used to validate file_content before Buffer.from
+ * Implements strict validation by checking character set, length, and canonicality
+ */
+export function isValidBase64(str: string): boolean {
+  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0) {
+    return false
+  }
+=======
+/** Maximum length for base64 strings to prevent OOM (64MB) */
+export const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+
+/**
+ * Check if a string is valid base64 encoding
+ * Used to validate file_content before Buffer.from
+ * Implements strict validation by checking character set, length, and canonicality
+ */
+export function isValidBase64(str: string): boolean {
+  if (
+    typeof str !== 'string' ||
+    str.length === 0 ||
+    str.length % 4 !== 0 ||
+    str.length > MAX_BASE64_LENGTH
+  ) {
+    return false
+  }
+>>>>>>> REPLACE

--- a/merge_diff_clean.txt
+++ b/merge_diff_clean.txt
@@ -1,0 +1,28 @@
+<<<<<<< SEARCH
+/**
+ * Check if a string is valid base64 encoding
+ * Used to validate file_content before Buffer.from
+ * Implements strict validation by checking character set, length, and canonicality
+ */
+export function isValidBase64(str: string): boolean {
+  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0) {
+    return false
+  }
+=======
+/** Maximum length for base64 strings to prevent OOM (64MB) */
+export const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+/**
+ * Check if a string is valid base64 encoding
+ * Used to validate file_content before Buffer.from
+ * Implements strict validation by checking character set, length, and canonicality
+ */
+export function isValidBase64(str: string): boolean {
+  if (
+    typeof str !== 'string' ||
+    str.length === 0 ||
+    str.length % 4 !== 0 ||
+    str.length > MAX_BASE64_LENGTH
+  ) {
+    return false
+  }
+>>>>>>> REPLACE

--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -150,4 +150,9 @@ describe('isValidBase64', () => {
     expect(isValidBase64('aGVsbG8=')).toBe(false)
     spy.mockRestore()
   })
+
+  it('should reject strings exceeding MAX_BASE64_LENGTH', () => {
+    const bigStr = 'A'.repeat(64 * 1024 * 1024 + 4)
+    expect(isValidBase64(bigStr)).toBe(false)
+  })
 })

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -43,12 +43,7 @@ export const MAX_BASE64_LENGTH = 64 * 1024 * 1024
  * Implements strict validation by checking character set, length, and canonicality
  */
 export function isValidBase64(str: string): boolean {
-  if (
-    typeof str !== 'string' ||
-    str.length === 0 ||
-    str.length % 4 !== 0 ||
-    str.length > MAX_BASE64_LENGTH
-  ) {
+  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0 || str.length > MAX_BASE64_LENGTH) {
     return false
   }
 

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -34,13 +34,21 @@ export function formatId(id: string): string {
   return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20)}`
 }
 
+/** Maximum length for base64 strings to prevent OOM (64MB) */
+export const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+
 /**
  * Check if a string is valid base64 encoding
  * Used to validate file_content before Buffer.from
  * Implements strict validation by checking character set, length, and canonicality
  */
 export function isValidBase64(str: string): boolean {
-  if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0) {
+  if (
+    typeof str !== 'string' ||
+    str.length === 0 ||
+    str.length % 4 !== 0 ||
+    str.length > MAX_BASE64_LENGTH
+  ) {
     return false
   }
 

--- a/test_diff.txt
+++ b/test_diff.txt
@@ -1,0 +1,34 @@
+<<<<<<< SEARCH
+  it('should return false if Buffer.from fails', () => {
+    const spy = vi.spyOn(Buffer, 'from').mockImplementation(() => {
+      throw new Error('Buffer failure')
+    })
+    expect(isValidBase64('aGVsbG8=')).toBe(false)
+    spy.mockRestore()
+  })
+})
+=======
+  it('should return false if Buffer.from fails', () => {
+    const spy = vi.spyOn(Buffer, 'from').mockImplementation(() => {
+      throw new Error('Buffer failure')
+    })
+    expect(isValidBase64('aGVsbG8=')).toBe(false)
+    spy.mockRestore()
+  })
+
+  it('should reject strings exceeding MAX_BASE64_LENGTH', () => {
+    // MAX_BASE64_LENGTH is 64MB. We don't need to actually allocate 64MB if we mock length
+    const longStr = {
+      length: 64 * 1024 * 1024 + 4,
+      toString: () => '',
+      indexOf: () => -1,
+      [Symbol.iterator]: function* () { yield '' }
+    }
+    // Since isValidBase64 checks typeof str !== 'string' first, we need a real string or a mock that passes
+    // Better to just create a large string since 64MB is manageable in memory but let's be careful.
+    // Actually, let's just use a real string of size 64MB + 4.
+    const bigStr = 'A'.repeat(64 * 1024 * 1024 + 4)
+    expect(isValidBase64(bigStr)).toBe(false)
+  })
+})
+>>>>>>> REPLACE


### PR DESCRIPTION
Added a 64MB length limit check to \`isValidBase64\` in \`src/tools/helpers/id.ts\` to prevent OOM/crashes when processing extremely large strings before Buffer allocation. This ensures that potentially malicious or accidental huge payloads are rejected before they can cause a process crash during buffer allocation.

---
*PR created automatically by Jules for task [16048448473398076](https://jules.google.com/task/16048448473398076) started by @n24q02m*