### PR TITLE
[TEST] Missing tests for exported entity: formatId

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -94,6 +94,22 @@ describe('formatId', () => {
   it('should format UUIDs with misplaced hyphens correctly', () => {
     expect(formatId('a3802967-3621-4b04-b6af-bfef-1b76-87b3')).toBe('a3802967-3621-4b04-b6af-bfef1b7687b3')
   })
+
+  it('should return empty string unchanged', () => {
+    expect(formatId('')).toBe('')
+  })
+
+  it('should return strings with only hyphens unchanged', () => {
+    expect(formatId('---')).toBe('---')
+  })
+
+  it('should return strings with whitespace unchanged', () => {
+    expect(formatId(' a380296736214b04b6afbfef1b7687b3 ')).toBe(' a380296736214b04b6afbfef1b7687b3 ')
+  })
+
+  it('should return strings with invalid characters in 32-char length unchanged', () => {
+    expect(formatId('a380296736214b04b6afbfef1b7687b!')).toBe('a380296736214b04b6afbfef1b7687b!')
+  })
 })
 
 describe('isValidBase64', () => {


### PR DESCRIPTION
### 💡 What
Added additional edge-case tests for the `formatId` utility in `src/tools/helpers/id.ts`.

### 🎯 Why
To ensure the utility handles unexpected inputs like empty strings, strings with only hyphens, or whitespace correctly, fulfilling the mission to fix missing/incomplete tests.

### 📊 Impact
Improved test robustness and verification of existing logic for the `formatId` function.

### 🧪 Measurement
Ran `bun run test --coverage src/tools/helpers/id.test.ts` and verified 100% coverage and all tests passing (37 tests total).

---
*PR created automatically by Jules for task [5631333136902651802](https://jules.google.com/task/5631333136902651802) started by @n24q02m*