### PR TITLE
[TEST] Missing tests for exported entity: normalizeId

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -30,6 +30,16 @@ describe('normalizeId', () => {
     expect(normalizeId('-abc-')).toBe('abc')
     expect(normalizeId(' a - b ')).toBe(' a  b ')
   })
+
+  it('should preserve other whitespace characters like tabs and newlines', () => {
+    expect(normalizeId('abc-\t-def')).toBe('abc\tdef')
+    expect(normalizeId('abc-\n-def')).toBe('abc\ndef')
+  })
+
+  it('should preserve unicode dashes but strip standard hyphens', () => {
+    // en-dash (–) and em-dash (—) should be preserved
+    expect(normalizeId('a-b–c—d')).toBe('ab–c—d')
+  })
 })
 
 describe('isValidNotionId', () => {


### PR DESCRIPTION
### What
Added additional edge case tests for the `normalizeId` utility in `src/tools/helpers/id.test.ts`. New test cases cover:
- Preservation of other whitespace characters like tabs and newlines.
- Preservation of non-standard unicode dashes (en-dash, em-dash) while still stripping standard hyphens.

### Why
The `normalizeId` function is a public utility used for Notion ID comparison. While it already had significant test coverage, adding these edge cases ensures maximum robustness and prevents regressions if the implementation logic is changed in the future.

---
*PR created automatically by Jules for task [8468026666525221743](https://jules.google.com/task/8468026666525221743) started by @n24q02m*