### PR TITLE
[FIX] Deeply nested conditional in page duplication

### DIFF
--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -480,6 +480,41 @@ async function archivePage(notion: Client, input: PagesInput): Promise<ArchivePa
 }
 
 /**
+ * Strip read-only fields and null values from a block object for duplication.
+ * Notion API rejects null where it expects an object or undefined.
+ */
+function stripNullValues(block: any): any {
+  const {
+    id,
+    parent,
+    created_time,
+    last_edited_time,
+    created_by,
+    last_edited_by,
+    has_children,
+    archived,
+    in_trash,
+    request_id,
+    object,
+    ...rest
+  } = block
+
+  const blockType = rest.type
+  if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
+    const blockData = rest[blockType]
+    const keys = Object.keys(blockData)
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      if (blockData[key] === null) {
+        delete blockData[key]
+      }
+    }
+  }
+
+  return rest
+}
+
+/**
  * Duplicate page
  * Maps to: GET /v1/pages/{id} + POST /v1/pages + GET/PATCH /v1/blocks
  */
@@ -534,33 +569,7 @@ async function duplicatePage(notion: Client, input: PagesInput): Promise<Duplica
 
       // Copy content — strip read-only fields that the create endpoint rejects
       if (originalBlocks.length > 0) {
-        const sanitizedBlocks = originalBlocks.map((block: any) => {
-          const {
-            id,
-            parent,
-            created_time,
-            last_edited_time,
-            created_by,
-            last_edited_by,
-            has_children,
-            archived,
-            in_trash,
-            request_id,
-            object,
-            ...rest
-          } = block
-          // Strip null values inside block type data (e.g., paragraph.icon: null)
-          // Notion API rejects null where it expects object or undefined
-          const blockType = rest.type
-          if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
-            for (const key of Object.keys(rest[blockType])) {
-              if (rest[blockType][key] === null) {
-                delete rest[blockType][key]
-              }
-            }
-          }
-          return rest
-        })
+        const sanitizedBlocks = originalBlocks.map(stripNullValues)
         await notion.blocks.children.append({
           block_id: duplicatedPage.id,
           children: sanitizedBlocks as any


### PR DESCRIPTION
This PR refactors the block sanitization logic in the page duplication tool. The previously inline and deeply nested logic has been extracted into a dedicated `stripNullValues` helper function, which improves readability and maintainability. The helper function also uses an optimized indexed loop for property cleanup.

---
*PR created automatically by Jules for task [14917529286103583147](https://jules.google.com/task/14917529286103583147) started by @n24q02m*