### PR TITLE
fix: bump @n24q02m/mcp-core to 1.17.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "1.17.2",
+        "@n24q02m/mcp-core": "1.17.3",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.17.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.10.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-/Zi/AqJVh19DmpI47pI61H87XqfbWv0Qmdty75QHOoHNw6h/gD73pHLYzvbs3pK9fTTObDoHqMfFRxQhRENryA=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.17.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.10.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-/hWR++n2SKbhUdhCo1QN5SjdZc1vLruM8wcWypxfyQDjQTAsYccaWMk1os6npBXTkM8va9v9xok/YhMLD5O8DA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@n24q02m/better-notion-mcp",
-  "version": "2.34.4",
+  "version": "2.34.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@n24q02m/better-notion-mcp",
-      "version": "2.34.4",
+      "version": "2.34.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "1.17.2",
+        "@n24q02m/mcp-core": "1.17.3",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3"
       },
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@n24q02m/mcp-core": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@n24q02m/mcp-core/-/mcp-core-1.17.2.tgz",
-      "integrity": "sha512-/Zi/AqJVh19DmpI47pI61H87XqfbWv0Qmdty75QHOoHNw6h/gD73pHLYzvbs3pK9fTTObDoHqMfFRxQhRENryA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@n24q02m/mcp-core/-/mcp-core-1.17.3.tgz",
+      "integrity": "sha512-/hWR++n2SKbhUdhCo1QN5SjdZc1vLruM8wcWypxfyQDjQTAsYccaWMk1os6npBXTkM8va9v9xok/YhMLD5O8DA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "1.17.2",
+    "@n24q02m/mcp-core": "1.17.3",
     "@notionhq/client": "^5.22.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
Bumps the exact mcp-core pin from 1.17.2 to 1.17.3 so the published artifact ships the current mcp-core (resolves the drift flagged by the tracking issue).

- `package.json`: `@n24q02m/mcp-core` 1.17.2 -> 1.17.3
- Regenerated `bun.lock` (`bun install`) + `package-lock.json` (`npm install --package-lock-only`); both now reference mcp-core 1.17.3
- `bun run check` (biome + tsc) passes
- `bun run test`: 800 tests passed

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)