### PR TITLE
[FIX] Deeply nested if in comments error handling

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/comments.ts
+++ b/src/tools/composite/comments.ts
@@ -17,6 +17,23 @@ export interface CommentsManageInput {
 }
 
 /**
+ * Helper to check if a block exists.
+ * Returns true if the block exists, false if it returns object_not_found.
+ * Throws for any other error.
+ */
+async function checkBlockExists(notion: Client, block_id: string): Promise<boolean> {
+  try {
+    await notion.blocks.retrieve({ block_id })
+    return true
+  } catch (error: any) {
+    if (error.code === 'object_not_found') {
+      return false
+    }
+    throw error
+  }
+}
+
+/**
  * Manage comments (list, get, create)
  * Maps to: GET /v1/comments, GET /v1/comments/{id}, POST /v1/comments
  */
@@ -50,30 +67,15 @@ export async function commentsManage(notion: Client, input: CommentsManageInput)
             }))
           }
         } catch (error: any) {
-          if (error.code === 'object_not_found') {
-            // Distinguish between a real 404 and the known Notion API limitation (OAuth 404)
-            // by checking if the block/page actually exists.
-            let blockExists = false
-            try {
-              await notion.blocks.retrieve({ block_id: input.page_id })
-              blockExists = true
-            } catch (innerError: any) {
-              // If we get any error other than 404, we should probably know about it
-              if (innerError.code !== 'object_not_found') {
-                throw innerError
-              }
-            }
-
-            if (blockExists) {
-              // If retrieve succeeds, it's the known API limitation
-              throw new NotionMCPError(
-                'The comments.list API is currently unavailable for this page due to a known Notion OAuth limitation.',
-                'COMMENTS_LIST_UNAVAILABLE'
-              )
-            }
-            // If it's a real 404 (block retrieve also failed with object_not_found),
-            // re-throw the original error which will be wrapped as NOT_FOUND by withErrorHandling.
+          if (error.code === 'object_not_found' && (await checkBlockExists(notion, input.page_id))) {
+            // If retrieve succeeds (checkBlockExists returns true), it's the known API limitation
+            throw new NotionMCPError(
+              'The comments.list API is currently unavailable for this page due to a known Notion OAuth limitation.',
+              'COMMENTS_LIST_UNAVAILABLE'
+            )
           }
+          // If it's a real 404 (block retrieve also failed with object_not_found),
+          // re-throw the original error which will be wrapped as NOT_FOUND by withErrorHandling.
           throw error
         }
       }


### PR DESCRIPTION
Extracted the block existence check in `src/tools/composite/comments.ts` to a separate asynchronous helper function `checkBlockExists`. This flattens the logic in the `commentsManage` function for the `list` action, improving readability while preserving the behavior of distinguishing between genuine 404s and known Notion API OAuth limitations.

Also updated `biome.json` schema version to match the current CLI (2.4.16).

---
*PR created automatically by Jules for task [12899863899571756363](https://jules.google.com/task/12899863899571756363) started by @n24q02m*