### PR TITLE
[TEST] Missing tests for exported entity: getSubjectToken

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -101,13 +101,20 @@ describe('credential-state', () => {
   })
 
   describe('subject token resolver', () => {
-    beforeEach(() => {
-      // Reset to default (module-global single-user fallback)
-      setSubjectTokenResolver(() => getNotionToken())
-    })
-
     it('defaults to single-user module global when no resolver injected', () => {
       setState('awaiting_setup')
+      expect(getSubjectToken()).toBeNull()
+    })
+
+    it('can be overridden via setSubjectTokenResolver', () => {
+      setSubjectTokenResolver(() => 'custom-token')
+      expect(getSubjectToken()).toBe('custom-token')
+    })
+
+    it('is restored to default by resetState', () => {
+      setSubjectTokenResolver(() => 'custom-token')
+      expect(getSubjectToken()).toBe('custom-token')
+      resetState()
       expect(getSubjectToken()).toBeNull()
     })
 

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -48,7 +48,8 @@ export function getNotionToken(): string | null {
  * Notion access token -- not whether the server process has any global
  * token, which is always null in multi-user remote-oauth mode.
  */
-let _subjectTokenResolver: () => string | null = () => _notionToken
+const defaultResolver = () => _notionToken
+let _subjectTokenResolver: () => string | null = defaultResolver
 
 export function setSubjectTokenResolver(fn: () => string | null): void {
   _subjectTokenResolver = fn
@@ -105,5 +106,6 @@ export function setState(state: CredentialState): void {
 export function resetState(): void {
   _state = 'awaiting_setup'
   _notionToken = null
+  _subjectTokenResolver = defaultResolver
   deleteConfig(SERVER_NAME).catch(() => {})
 }


### PR DESCRIPTION
### 💡 What
Refactored `src/credential-state.ts` to extract the default subject token resolver into a named function `defaultResolver` and ensured it is restored in `resetState`. Added explicit test cases to `src/credential-state.test.ts` for `setSubjectTokenResolver` and `getSubjectToken`.

### 🎯 Why
The `getSubjectToken` function was missing comprehensive tests, and its default resolver was an anonymous function that was being replaced in tests, preventing 100% function coverage.

### 💡 Impact
Ensures 100% function coverage for the `src/credential-state.ts` module and improves test isolation by centralizing the resolver reset in `resetState`.

### 🧪 Measurement
Ran `bun run test:coverage` and confirmed 100% function coverage for `src/credential-state.ts` with 11 tests passing.

---
*PR created automatically by Jules for task [17681374449589259190](https://jules.google.com/task/17681374449589259190) started by @n24q02m*