### PR TITLE
[TEST] Missing tests for exported entity: formatId

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -122,6 +122,18 @@ describe('formatId', () => {
   it('should format UUIDs with misplaced hyphens correctly', () => {
     expect(formatId('a3802967-3621-4b04-b6af-bfef-1b76-87b3')).toBe('a3802967-3621-4b04-b6af-bfef1b7687b3')
   })
+
+  it('should return empty string unchanged', () => {
+    expect(formatId('')).toBe('')
+  })
+
+  it('should return strings containing only hyphens unchanged', () => {
+    expect(formatId('---')).toBe('---')
+  })
+
+  it('should return strings with leading/trailing whitespace unchanged', () => {
+    expect(formatId(' a380296736214b04b6afbfef1b7687b3 ')).toBe(' a380296736214b04b6afbfef1b7687b3 ')
+  })
 })
 
 describe('isValidBase64', () => {


### PR DESCRIPTION
This PR adds missing unit tests for the `formatId` utility in `src/tools/helpers/id.ts`.

### Changes
- Added tests for edge cases in `src/tools/helpers/id.test.ts`:
  - Empty strings
  - Strings containing only hyphens
  - Strings with leading/trailing whitespace
- Updated `biome.json` schema version from `2.4.15` to `2.4.16` to match the project's active CLI version and ensure stable linting/formatting checks.

### Verification
- Ran `bun run test:coverage src/tools/helpers/id.test.ts`: 100% coverage, all 44 tests passing.
- Ran `bun run check`: All linting, formatting, and type-checks passing.

---
*PR created automatically by Jules for task [13415396137033332585](https://jules.google.com/task/13415396137033332585) started by @n24q02m*