### PR TITLE
[TEST] Missing tests for exported entity: initServer

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -21,6 +21,7 @@ describe('initServer', () => {
   afterEach(() => {
     process.env = originalEnv
     process.argv = originalArgv
+    vi.unstubAllEnvs()
   })
 
   it('dispatches http when --http flag is set', async () => {
@@ -31,14 +32,14 @@ describe('initServer', () => {
   })
 
   it('dispatches http when MCP_TRANSPORT=http', async () => {
-    process.env.MCP_TRANSPORT = 'http'
+    vi.stubEnv('MCP_TRANSPORT', 'http')
     const { initServer } = await import('./init-server.js')
     await initServer()
     expect(startServerMock).toHaveBeenCalledWith('http')
   })
 
   it('dispatches http when TRANSPORT_MODE=http', async () => {
-    process.env.TRANSPORT_MODE = 'http'
+    vi.stubEnv('TRANSPORT_MODE', 'http')
     const { initServer } = await import('./init-server.js')
     await initServer()
     expect(startServerMock).toHaveBeenCalledWith('http')
@@ -48,5 +49,36 @@ describe('initServer', () => {
     const { initServer } = await import('./init-server.js')
     await initServer()
     expect(startServerMock).toHaveBeenCalledWith('stdio')
+  })
+
+  it('verifies case-sensitivity for environment variables', async () => {
+    vi.stubEnv('MCP_TRANSPORT', 'HTTP')
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('stdio')
+  })
+
+  it('verifies exact match for argv flags', async () => {
+    process.argv = [process.argv[0], 'main.js', '--http-proxy']
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('stdio')
+  })
+
+  it('prioritizes any http trigger over others', async () => {
+    // Conflicting: --http is set, but TRANSPORT_MODE=stdio
+    process.argv = [process.argv[0], 'main.js', '--http']
+    vi.stubEnv('TRANSPORT_MODE', 'stdio')
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('http')
+  })
+
+  it('propagates errors from startServer', async () => {
+    const testError = new Error('Startup failed')
+    startServerMock.mockRejectedValueOnce(testError)
+
+    const { initServer } = await import('./init-server.js')
+    await expect(initServer()).rejects.toThrow('Startup failed')
   })
 })


### PR DESCRIPTION
## What
- Expanded `src/init-server.test.ts` to include robust test cases for `initServer`.
- Added coverage for error propagation, case-sensitivity in environment variables, and exact flag matching in `process.argv`.
- Fixed a Biome schema mismatch in `biome.json` (updated from 2.4.15 to 2.4.16).

## Why
- The `initServer` function is a critical entry point for the server, and although it had basic coverage, it lacked verification for edge cases and error handling.
- Ensuring that transport selection logic is robust prevents misconfigurations when starting the server in different environments (stdio vs http).
- Maintaining consistent linting tools across the project ensures stable CI/CD pipelines.

---
*PR created automatically by Jules for task [17869562905056557260](https://jules.google.com/task/17869562905056557260) started by @n24q02m*