### PR TITLE
[FIX] P0 fork-bomb fix

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -230,7 +230,24 @@ describe('main.ts', () => {
       consoleSpy.mockRestore()
     })
 
-    it('verifies fork-bomb protection prevents multiple starts', async () => {
+    it('verifies fork-bomb protection prevents multiple starts via startServer', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      // First call should work
+      await startServer('stdio')
+      expect(stdioConnectMock).toHaveBeenCalledTimes(1)
+
+      // Second call should be aborted
+      await startServer('stdio')
+      expect(stdioConnectMock).toHaveBeenCalledTimes(1)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Startup aborted'))
+
+      consoleSpy.mockRestore()
+      delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED
+    })
+
+    it('verifies fork-bomb protection prevents multiple starts via bootstrap', async () => {
       process.env.NOTION_TOKEN = 'ntn_test_token'
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
@@ -241,7 +258,7 @@ describe('main.ts', () => {
       // Second call should be aborted
       await bootstrap('stdio')
       expect(stdioConnectMock).toHaveBeenCalledTimes(1)
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Bootstrap aborted'))
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Startup aborted'))
 
       consoleSpy.mockRestore()
       delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,12 @@ export function getTransportMode(env: NodeJS.ProcessEnv = process.env): string {
  * Dynamically imports and starts the server for the specified mode.
  */
 export async function startServer(mode: string): Promise<void> {
+  if (process.env.BETTER_NOTION_MCP_BOOTSTRAPPED) {
+    console.error('[better-notion-mcp] Startup aborted: server already running in this process tree.')
+    return
+  }
+  process.env.BETTER_NOTION_MCP_BOOTSTRAPPED = 'true'
+
   if (mode === 'http') {
     const { startHttp } = await import('./transports/http.js')
     await startHttp()
@@ -123,12 +129,6 @@ export const mode = getTransportMode()
  * Bootstrap function to start the server with error handling.
  */
 export async function bootstrap(selectedMode: string = mode) {
-  if (process.env.BETTER_NOTION_MCP_BOOTSTRAPPED) {
-    console.error('[better-notion-mcp] Bootstrap aborted: server already running in this process tree.')
-    return
-  }
-  process.env.BETTER_NOTION_MCP_BOOTSTRAPPED = 'true'
-
   try {
     await startServer(selectedMode)
   } catch (error) {


### PR DESCRIPTION
The fork-bomb protection guard using the \`BETTER_NOTION_MCP_BOOTSTRAPPED\` environment variable was relocated from the \`bootstrap\` function to the beginning of the \`startServer\` function in \`src/main.ts\`.

**Why:**
Relocating the guard to \`startServer\` ensures that all entry points into the server initialization process (such as \`initServer\` in \`src/init-server.ts\`) are protected against recursive process spawning, not just those calling \`bootstrap\`.

**Changes:**
- \`src/main.ts\`: Moved the \`BETTER_NOTION_MCP_BOOTSTRAPPED\` check and assignment to \`startServer\`.
- \`src/main.test.ts\`: Added a test case to verify the guard at the \`startServer\` level and updated existing bootstrap tests to reflect the new "Startup aborted" error message.
- \`biome.json\`: Updated \`$schema\` version to 2.4.16 to match the CLI.

---
*PR created automatically by Jules for task [6448983986909051788](https://jules.google.com/task/6448983986909051788) started by @n24q02m*