### PR TITLE
[CLEANUP] Potential Unsafe Allocation via Buffer.from without Length Limit Check Prior to Validation

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -178,9 +178,33 @@ describe('isValidBase64', () => {
     expect(isValidBase64('aGVsbG8=')).toBe(false)
     spy.mockRestore()
   })
+
   it('should reject string that exceeds maximum length', () => {
-    // MAX_BASE64_LENGTH is 64MB. Let's create a string slightly larger.
-    const largeStr = 'a'.repeat(64 * 1024 * 1024 + 4)
+    // MAX_BASE64_LENGTH is 32MB. Let's create a string slightly larger.
+    const largeStr = 'a'.repeat(32 * 1024 * 1024 + 4)
     expect(isValidBase64(largeStr)).toBe(false)
+  })
+
+  it('should reject non-string types', () => {
+    expect(isValidBase64(null as any)).toBe(false)
+    expect(isValidBase64(undefined as any)).toBe(false)
+    expect(isValidBase64(123 as any)).toBe(false)
+    expect(isValidBase64({} as any)).toBe(false)
+  })
+
+  it('should reject more non-canonical base64 examples', () => {
+    // These have bits set in the padding bits that should be zero
+    // 'f' -> 'Zg==' (canonical)
+    // 'g' is 100000, padding bits are 0000.
+    // 'h' is 100001, last bit is 1.
+    expect(isValidBase64('Zh==')).toBe(false)
+    expect(isValidBase64('Zi==')).toBe(false)
+    expect(isValidBase64('Zg==')).toBe(true)
+
+    // 'fo' -> 'Zm8=' (canonical)
+    // '8' is 111100, padding bits are 00.
+    // '9' is 111101, last bit is 1.
+    expect(isValidBase64('Zm9=')).toBe(false)
+    expect(isValidBase64('Zm8=')).toBe(true)
   })
 })

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -34,13 +34,21 @@ export function formatId(id: string): string {
   return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20)}`
 }
 
-/** Maximum length for base64 string to prevent OOM during validation (64MB) */
-const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+/**
+ * Maximum length for base64 string to prevent OOM during validation (32MB).
+ * This is 3x the max file upload size (10MB) to allow for base64 overhead
+ * and concurrent request headroom.
+ */
+const MAX_BASE64_LENGTH = 32 * 1024 * 1024
 
 /**
- * Check if a string is valid base64 encoding
- * Used to validate file_content before Buffer.from
- * Implements strict validation by checking character set, length, and canonicality
+ * Check if a string is valid base64 encoding.
+ * Used to validate file_content before Buffer.from.
+ *
+ * Implements multi-stage strict validation for both correctness and safety:
+ * 1. Cheap early returns for type, length, and MAX_BASE64_LENGTH (OOM guard).
+ * 2. Regex check for character set and padding structure.
+ * 3. Buffer roundtrip to ensure canonicality (rejects bits in padding).
  */
 export function isValidBase64(str: string): boolean {
   if (typeof str !== 'string' || str.length === 0 || str.length % 4 !== 0 || str.length > MAX_BASE64_LENGTH) {
@@ -52,7 +60,8 @@ export function isValidBase64(str: string): boolean {
     return false
   }
 
-  // Strict check: Buffer roundtrip to ensure canonicality
+  // Strict check: Buffer roundtrip to ensure canonicality.
+  // The str.length check above ensures this won't cause OOM.
   try {
     const buffer = Buffer.from(str, 'base64')
     return buffer.toString('base64') === str


### PR DESCRIPTION
This PR implements a more conservative safety boundary for base64 validation to prevent Out-Of-Memory (OOM) attacks.

### Changes:
- **Refined `isValidBase64`**: Lowered `MAX_BASE64_LENGTH` to 32MB (from 64MB). This provides ample headroom for the 10MB file upload limit while significantly reducing memory pressure on concurrent requests.
- **Improved Documentation**: Added comments explaining the multi-stage validation strategy (Type -> Length -> Regex -> Canonicality).
- **Expanded Test Suite**: Added tests for:
    - Non-string inputs (`null`, `undefined`, numbers, objects).
    - Boundary length checks.
    - Bit-level non-canonical base64 validation (rejecting strings with invalid bits in padding, e.g., `Zh==`).
- **Maintenance**: Migrated `biome.json` schema to version 2.4.16 to match the environment's CLI.

These changes ensure that malformed or malicious payloads are rejected early with minimal resource consumption.

---
*PR created automatically by Jules for task [3674884175878534554](https://jules.google.com/task/3674884175878534554) started by @n24q02m*