### PR TITLE
⚡ Bolt: precompute static arrays in tool registry

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2025-05-26 - Array.includes() vs Set.has() for O(1) Lookups
 **Learning:** Checking for membership in an array using `['a', 'b', ...].includes(value)` within hot paths requires an O(N) scan. This can become an issue when iterating or repeatedly checking values.
 **Action:** Replace `Array.includes()` with `Set.has()` by extracting the array into a module-level `Set`. This improves lookup times significantly to O(1).
+
+## 2025-05-28 - Precomputing Static Data from Arrays
+**Learning:** Using `Array.prototype.map()` over constant module-level arrays inside hot path functions (such as request handlers mapping `TOOLS` or `RESOURCES` on each invocation) causes completely unnecessary dynamic array allocations, leading to performance degradation and increased garbage collection overhead.
+**Action:** When a computed value depends entirely on static data that will never change at runtime, precompute that data by performing the `.map()` and `.join()` operations once outside of the function, storing the result in a module-level constant.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -443,6 +443,16 @@ const TOOLS = [
 // BOLT OPTIMIZATION: Use Set for O(1) lookups instead of dynamic array creation
 const VALID_HELP_TOOL_NAMES = new Set(TOOLS.map((t) => t.name).filter((name) => name !== 'help'))
 const VALID_HELP_TOOLS_STRING = Array.from(VALID_HELP_TOOL_NAMES).join(', ')
+
+// BOLT OPTIMIZATION: Pre-compute static values for resource endpoints and unknown tool suggestions
+const ALL_TOOL_NAMES = TOOLS.map((t) => t.name)
+const PRECOMPUTED_RESOURCES = RESOURCES.map((r) => ({
+  uri: r.uri,
+  name: r.name,
+  mimeType: 'text/markdown'
+}))
+const AVAILABLE_RESOURCES_STRING = RESOURCES.map((r) => r.uri).join(', ')
+
 /**
  * Register all tools with MCP server
  * @param notionClientFactory - Returns a Notion Client.
@@ -455,11 +465,7 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
 
   // Resources handlers for full documentation
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-    resources: RESOURCES.map((r) => ({
-      uri: r.uri,
-      name: r.name,
-      mimeType: 'text/markdown'
-    }))
+    resources: PRECOMPUTED_RESOURCES
   }))
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
@@ -470,7 +476,7 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
       throw new NotionMCPError(
         `Resource not found: ${uri}`,
         'RESOURCE_NOT_FOUND',
-        `Available: ${RESOURCES.map((r) => r.uri).join(', ')}`
+        `Available: ${AVAILABLE_RESOURCES_STRING}`
       )
     }
 
@@ -580,13 +586,12 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         }
         default: {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, ALL_TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new NotionMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'UNKNOWN_TOOL',
-            `Available tools: ${validTools.join(', ')}`
+            `Available tools: ${ALL_TOOL_NAMES.join(', ')}`
           )
         }
       }


### PR DESCRIPTION
💡 What: Precomputes `ALL_TOOL_NAMES`, `PRECOMPUTED_RESOURCES`, and `AVAILABLE_RESOURCES_STRING` outside the exported `registerTools` function in `src/tools/registry.ts`.
🎯 Why: `TOOLS` and `RESOURCES` are static module-level arrays. By calling `.map` and `.join` dynamically on these arrays inside the `ListResourcesRequestSchema`, `ReadResourceRequestSchema`, and the unhandled tool `default` block, the server incurred unnecessary array allocation and garbage collection overhead on every request for these endpoints.
📊 Impact: Reduces transient object creation, function calls, and loop execution overhead, specifically for resource queries and validation fallbacks. The array mapping time is reduced to O(1) lookups referencing precomputed values instead of O(N) recreations.
🧪 Measurement: Run `bun run test src/tools/registry.test.ts` to ensure behavior parity.

---
*PR created automatically by Jules for task [16184641282221382374](https://jules.google.com/task/16184641282221382374) started by @n24q02m*