### PR TITLE
⚡ Bolt: [performance improvement] optimize property array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@
 ## 2025-05-26 - Array.includes() vs Set.has() for O(1) Lookups
 **Learning:** Checking for membership in an array using `['a', 'b', ...].includes(value)` within hot paths requires an O(N) scan. This can become an issue when iterating or repeatedly checking values.
 **Action:** Replace `Array.includes()` with `Set.has()` by extracting the array into a module-level `Set`. This improves lookup times significantly to O(1).
+
+## 2025-06-08 - Array Allocation in Paginated Properties
+**Learning:** Using `array.map(fn).join('')` or `array.map(fn)` without pre-allocating the result array creates unnecessary intermediate array objects and incurs iterator overhead. This is particularly problematic in paginated result handlers (like `getPageProperty`) where the length of `allResults` can be large.
+**Action:** Replace `.map().join('')` with a `for` loop and direct string concatenation (`+=`). For object mapping, use a pre-allocated array (`new Array(len)`) and an indexed `for` loop to minimize allocation and garbage collection overhead.

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -292,9 +292,15 @@ async function getPageProperty(notion: Client, input: PagesInput): Promise<GetPa
   let value: any
   switch (propertyType) {
     case 'title':
-    case 'rich_text':
-      value = allResults.map((item: any) => item[propertyType]?.plain_text || '').join('')
+    case 'rich_text': {
+      let str = ''
+      for (let i = 0; i < allResults.length; i++) {
+        const item = allResults[i] as any
+        str += item[propertyType]?.plain_text || ''
+      }
+      value = str
       break
+    }
     case 'relation': {
       const relationIds: string[] = []
       for (const item of allResults as any[]) {
@@ -309,12 +315,18 @@ async function getPageProperty(notion: Client, input: PagesInput): Promise<GetPa
     case 'rollup':
       value = firstResult.rollup
       break
-    case 'people':
-      value = allResults.map((item: any) => ({
-        id: item.people?.id,
-        name: item.people?.name
-      }))
+    case 'people': {
+      const ppl = new Array(allResults.length)
+      for (let i = 0; i < allResults.length; i++) {
+        const item = allResults[i] as any
+        ppl[i] = {
+          id: item.people?.id,
+          name: item.people?.name
+        }
+      }
+      value = ppl
       break
+    }
     default:
       // For non-paginated types, return the raw value
       value = firstResult?.[propertyType] ?? firstResult


### PR DESCRIPTION
💡 What: Refactored `getPageProperty` in `src/tools/composite/pages.ts` to replace array `.map().join('')` and `.map(...)` calls with standard `for` loops, pre-allocated arrays, and direct string concatenation.

🎯 Why: When fetching heavily paginated Notion properties (like large text blocks or long lists of people), using `.map().join('')` creates transient array objects and incurs iterator overhead. This micro-optimization reduces garbage collection pressure on the hot path.

📊 Impact: Reduces memory overhead and allocation time proportional to the number of elements in the paginated property response (`allResults.length`), which can be up to 100 per page block.

🔬 Measurement: `bun run check:fix` and `bun run test` verified behavior parity (0 regressions) while avoiding intermediate V8 object creation during data transformation.

---
*PR created automatically by Jules for task [3197894082233806956](https://jules.google.com/task/3197894082233806956) started by @n24q02m*