### PR TITLE
fix: correct tool-count drift and stale tool references in docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-notion-mcp",
-  "description": "Comprehensive Notion API integration — 9 composite tools, ~95% coverage",
+  "description": "Comprehensive Notion API integration — 11 composite tools, ~95% coverage",
   "version": "2.34.8-beta.1",
   "userConfig": {
     "NOTION_TOKEN": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # better-notion-mcp
 
-TypeScript MCP Server cho Notion API. 10 composite tools (pages, databases, blocks, users, workspace, comments, content_convert, file_uploads, setup, help), dual-mode stdio/http.
+TypeScript MCP Server cho Notion API. 11 composite tools (pages, databases, blocks, users, workspace, comments, content_convert, file_uploads, config, config__open_relay, help), dual-mode stdio/http.
 Xem `AGENTS.md` va `README.md` de hieu architecture va OAuth flow.
 
 ## Cau truc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,25 +87,18 @@ We use [Conventional Commits](https://www.conventionalcommits.org/) with automat
 
 ### Types
 
+Only `feat` and `fix` are accepted (enforced by the commit-message hook):
+
 - `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, no logic change)
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks, dependencies
-- `ci`: CI/CD changes
-- `build`: Build system changes
+- `fix`: Bug fix (also used for docs, tests, chores, and other maintenance changes)
 
 ### Examples
 
 ```text
 feat: add bulk delete operation for pages
 fix: handle pagination errors gracefully
-docs: update API examples in README
-test: add integration tests for databases tool
-chore: upgrade dependencies
+fix: update API examples in README
+fix: add integration tests for databases tool
 ```
 
 **Note**: Commit messages are validated automatically via git hooks when you commit.
@@ -120,8 +113,7 @@ It is mandatory to use correct commit types so the release system knows how to b
 
 - **fix**: Patches a bug (PATCH version bump, e.g., 1.0.0 -> 1.0.1)
 - **feat**: Introduces a new feature (MINOR version bump, e.g., 1.0.0 -> 1.1.0)
-- **feat!** or **fix!** (or generic **BREAKING CHANGE** in footer): Introduces a breaking change (MAJOR version bump, e.g., 1.0.0 -> 2.0.0)
-- **chore**, **docs**, **style**, **refactor**, **test**: No version bump (usually)
+- **BREAKING CHANGE** in the commit footer: Introduces a breaking change (MAJOR version bump, e.g., 1.0.0 -> 2.0.0)
 
 ### How to Release
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/better-notion-mcp
 
-**Markdown-first Notion API server for AI agents -- 10 composite tools replacing 28+ endpoint calls**
+**Markdown-first Notion API server for AI agents -- 11 composite tools replacing 28+ endpoint calls**
 
 <!-- Badge Row 1: Status -->
 [![CI](https://github.com/n24q02m/better-notion-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/better-notion-mcp/actions/workflows/ci.yml)
@@ -27,7 +27,7 @@ mcp-name: io.github.n24q02m/better-notion-mcp
 | [better-code-review-graph](https://github.com/n24q02m/better-code-review-graph) | Knowledge graph for token-efficient code reviews -- fixed search, configurabl... | MCP |
 | [better-email-mcp](https://github.com/n24q02m/better-email-mcp) | IMAP/SMTP email server for AI agents -- 6 composite tools with multi-account ... | MCP |
 | [better-godot-mcp](https://github.com/n24q02m/better-godot-mcp) | Composite MCP server for Godot Engine -- 17 mega-tools for AI-assisted game d... | MCP |
-| [better-notion-mcp](https://github.com/n24q02m/better-notion-mcp) | Markdown-first Notion API server for AI agents -- 10 composite tools replacin... | MCP |
+| [better-notion-mcp](https://github.com/n24q02m/better-notion-mcp) | Markdown-first Notion API server for AI agents -- 11 composite tools replacin... | MCP |
 | [better-telegram-mcp](https://github.com/n24q02m/better-telegram-mcp) | MCP server for Telegram with dual-mode support: Bot API (httpx) for quick bot... | MCP |
 | [claude-plugins](https://github.com/n24q02m/claude-plugins) | Full documentation: mcp.n24q02m.com — unified docs for all 8 servers + the mc... | Marketplace |
 | [imagine-mcp](https://github.com/n24q02m/imagine-mcp) | Production-grade MCP server for image and video understanding + generation ac... | MCP |
@@ -63,7 +63,7 @@ mcp-name: io.github.n24q02m/better-notion-mcp
 ## Features
 
 - **Markdown in, Markdown out** -- human-readable content instead of raw JSON blocks
-- **10 composite tools** with 44 actions -- one call instead of chaining 2+ atomic endpoints
+- **11 composite tools** with 44 actions -- one call instead of chaining 2+ atomic endpoints
 - **Auto-pagination and bulk operations** -- no manual cursor handling or looping
 - **Tiered token optimization** -- ~77% reduction via compressed descriptions + on-demand `help` tool
 - **Dual transport** -- local stdio (token) or remote HTTP (OAuth 2.1, no token needed)
@@ -112,7 +112,8 @@ Full docs at **[mcp.n24q02m.com/servers/better-notion-mcp/](https://mcp.n24q02m.
 | `comments` | `list`, `get`, `create` | Page and block comments |
 | `content_convert` | `markdown-to-blocks`, `blocks-to-markdown` | Convert between Markdown and Notion blocks |
 | `file_uploads` | `create`, `send`, `complete`, `retrieve`, `list` | Upload files to Notion |
-| `setup` | `status`, `start`, `reset`, `complete` | Credential setup via browser relay, status check, reset, re-resolve |
+| `config` | `status`, `setup_start`, `setup_reset`, `setup_complete`, `set`, `cache_clear` | Manage server configuration and credential state via browser relay |
+| `config__open_relay` | - | Open the relay configuration form in the browser and return the relay URL + credential state |
 | `help` | - | Get full documentation for any tool |
 
 ### MCP Resources
@@ -178,7 +179,7 @@ bun run dev
 
 ## Trust Model
 
-This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-NearZK** (in-memory, ephemeral). See [the trust model reference](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-notion-mcp",
-  "description": "Markdown-first MCP server for Notion API with 9 composite tools and 39+ actions.",
+  "description": "Markdown-first MCP server for Notion API with 11 composite tools and 39+ actions.",
   "repository": {
     "url": "https://github.com/n24q02m/better-notion-mcp.git",
     "source": "github"

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -8,8 +8,7 @@
  * token storage. Single-user paste-token relay form is no longer supported
  * here -- use stdio mode with NOTION_TOKEN env for single-user setups.
  *
- * Required env: NOTION_OAUTH_CLIENT_ID, NOTION_OAUTH_CLIENT_SECRET,
- * DCR_SERVER_SECRET (multi-user JWT signing).
+ * Required env: NOTION_OAUTH_CLIENT_ID, NOTION_OAUTH_CLIENT_SECRET.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks'


### PR DESCRIPTION
Docs/config drift fixes from the multi-repo docs audit. All findings verified against source before editing.

## Findings

1. **Tool-count drift (10/9 -> 11)** — `src/tools/registry.ts` `TOOLS` array registers exactly 11 tools (pages, databases, blocks, users, workspace, comments, content_convert, file_uploads, help, config, config__open_relay). Updated README header, Features bullet, cross-promo mirror line, `.claude-plugin/plugin.json`, `server.json`, and `CLAUDE.md` to 11.
2. **Renamed tool `setup` -> `config`** — actual tool name in source is `config` (registry.ts:388). README Tools table still listed a `setup` row with stale actions; replaced with `config` (real actions: status, setup_start, setup_reset, setup_complete, set, cache_clear).
3. **`config__open_relay` missing from tool-surface table** — added a row to the README Tools table.
4. **Phantom `DCR_SERVER_SECRET`** — referenced only in the `http.ts` JSDoc "Required env" comment (lines 11-13); never read or validated anywhere in code (only NOTION_OAUTH_CLIENT_ID/SECRET are validated, http.ts:49-53). Removed the dead doc reference from the comment. No code logic touched.
5. **Dead link `mcp-core/docs/TRUST-MODEL.md`** — GitHub blob + raw both 404; the trust model now lives on the docs site. Repointed to `https://mcp.n24q02m.com/servers/mcp-core/trust-model/` (verified 200). The `servers/notion/` 404 slug does not appear in this repo (README already uses the correct `servers/better-notion-mcp/` slug — verified 200), so nothing to change there.
6. **CONTRIBUTING.md commit-type list** — contradicted the repo's feat/fix-only enforcement (pre-commit hook). Trimmed the type list and `!`/extra-type examples to fix/feat only, matching enforcement.

## Verification
- `bun run check` (biome + tsc --noEmit) passes (pre-existing biome schema-version info notice unrelated to this change).
- Pre-commit hooks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)