### PR TITLE
fix: add Comparison capability matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ mcp-name: io.github.n24q02m/better-notion-mcp
 - [Documentation](#documentation)
 - [Tools](#tools)
 - [Configuration](#configuration)
+- [Comparison](#comparison)
 - [Security](#security)
 - [Build from Source](#build-from-source)
 - [Trust Model](#trust-model)
@@ -160,6 +161,20 @@ docker run -p 8080:8080 \
   -e NOTION_OAUTH_CLIENT_SECRET=your-client-secret \
   n24q02m/better-notion-mcp:latest
 ```
+
+## Comparison
+
+How better-notion-mcp stacks up against direct competitors in each pillar:
+
+| Capability | better-notion-mcp | makenotion/notion-mcp-server | suekou/mcp-notion-server | awkoy/notion-mcp-server |
+|---|---|---|---|---|
+| Markdown in / out | Yes (round-trip on pages + blocks) | No (raw Notion JSON) | partial (experimental, append + opt-in convert) | Yes (round-trip + GFM) |
+| Composite tool design | Yes (11 tools, 44 actions) | No (22 endpoint-mapped tools) | partial (simplified + raw JSON tools) | Yes (2 dispatch tools, 35+ ops) |
+| File uploads to Notion | Yes (`file_uploads`, single + multi-part) | No | No | Yes (`upload_file`, single + multi-part) |
+| Comments | Yes (`comments`: list/get/create) | Yes | Yes | Yes |
+| Remote HTTP + OAuth 2.1 transport | Yes (per-JWT-sub multi-user) | partial (HTTP + bearer token, no OAuth) | No (stdio token only) | No (stdio token only) |
+| Self-hostable | Yes (Docker, own OAuth app) | Yes | Yes | Yes |
+| License | MIT | ? | MIT | MIT |
 
 ## Security
 


### PR DESCRIPTION
## What

Adds the missing `## Comparison` section to the README, matching the Tier-1 house style used by sibling repos (`wet-mcp`, `mnemo-mcp`): a capability matrix versus named, real competitor Notion MCP servers. Also adds the section to the Table of contents. Placed immediately before `## Security`, matching `wet-mcp`'s relative position (Comparison directly before Security).

## Our capabilities (derived from this repo's code)

All "better-notion-mcp" cells trace to actual code, not aspiration:
- Markdown round-trip: `content_convert` tool + markdown handling in `pages`/`blocks` (`src/tools/registry.ts`).
- 11 composite tools / 44 actions: `TOOLS` array in `src/tools/registry.ts`.
- `file_uploads` single + multi-part: `src/tools/composite/file-uploads.ts`.
- `comments` list/get/create: `src/tools/composite/comments.ts`.
- Remote HTTP + OAuth 2.1, per-JWT-sub multi-user: `src/transports/http.ts`, `src/auth/notion-token-store.ts`.
- Self-host via Docker + own OAuth app: README Self-Hosting section.
- License MIT: `LICENSE`.

## Competitor sources (fact-check these)

| Competitor | Source | Verified |
|---|---|---|
| makenotion/notion-mcp-server (official) | https://github.com/makenotion/notion-mcp-server/blob/main/README.md | Raw Notion JSON (no markdown convert in local server); 22 endpoint-mapped tools (v2.0.0); HTTP + **bearer token** (not OAuth) — marked `partial`; comments Yes; self-host Yes (npm/Docker). License **could not be confirmed** from README -> cell = `?`. File uploads: not mentioned -> `No`. |
| suekou/mcp-notion-server | https://github.com/suekou/mcp-notion-server/blob/main/README.md | Markdown experimental + opt-in convert + safe append -> `partial`; stdio token only (no remote/OAuth) -> `No`; both simplified + raw JSON tools -> composite `partial`; comments Yes; self-host Yes; file uploads not mentioned -> `No`; License MIT. |
| awkoy/notion-mcp-server | https://github.com/awkoy/notion-mcp-server/blob/main/README.md | Markdown round-trip + GFM -> `Yes`; 2 dispatch tools (`notion_execute`/`notion_describe`) over 35+ ops -> composite `Yes`; `upload_file` single+multi-part -> `Yes`; 5 comment ops -> `Yes`; stdio token only -> `No` remote/OAuth; self-host Docker/Podman -> `Yes`; License MIT. |

## Per-competitor verification notes

- **makenotion**: One cell intentionally left `?` (License) — not stated in the README I fetched; did not fabricate. The README explicitly notes the local repo is being de-prioritized in favor of the remote Notion MCP service; "Markdown editing" belongs to the *remote* service, so the local-server row is `No`.
- **suekou**: Markdown is gated behind `NOTION_MARKDOWN_CONVERSION=true` and documented as experimental/lossy on edit -> `partial`, not `Yes`.
- **awkoy**: All cells verified directly from README. No remote/OAuth transport documented.

## Anti-fabrication

No invented capabilities, metrics, or marketing superlatives. Cells are Yes/No/partial only where verifiable from each competitor's README; the one unverifiable cell uses `?`.

## Checks

`bun run check` (biome + tsc --noEmit) passes; the only output is a pre-existing biome schema-version `info` notice unrelated to this change. Markdown is not linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive comparison section providing details on how the tool compares against other Notion MCP servers. The comparison highlights key differences across multiple capability areas including Markdown round-trip support, composite tool design, file upload handling, comments functionality, remote HTTP and OAuth 2.1 transport options, self-hostability, and licensing terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->