### PR TITLE
[FIX] Complex blocks function

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -29,6 +29,161 @@ export interface BlocksInput {
 }
 
 /**
+ * Retrieve a block
+ * Maps to: GET /v1/blocks/{id}
+ */
+async function handleBlockGet(notion: Client, input: BlocksInput): Promise<any> {
+  const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+  return {
+    action: 'get',
+    block_id: block.id,
+    type: block.type,
+    has_children: block.has_children,
+    archived: block.archived,
+    block
+  }
+}
+
+/**
+ * List block children
+ * Maps to: GET /v1/blocks/{id}/children
+ */
+async function handleBlockChildren(notion: Client, input: BlocksInput): Promise<any> {
+  const blocksList = await autoPaginate((cursor) =>
+    notion.blocks.children.list({
+      block_id: input.block_id,
+      start_cursor: cursor,
+      page_size: 100
+    })
+  )
+
+  // Recursively fetch children for blocks that need them (tables, toggles, columns)
+  await populateDeepChildren(notion, blocksList as any[])
+
+  const markdown = blocksToMarkdown(blocksList as any)
+  return {
+    action: 'children',
+    block_id: input.block_id,
+    total_children: blocksList.length,
+    markdown,
+    blocks: blocksList
+  }
+}
+
+/**
+ * Append blocks to a block
+ * Maps to: PATCH /v1/blocks/{id}/children
+ */
+async function handleBlockAppend(notion: Client, input: BlocksInput): Promise<any> {
+  if (!input.content) {
+    throw new NotionMCPError('content required for append', 'VALIDATION_ERROR', 'Provide markdown content')
+  }
+  if (input.position === 'after_block' && !input.after_block_id) {
+    throw new NotionMCPError(
+      'after_block_id required when position is after_block',
+      'VALIDATION_ERROR',
+      'Provide after_block_id with the block ID to insert after'
+    )
+  }
+  const blocksList = markdownToBlocks(input.content)
+  const appendParams: any = {
+    block_id: input.block_id,
+    children: blocksList as any
+  }
+  if (input.position === 'start') {
+    appendParams.position = { type: 'start' }
+  } else if (input.position === 'after_block' && input.after_block_id) {
+    appendParams.position = { type: 'after_block', after_block: { id: input.after_block_id } }
+  }
+  await notion.blocks.children.append(appendParams)
+  return {
+    action: 'append',
+    block_id: input.block_id,
+    appended_count: blocksList.length
+  }
+}
+
+/**
+ * Update a block
+ * Maps to: PATCH /v1/blocks/{id}
+ */
+async function handleBlockUpdate(notion: Client, input: BlocksInput): Promise<any> {
+  if (!input.content) {
+    throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
+  }
+  const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+  const blockType = block.type
+  const newBlocks = markdownToBlocks(input.content)
+
+  if (newBlocks.length === 0) {
+    throw new NotionMCPError('Content must produce at least one block', 'VALIDATION_ERROR', 'Invalid markdown')
+  }
+
+  const newContent = newBlocks[0]
+
+  // Validate block type match
+  if (newContent.type !== blockType) {
+    throw new NotionMCPError(
+      `Block type mismatch: cannot update ${blockType} with content that parses to ${newContent.type}`,
+      'VALIDATION_ERROR',
+      `Provide markdown that parses to ${blockType}`
+    )
+  }
+
+  const updatePayload: any = {}
+
+  // Build update based on block type
+  if (UPDATABLE_BLOCK_TYPES.has(blockType)) {
+    if (blockType === 'to_do') {
+      updatePayload.to_do = {
+        rich_text: (newContent as any).to_do?.rich_text || [],
+        checked: (newContent as any).to_do?.checked ?? block.to_do?.checked ?? false
+      }
+    } else if (blockType === 'code') {
+      updatePayload.code = {
+        rich_text: (newContent as any).code?.rich_text || [],
+        language: (newContent as any).code?.language || block.code?.language || 'plain text'
+      }
+    } else {
+      updatePayload[blockType] = {
+        rich_text: (newContent as any)[blockType]?.rich_text || []
+      }
+    }
+  } else {
+    throw new NotionMCPError(
+      `Block type '${blockType}' cannot be updated`,
+      'VALIDATION_ERROR',
+      'Only text-based blocks (paragraph, headings, lists, quote, to_do, code) can be updated'
+    )
+  }
+
+  await notion.blocks.update({
+    block_id: input.block_id,
+    ...updatePayload
+  } as any)
+
+  return {
+    action: 'update',
+    block_id: input.block_id,
+    type: blockType,
+    updated: true
+  }
+}
+
+/**
+ * Delete a block
+ * Maps to: DELETE /v1/blocks/{id}
+ */
+async function handleBlockDelete(notion: Client, input: BlocksInput): Promise<any> {
+  await notion.blocks.delete({ block_id: input.block_id })
+  return {
+    action: 'delete',
+    block_id: input.block_id,
+    deleted: true
+  }
+}
+
+/**
  * Unified blocks tool
  * Maps to: GET/PATCH/DELETE /v1/blocks/{id} and GET/PATCH /v1/blocks/{id}/children
  */
@@ -39,141 +194,16 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
     }
 
     switch (input.action) {
-      case 'get': {
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
-        return {
-          action: 'get',
-          block_id: block.id,
-          type: block.type,
-          has_children: block.has_children,
-          archived: block.archived,
-          block
-        }
-      }
-
-      case 'children': {
-        const blocksList = await autoPaginate((cursor) =>
-          notion.blocks.children.list({
-            block_id: input.block_id,
-            start_cursor: cursor,
-            page_size: 100
-          })
-        )
-
-        // Recursively fetch children for blocks that need them (tables, toggles, columns)
-        await populateDeepChildren(notion, blocksList as any[])
-
-        const markdown = blocksToMarkdown(blocksList as any)
-        return {
-          action: 'children',
-          block_id: input.block_id,
-          total_children: blocksList.length,
-          markdown,
-          blocks: blocksList
-        }
-      }
-
-      case 'append': {
-        if (!input.content) {
-          throw new NotionMCPError('content required for append', 'VALIDATION_ERROR', 'Provide markdown content')
-        }
-        if (input.position === 'after_block' && !input.after_block_id) {
-          throw new NotionMCPError(
-            'after_block_id required when position is after_block',
-            'VALIDATION_ERROR',
-            'Provide after_block_id with the block ID to insert after'
-          )
-        }
-        const blocksList = markdownToBlocks(input.content)
-        const appendParams: any = {
-          block_id: input.block_id,
-          children: blocksList as any
-        }
-        if (input.position === 'start') {
-          appendParams.position = { type: 'start' }
-        } else if (input.position === 'after_block' && input.after_block_id) {
-          appendParams.position = { type: 'after_block', after_block: { id: input.after_block_id } }
-        }
-        await notion.blocks.children.append(appendParams)
-        return {
-          action: 'append',
-          block_id: input.block_id,
-          appended_count: blocksList.length
-        }
-      }
-
-      case 'update': {
-        if (!input.content) {
-          throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
-        }
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
-        const blockType = block.type
-        const newBlocks = markdownToBlocks(input.content)
-
-        if (newBlocks.length === 0) {
-          throw new NotionMCPError('Content must produce at least one block', 'VALIDATION_ERROR', 'Invalid markdown')
-        }
-
-        const newContent = newBlocks[0]
-
-        // Validate block type match
-        if (newContent.type !== blockType) {
-          throw new NotionMCPError(
-            `Block type mismatch: cannot update ${blockType} with content that parses to ${newContent.type}`,
-            'VALIDATION_ERROR',
-            `Provide markdown that parses to ${blockType}`
-          )
-        }
-
-        const updatePayload: any = {}
-
-        // Build update based on block type
-        if (UPDATABLE_BLOCK_TYPES.has(blockType)) {
-          if (blockType === 'to_do') {
-            updatePayload.to_do = {
-              rich_text: (newContent as any).to_do?.rich_text || [],
-              checked: (newContent as any).to_do?.checked ?? block.to_do?.checked ?? false
-            }
-          } else if (blockType === 'code') {
-            updatePayload.code = {
-              rich_text: (newContent as any).code?.rich_text || [],
-              language: (newContent as any).code?.language || block.code?.language || 'plain text'
-            }
-          } else {
-            updatePayload[blockType] = {
-              rich_text: (newContent as any)[blockType]?.rich_text || []
-            }
-          }
-        } else {
-          throw new NotionMCPError(
-            `Block type '${blockType}' cannot be updated`,
-            'VALIDATION_ERROR',
-            'Only text-based blocks (paragraph, headings, lists, quote, to_do, code) can be updated'
-          )
-        }
-
-        await notion.blocks.update({
-          block_id: input.block_id,
-          ...updatePayload
-        } as any)
-
-        return {
-          action: 'update',
-          block_id: input.block_id,
-          type: blockType,
-          updated: true
-        }
-      }
-
-      case 'delete': {
-        await notion.blocks.delete({ block_id: input.block_id })
-        return {
-          action: 'delete',
-          block_id: input.block_id,
-          deleted: true
-        }
-      }
-
+      case 'get':
+        return handleBlockGet(notion, input)
+      case 'children':
+        return handleBlockChildren(notion, input)
+      case 'append':
+        return handleBlockAppend(notion, input)
+      case 'update':
+        return handleBlockUpdate(notion, input)
+      case 'delete':
+        return handleBlockDelete(notion, input)
       default:
         throw new NotionMCPError(
           `Unknown action: ${input.action}`,


### PR DESCRIPTION
The `blocks` mega-tool function in `src/tools/composite/blocks.ts` was becoming complex as it handled multiple block operations (get, children, append, update, delete) within a single switch statement.

This change extracts each action's logic into dedicated internal handler functions (`handleBlockGet`, `handleBlockChildren`, etc.), improving readability and maintainability while preserving all existing functionality.

- Extracted handler functions for each block action
- Updated dispatcher logic in the main `blocks` tool
- Verified behavior parity with existing test suite
- Migrated biome.json schema to align with environment CLI version

---
*PR created automatically by Jules for task [1400497721019582972](https://jules.google.com/task/1400497721019582972) started by @n24q02m*