### PR TITLE
[FIX] Deeply nested conditional in page duplication

### DIFF
--- a/merge_diff.txt
+++ b/merge_diff.txt
@@ -1,0 +1,48 @@
+<<<<<<< SEARCH
+/**
+ * Duplicate page
+ * Maps to: GET /v1/pages/{id} + POST /v1/pages + GET/PATCH /v1/blocks
+ */
+async function duplicatePage(notion: Client, input: PagesInput): Promise<DuplicatePageResult> {
+=======
+/**
+ * Strip read-only fields and null values from block data.
+ * Notion API rejects null where it expects an object or undefined.
+ */
+function stripNullValues(block: any): any {
+  const {
+    id,
+    parent,
+    created_time,
+    last_edited_time,
+    created_by,
+    last_edited_by,
+    has_children,
+    archived,
+    in_trash,
+    request_id,
+    object,
+    ...rest
+  } = block
+
+  const blockType = rest.type
+  if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
+    const data = rest[blockType]
+    const keys = Object.keys(data)
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      if (data[key] === null) {
+        delete data[key]
+      }
+    }
+  }
+
+  return rest
+}
+
+/**
+ * Duplicate page
+ * Maps to: GET /v1/pages/{id} + POST /v1/pages + GET/PATCH /v1/blocks
+ */
+async function duplicatePage(notion: Client, input: PagesInput): Promise<DuplicatePageResult> {
+>>>>>>> REPLACE

--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -833,6 +833,55 @@ describe('pages', () => {
       })
     })
 
+    it('strips null values from blocks during duplication', async () => {
+      mockNotion.pages.retrieve.mockResolvedValue({
+        id: 'orig-null',
+        parent: { type: 'page_id', page_id: 'parent-1' },
+        properties: {},
+        icon: null,
+        cover: null
+      })
+      mockNotion.blocks.children.list.mockResolvedValue({
+        results: [
+          {
+            id: 'block-null',
+            type: 'paragraph',
+            paragraph: {
+              rich_text: [],
+              color: 'default',
+              caption: null // This should be stripped
+            }
+          }
+        ],
+        next_cursor: null,
+        has_more: false
+      })
+      mockNotion.pages.create.mockResolvedValue({
+        id: 'dup-null',
+        url: 'https://notion.so/dup-null'
+      })
+      mockNotion.blocks.children.append.mockResolvedValue({ results: [] })
+
+      await pages(mockNotion as any, {
+        action: 'duplicate',
+        page_id: 'orig-null'
+      })
+
+      expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({
+        block_id: 'dup-null',
+        children: [
+          {
+            type: 'paragraph',
+            paragraph: {
+              rich_text: [],
+              color: 'default'
+              // caption should be gone
+            }
+          }
+        ]
+      })
+    })
+
     it('skips block append when original has no blocks', async () => {
       mockNotion.pages.retrieve.mockResolvedValue({
         id: 'orig-2',

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -483,6 +483,41 @@ async function archivePage(notion: Client, input: PagesInput): Promise<ArchivePa
 }
 
 /**
+ * Strip read-only fields and null values from block data.
+ * Notion API rejects null where it expects an object or undefined.
+ */
+function stripNullValues(block: any): any {
+  const {
+    id,
+    parent,
+    created_time,
+    last_edited_time,
+    created_by,
+    last_edited_by,
+    has_children,
+    archived,
+    in_trash,
+    request_id,
+    object,
+    ...rest
+  } = block
+
+  const blockType = rest.type
+  if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
+    const data = rest[blockType]
+    const keys = Object.keys(data)
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      if (data[key] === null) {
+        delete data[key]
+      }
+    }
+  }
+
+  return rest
+}
+
+/**
  * Duplicate page
  * Maps to: GET /v1/pages/{id} + POST /v1/pages + GET/PATCH /v1/blocks
  */
@@ -537,33 +572,7 @@ async function duplicatePage(notion: Client, input: PagesInput): Promise<Duplica
 
       // Copy content — strip read-only fields that the create endpoint rejects
       if (originalBlocks.length > 0) {
-        const sanitizedBlocks = originalBlocks.map((block: any) => {
-          const {
-            id,
-            parent,
-            created_time,
-            last_edited_time,
-            created_by,
-            last_edited_by,
-            has_children,
-            archived,
-            in_trash,
-            request_id,
-            object,
-            ...rest
-          } = block
-          // Strip null values inside block type data (e.g., paragraph.icon: null)
-          // Notion API rejects null where it expects object or undefined
-          const blockType = rest.type
-          if (blockType && rest[blockType] && typeof rest[blockType] === 'object') {
-            for (const key of Object.keys(rest[blockType])) {
-              if (rest[blockType][key] === null) {
-                delete rest[blockType][key]
-              }
-            }
-          }
-          return rest
-        })
+        const sanitizedBlocks = originalBlocks.map(stripNullValues)
         await notion.blocks.children.append({
           block_id: duplicatedPage.id,
           children: sanitizedBlocks as any


### PR DESCRIPTION
Extracted the block property cleanup logic into a `stripNullValues` helper function in `src/tools/composite/pages.ts` to reduce nesting and improve readability in `duplicatePage`. The helper function uses an optimized indexed `for` loop over cached keys (`Object.keys(obj)`) to remove `null` values from block-type-specific data, aligning with repository performance standards. Added a regression test case in `src/tools/composite/pages.test.ts` to verify the fix.

---
*PR created automatically by Jules for task [4813791767109432811](https://jules.google.com/task/4813791767109432811) started by @n24q02m*