### PR TITLE
[CLEANUP] Potential Unsafe Allocation via Buffer.from without Length Limit Check Prior to Validation

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -179,8 +179,8 @@ describe('isValidBase64', () => {
     spy.mockRestore()
   })
   it('should reject string that exceeds maximum length', () => {
-    // MAX_BASE64_LENGTH is 64MB. Let's create a string slightly larger.
-    const largeStr = 'a'.repeat(64 * 1024 * 1024 + 4)
+    // MAX_BASE64_LENGTH is 20MB. Let's create a string slightly larger.
+    const largeStr = 'a'.repeat(20 * 1024 * 1024 + 4)
     expect(isValidBase64(largeStr)).toBe(false)
   })
 })

--- a/src/tools/helpers/id.ts
+++ b/src/tools/helpers/id.ts
@@ -34,8 +34,8 @@ export function formatId(id: string): string {
   return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20)}`
 }
 
-/** Maximum length for base64 string to prevent OOM during validation (64MB) */
-const MAX_BASE64_LENGTH = 64 * 1024 * 1024
+/** Maximum length for base64 string to prevent OOM during validation (20MB) to mitigate OOM attacks prior to canonicality check */
+const MAX_BASE64_LENGTH = 20 * 1024 * 1024
 
 /**
  * Check if a string is valid base64 encoding


### PR DESCRIPTION
Tightens the base64 length limit in `isValidBase64` to 20MB (previously 64MB) and adds an explanatory comment. This change mitigates potential Out-of-Memory (OOM) attacks during the strict canonicality validation step, which involves a memory-intensive Buffer roundtrip. The 20MB limit remains sufficient to support Notion's 10MB per-request file upload limit.

Key changes:
- Updated `MAX_BASE64_LENGTH` in `src/tools/helpers/id.ts`.
- Added security-focused comment to the constant.
- Updated large string boundary test in `src/tools/helpers/id.test.ts`.
- Verified all 800 tests pass.

---
*PR created automatically by Jules for task [2568925606554633187](https://jules.google.com/task/2568925606554633187) started by @n24q02m*