### PR TITLE
[TEST] Missing tests for exported entity: initServer

### DIFF
--- a/src/init-server.integration.test.ts
+++ b/src/init-server.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// This test verifies the integration between initServer and the actual startServer logic in main.ts
+// while mocking the external transports and SDK classes.
+
+const startHttpMock = vi.fn()
+const stdioConnectMock = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('./transports/http.js', () => ({
+  startHttp: startHttpMock
+}))
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
+  return {
+    Server: class {
+      connect = stdioConnectMock
+    }
+  }
+})
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => {
+  return {
+    StdioServerTransport: class {}
+  }
+})
+
+vi.mock('./tools/registry.js', () => ({
+  registerTools: vi.fn()
+}))
+
+vi.mock('./credential-state.js', () => ({
+  resolveCredentialState: vi.fn().mockResolvedValue(undefined),
+  getNotionToken: vi.fn().mockReturnValue('ntn_test_token')
+}))
+
+// Mock process.exit to prevent test runner from exiting
+vi.spyOn(process, 'exit').mockImplementation((() => {}) as any)
+
+describe('initServer integration', () => {
+  const originalEnv = process.env
+  const originalArgv = process.argv
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = { ...originalEnv, NODE_ENV: 'test', NOTION_TOKEN: 'ntn_test' }
+    process.argv = [...originalArgv]
+    delete process.env.MCP_TRANSPORT
+    delete process.env.TRANSPORT_MODE
+    delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    process.argv = originalArgv
+  })
+
+  it('flows from initServer to startHttp in main.ts when --http is present', async () => {
+    process.argv = [process.argv[0], 'main.js', '--http']
+
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+
+    expect(startHttpMock).toHaveBeenCalled()
+  })
+
+  it('flows from initServer to stdio connect in main.ts by default', async () => {
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+
+    expect(stdioConnectMock).toHaveBeenCalled()
+  })
+})

--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -49,4 +49,17 @@ describe('initServer', () => {
     await initServer()
     expect(startServerMock).toHaveBeenCalledWith('stdio')
   })
+
+  it('does not dispatch http for partial matches like --http-proxy', async () => {
+    process.argv = [process.argv[0], 'main.js', '--http-proxy']
+    const { initServer } = await import('./init-server.js')
+    await initServer()
+    expect(startServerMock).toHaveBeenCalledWith('stdio')
+  })
+
+  it('propagates errors from startServer', async () => {
+    startServerMock.mockRejectedValueOnce(new Error('Startup failed'))
+    const { initServer } = await import('./init-server.js')
+    await expect(initServer()).rejects.toThrow('Startup failed')
+  })
 })


### PR DESCRIPTION
This PR adds missing test coverage for the `initServer` function in `src/init-server.ts`. 

As an entry point, `initServer` is critical for correctly selecting the transport mode (HTTP vs Stdio) based on CLI arguments and environment variables. 

Changes:
1. **Robust Unit Tests**: Updated `src/init-server.test.ts` to ensure that `--http` is matched exactly (avoiding false positives like `--http-proxy`) and that errors from the underlying server startup are correctly propagated.
2. **Integration Verification**: Created `src/init-server.integration.test.ts` which exercises the real logic in `src/main.ts` (without mocking the module itself) while isolating the test from real network/IO by mocking only the transport and SDK classes.

These additions ensure the server entry point is reliable and correctly routes to the appropriate transport.

---
*PR created automatically by Jules for task [2295142160219861745](https://jules.google.com/task/2295142160219861745) started by @n24q02m*