### PR TITLE
[TEST] Missing tests for exported entity: formatId

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -122,6 +122,18 @@ describe('formatId', () => {
   it('should format UUIDs with misplaced hyphens correctly', () => {
     expect(formatId('a3802967-3621-4b04-b6af-bfef-1b76-87b3')).toBe('a3802967-3621-4b04-b6af-bfef1b7687b3')
   })
+
+  it('should return empty string unchanged', () => {
+    expect(formatId('')).toBe('')
+  })
+
+  it('should return string with only whitespace unchanged', () => {
+    expect(formatId('   ')).toBe('   ')
+  })
+
+  it('should return 32-character string with non-hex symbols unchanged', () => {
+    expect(formatId('a380296736214b04b6afbfef1b7687b!')).toBe('a380296736214b04b6afbfef1b7687b!')
+  })
 })
 
 describe('isValidBase64', () => {


### PR DESCRIPTION
This PR adds missing unit tests for the `formatId` utility in `src/tools/helpers/id.ts`. 

While the function already had some basic tests, the task indicated missing coverage/tests for this entity. I have added additional test cases for edge cases such as:
- Empty strings
- Strings with only whitespace
- 32-character strings with non-hex symbols

All tests passed with 100% statement and branch coverage for the `id.ts` module.

---
*PR created automatically by Jules for task [8436724530338399428](https://jules.google.com/task/8436724530338399428) started by @n24q02m*