### PR TITLE
[FIX] P0 fork-bomb fix

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -241,7 +241,22 @@ describe('main.ts', () => {
       // Second call should be aborted
       await bootstrap('stdio')
       expect(stdioConnectMock).toHaveBeenCalledTimes(1)
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Bootstrap aborted'))
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Startup aborted'))
+
+      consoleSpy.mockRestore()
+      delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED
+    })
+
+    it('verifies fork-bomb protection in startServer directly', async () => {
+      process.env.NOTION_TOKEN = 'ntn_test_token'
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      await startServer('stdio')
+      expect(stdioConnectMock).toHaveBeenCalledTimes(1)
+
+      await startServer('stdio')
+      expect(stdioConnectMock).toHaveBeenCalledTimes(1)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Startup aborted'))
 
       consoleSpy.mockRestore()
       delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,12 @@ export function getTransportMode(env: NodeJS.ProcessEnv = process.env): string {
  * Dynamically imports and starts the server for the specified mode.
  */
 export async function startServer(mode: string): Promise<void> {
+  if (process.env.BETTER_NOTION_MCP_BOOTSTRAPPED) {
+    console.error('[better-notion-mcp] Startup aborted: server already running in this process tree.')
+    return
+  }
+  process.env.BETTER_NOTION_MCP_BOOTSTRAPPED = 'true'
+
   if (mode === 'http') {
     const { startHttp } = await import('./transports/http.js')
     await startHttp()
@@ -123,12 +129,6 @@ export const mode = getTransportMode()
  * Bootstrap function to start the server with error handling.
  */
 export async function bootstrap(selectedMode: string = mode) {
-  if (process.env.BETTER_NOTION_MCP_BOOTSTRAPPED) {
-    console.error('[better-notion-mcp] Bootstrap aborted: server already running in this process tree.')
-    return
-  }
-  process.env.BETTER_NOTION_MCP_BOOTSTRAPPED = 'true'
-
   try {
     await startServer(selectedMode)
   } catch (error) {
@@ -136,6 +136,7 @@ export async function bootstrap(selectedMode: string = mode) {
     process.exit(1)
   }
 }
+// Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)
 
 // Only execute bootstrap if we're the main module and not in a test environment.
 if (isMain(import.meta.url) && process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
This PR addresses the P0 fork-bomb fix by relocating the protection guard from the `bootstrap` wrapper to the core `startServer` function in `src/main.ts`. 

Previously, the guard was only in `bootstrap`, meaning direct calls to `startServer` (e.g., from `init-server.ts`) could bypass the protection. By moving it into `startServer`, we ensure that any attempt to start the server within the same process tree is blocked if it's already running.

Changes:
- Relocated `BETTER_NOTION_MCP_BOOTSTRAPPED` check to the top of `startServer`.
- Updated error message from "Bootstrap aborted" to "Startup aborted".
- Added the rebuild target comment: `// Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)`.
- Updated existing tests and added a new test case in `src/main.test.ts` to verify the protection on direct `startServer` calls.

---
*PR created automatically by Jules for task [14319220639642816191](https://jules.google.com/task/14319220639642816191) started by @n24q02m*