### PR TITLE
[FIX] N+1 Query in deleteDatabasePages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -653,6 +653,40 @@ describe('databases', () => {
     it('should throw when no page ids provided', async () => {
       await expect(databases(notion, { action: 'delete_page' })).rejects.toThrow('page_id or page_ids required')
     })
+
+    it('should deduplicate page IDs', async () => {
+      mockNotion.pages.update.mockResolvedValue({})
+
+      const result = (await databases(notion, {
+        action: 'delete_page',
+        page_ids: ['page-1', 'page-1', 'page-2', 'page-2', 'page-2']
+      })) as DeleteDatabasePageResponse
+
+      expect(result.processed).toBe(2)
+      expect(mockNotion.pages.update).toHaveBeenCalledTimes(2)
+      expect(result.results).toEqual([
+        { page_id: 'page-1', deleted: true },
+        { page_id: 'page-2', deleted: true }
+      ])
+    })
+
+    it('should retry on transient failures using retryWithBackoff', async () => {
+      const error = new Error('Rate limited') as any
+      error.code = 'rate_limited'
+
+      mockNotion.pages.update
+        .mockRejectedValueOnce(error) // Fail once
+        .mockResolvedValueOnce({}) // Succeed on retry
+
+      const result = (await databases(notion, {
+        action: 'delete_page',
+        page_id: 'page-retry'
+      })) as DeleteDatabasePageResponse
+
+      expect(result.processed).toBe(1)
+      expect(mockNotion.pages.update).toHaveBeenCalledTimes(2)
+      expect(result.results[0]).toEqual({ page_id: 'page-retry', deleted: true })
+    })
   })
 
   describe('create_data_source', () => {

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -5,7 +5,7 @@
 
 import type { Client } from '@notionhq/client'
 import { formatCover } from '../helpers/covers.js'
-import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
+import { NotionMCPError, retryWithBackoff, withErrorHandling } from '../helpers/errors.js'
 import { formatIcon } from '../helpers/icons.js'
 import { normalizeId } from '../helpers/id.js'
 import { autoPaginate, processBatches } from '../helpers/pagination.js'
@@ -647,12 +647,17 @@ async function deleteDatabasePages(notion: Client, input: DatabasesInput): Promi
     throw new NotionMCPError('page_id or page_ids required', 'VALIDATION_ERROR', 'Provide page IDs to delete')
   }
 
+  // Deduplicate page IDs
+  const uniquePageIds = [...new Set(pageIds)]
+
   const results = await processBatches(
-    pageIds,
+    uniquePageIds,
     async (pageId) => {
-      await notion.pages.update({
-        page_id: pageId,
-        archived: true
+      await retryWithBackoff(async () => {
+        await notion.pages.update({
+          page_id: pageId,
+          archived: true
+        })
       })
 
       return {


### PR DESCRIPTION
The deleteDatabasePages function was making redundant API calls for duplicate page IDs and lacked retry logic for transient Notion API errors. This PR implements page ID deduplication and wraps the update calls with retryWithBackoff to improve reliability and performance, aligning with other bulk operations in the codebase.

---
*PR created automatically by Jules for task [13198298441029987165](https://jules.google.com/task/13198298441029987165) started by @n24q02m*