### PR TITLE
[TEST] Missing tests for exported entity: isValidNotionId

### DIFF
--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -84,6 +84,34 @@ describe('isValidNotionId', () => {
   it('should accept mixed hyphenation', () => {
     expect(isValidNotionId('a38029673621-4b04-b6afbfef1b7687b3')).toBe(true)
   })
+
+  it('should accept single hyphen at the first slot', () => {
+    expect(isValidNotionId('a3802967-36214b04b6afbfef1b7687b3')).toBe(true)
+  })
+
+  it('should accept single hyphen at the second slot', () => {
+    expect(isValidNotionId('a38029673621-4b04b6afbfef1b7687b3')).toBe(true)
+  })
+
+  it('should accept single hyphen at the third slot', () => {
+    expect(isValidNotionId('a380296736214b04-b6afbfef1b7687b3')).toBe(true)
+  })
+
+  it('should accept single hyphen at the fourth slot', () => {
+    expect(isValidNotionId('a380296736214b04b6af-bfef1b7687b3')).toBe(true)
+  })
+
+  it('should reject dots as separators', () => {
+    expect(isValidNotionId('a3802967.3621.4b04.b6af.bfef1b7687b3')).toBe(false)
+  })
+
+  it('should reject underscores as separators', () => {
+    expect(isValidNotionId('a3802967_3621_4b04_b6af_bfef1b7687b3')).toBe(false)
+  })
+
+  it('should reject spaces as separators', () => {
+    expect(isValidNotionId('a3802967 3621 4b04 b6af bfef1b7687b3')).toBe(false)
+  })
 })
 
 describe('formatId', () => {


### PR DESCRIPTION
This PR adds targeted robustness tests for the `isValidNotionId` function in `src/tools/helpers/id.ts`.

While the function already had 100% statement coverage, these additional tests ensure that the optional hyphen logic in the UUID regex is fully exercised and that non-standard separators are strictly rejected.

### Changes
- Added 4 tests for single-hyphen UUID variants.
- Added 3 tests for invalid separators (dots, underscores, spaces).
- Verified that all 48 tests in `id.test.ts` pass with 100% coverage.

---
*PR created automatically by Jules for task [2292913424661634489](https://jules.google.com/task/2292913424661634489) started by @n24q02m*