### PR TITLE
[TEST] Missing tests for exported entity: isValidBase64

### DIFF
--- a/src/tools/composite/file-uploads.test.ts
+++ b/src/tools/composite/file-uploads.test.ts
@@ -178,6 +178,16 @@ describe('fileUploads', () => {
         'file_content is required'
       )
     })
+
+    it('should throw with invalid base64 content', async () => {
+      await expect(
+        fileUploads(mockNotion as any, {
+          action: 'send',
+          file_upload_id: 'upload-123',
+          file_content: 'invalid-base64!'
+        })
+      ).rejects.toThrow('file_content is not valid base64 encoding')
+    })
   })
 
   describe('complete', () => {

--- a/src/tools/helpers/id.test.ts
+++ b/src/tools/helpers/id.test.ts
@@ -178,9 +178,47 @@ describe('isValidBase64', () => {
     expect(isValidBase64('aGVsbG8=')).toBe(false)
     spy.mockRestore()
   })
+
   it('should reject string that exceeds maximum length', () => {
     // MAX_BASE64_LENGTH is 64MB. Let's create a string slightly larger.
     const largeStr = 'a'.repeat(64 * 1024 * 1024 + 4)
     expect(isValidBase64(largeStr)).toBe(false)
+  })
+
+  it('should reject URL-safe base64 characters', () => {
+    // Notion API expects standard base64 (+/), not URL-safe (-_)
+    expect(isValidBase64('aA-_')).toBe(false)
+  })
+
+  it('should reject non-string inputs', () => {
+    // @ts-expect-error
+    expect(isValidBase64(null)).toBe(false)
+    // @ts-expect-error
+    expect(isValidBase64(undefined)).toBe(false)
+    // @ts-expect-error
+    expect(isValidBase64(123)).toBe(false)
+    // @ts-expect-error
+    expect(isValidBase64({ key: 'value' })).toBe(false)
+    // @ts-expect-error
+    expect(isValidBase64(['a', 'b'])).toBe(false)
+  })
+
+  it('should reject strings with other special characters', () => {
+    expect(isValidBase64('aGVsbG8#')).toBe(false)
+    expect(isValidBase64('aGVsbG8@')).toBe(false)
+    expect(isValidBase64('aGVsbG8*')).toBe(false)
+  })
+
+  it('should reject padding characters in the middle', () => {
+    expect(isValidBase64('a=GVsbG8')).toBe(false)
+    expect(isValidBase64('aGV=sbG8')).toBe(false)
+  })
+
+  it('should accept diverse valid base64 strings', () => {
+    expect(isValidBase64('YWJj')).toBe(true) // 'abc'
+    expect(isValidBase64('YWJjZA==')).toBe(true) // 'abcd'
+    expect(isValidBase64('YWJjZGU=')).toBe(true) // 'abcde'
+    expect(isValidBase64('YWJjZGVm')).toBe(true) // 'abcdef'
+    expect(isValidBase64('U29tZSB0ZXh0IHdpdGggc3BlY2lhbCBjaGFycyAhQCMkJV4mKigp')).toBe(true)
   })
 })


### PR DESCRIPTION
Added missing test coverage for the `isValidBase64` utility in `src/tools/helpers/id.ts`.

Key changes:
- Enhanced `id.test.ts` with cases for:
    - Non-string inputs (null, undefined, number, object, array).
    - URL-safe base64 characters (`-`, `_`) which are rejected.
    - Invalid special characters (`#`, `@`, `*`).
    - Malformed padding (padding in the middle of the string).
    - Diverse valid base64 strings of varying lengths.
- Added an integration test in `file-uploads.test.ts` to ensure the `file_uploads` tool's `send` action correctly utilizes the validation helper to reject invalid content.
- Ensured all tests pass and maintained 100% coverage for the `id.ts` module.

---
*PR created automatically by Jules for task [1926268576377225984](https://jules.google.com/task/1926268576377225984) started by @n24q02m*