### PR TITLE
fix: reconcile notionClientFactory test with auto-invoke registerTools mock

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -257,7 +257,10 @@ describe('main.ts', () => {
     it('verifies notionClientFactory throws when token is missing', async () => {
       process.env.NOTION_TOKEN = 'ntn_test_token'
       const { getNotionToken } = await import('./credential-state.js')
-      vi.mocked(getNotionToken).mockReturnValueOnce(null)
+      // Persist the null return: the registerTools mock auto-invokes the
+      // factory once (swallowing the throw), so a one-shot mock would be
+      // consumed before this test's explicit factory() assertion below.
+      vi.mocked(getNotionToken).mockReturnValue(null)
 
       await startServer('stdio')
 


### PR DESCRIPTION
## Problem
After merging the open-PR backlog, main CI went red with a single failing test:
`main.test.ts > startServer > verifies notionClientFactory throws when token is missing` -- "expected [Function] to throw an error".

## Root cause
PR #935 changed the `registerTools` mock to auto-invoke the factory (`args[1]()`) inside a swallowing `try/catch` to lift coverage. That auto-invoke consumed the one-shot `getNotionToken` `mockReturnValueOnce(null)` set up by the pre-existing test before the test's own explicit `factory()` assertion ran. The explicit call then saw the default mocked token (`ntn_test_token`) and did not throw.

## Fix
Use a persistent `mockReturnValue(null)` so the token stays null for both the mock's auto-invoke and the test's assertion. Surgical one-line change + comment.

## Verification
- `bun run test`: 861 passed (30 files)
- `bun run check`: biome + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)