### PR TITLE
[TEST] Missing error path test in credential-state.ts

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -88,6 +88,22 @@ describe('credential-state', () => {
       const state = await resolveCredentialState()
       expect(state).toBe('awaiting_setup')
     })
+    it('clears notion token when resolveCredentialState falls back to awaiting_setup', async () => {
+      // 1. Setup a configured state
+      process.env.NOTION_TOKEN = 'initial-token'
+      await resolveCredentialState()
+      expect(getState()).toBe('configured')
+      expect(getNotionToken()).toBe('initial-token')
+
+      // 2. Remove env var and make resolveConfig fail
+      delete process.env.NOTION_TOKEN
+      vi.mocked(resolveConfig).mockRejectedValue(new Error('read error') as never)
+
+      // 3. Resolve again
+      const state = await resolveCredentialState()
+      expect(state).toBe('awaiting_setup')
+      expect(getNotionToken()).toBeNull()
+    })
   })
 
   describe('resetState', () => {

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -98,6 +98,7 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   }
 
   // 3. Nothing found
+  _notionToken = null
   _state = 'awaiting_setup'
   return _state
 }


### PR DESCRIPTION
Fixed a missing error path test in src/credential-state.ts. The resolveCredentialState function was updated to explicitly set _notionToken to null when it falls back to the awaiting_setup state. This prevents a stale token from remaining in memory if the server's configuration is removed or corrupted. A new test case was added to src/credential-state.test.ts to verify that the token is correctly cleared when resolveConfig throws an error.

---
*PR created automatically by Jules for task [5338290844977619040](https://jules.google.com/task/5338290844977619040) started by @n24q02m*