### PR TITLE
[FIX] Exposure of unsanitized input in exception message

### DIFF
--- a/src/tools/helpers/errors.test.ts
+++ b/src/tools/helpers/errors.test.ts
@@ -240,6 +240,34 @@ describe('enhanceError', () => {
       expect(enhanced.details.config).toBeUndefined()
       expect(enhanced.details.request).toBeUndefined()
     })
+
+    it('should redact sensitive information in validation_error path', () => {
+      const sensitiveError = {
+        code: 'validation_error',
+        message: 'Invalid request',
+        body: {
+          message: 'Invalid value',
+          path: 'properties.Password.text[0].text.content:secret-token'
+        }
+      }
+
+      const enhanced = enhanceError(sensitiveError)
+      expect(enhanced.details.path).not.toContain('secret-token')
+    })
+
+    it('should allow safe paths in validation_error', () => {
+      const safeError = {
+        code: 'validation_error',
+        message: 'Invalid request',
+        body: {
+          message: 'Invalid value',
+          path: 'properties.Name.title[0]'
+        }
+      }
+
+      const enhanced = enhanceError(safeError)
+      expect(enhanced.details.path).toBe('properties.Name.title[0]')
+    })
   })
 })
 

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -35,7 +35,15 @@ function sanitizeValidationBody(body: any): any {
 
   for (const field of safeFields) {
     if (field in body) {
-      safe[field] = body[field]
+      if (field === 'path' && typeof body[field] === 'string') {
+        // Sanitize path: allow only alphanumeric, dots, brackets, underscores, hyphens, spaces, and slashes.
+        // We truncate at the first "unsafe" character to avoid leaking potentially sensitive
+        // values that might have been appended (e.g. by a proxy or if Notion includes values in paths).
+        const match = body[field].match(/^[a-zA-Z0-9.[\]_ /-]*/)
+        safe[field] = match ? match[0] : ''
+      } else {
+        safe[field] = body[field]
+      }
     }
   }
 


### PR DESCRIPTION
## [FIX] Exposure of unsanitized input in exception message

### 💡 What
Sanitized the `path` field in `validation_error` responses within `src/tools/helpers/errors.ts`.

### 🎯 Why
The `path` field, while typically a string representing a JSON property path, could potentially contain sensitive information depending on what Notion returns or if there is a proxy in between. Sanitize it to prevent leakage.

### 📊 Impact
- Prevents accidental exposure of sensitive tokens or data that might be present in the `path` field of validation errors.
- Ensures that only safe characters are included in the `path` details.

### 🔬 Measurement
- Added two new unit tests to `src/tools/helpers/errors.test.ts`:
  - `should redact sensitive information in validation_error path`: Verifies that sensitive suffixes in the path are truncated.
  - `should allow safe paths in validation_error`: Verifies that standard Notion property paths (with dots, brackets, slashes) are still correctly reported.
- All 865 tests passed.
- Verified with `bun run check:fix` for formatting and type safety.

---
*PR created automatically by Jules for task [11965924776230138587](https://jules.google.com/task/11965924776230138587) started by @n24q02m*