### PR TITLE
[FIX] Missing Database Container Info Caching (databases.ts)

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -8,6 +8,7 @@ import {
   type GetDatabaseResponse,
   type ListDataSourceTemplatesResponse,
   type QueryDatabaseResponse,
+  resolutionCache,
   schemaCache,
   type UpdateDatabasePageResponse,
   type UpdateDatabaseResponse,
@@ -69,6 +70,7 @@ function makeDataSourceResponse(overrides: Record<string, any> = {}) {
 describe('databases', () => {
   beforeEach(() => {
     schemaCache.clear()
+    resolutionCache.clear()
     vi.resetAllMocks()
   })
 
@@ -423,6 +425,7 @@ describe('databases', () => {
   describe('create_page', () => {
     beforeEach(() => {
       schemaCache.clear()
+      resolutionCache.clear()
       mockNotion.databases.retrieve.mockResolvedValue(makeDbRetrieveResponse())
       mockNotion.dataSources.retrieve.mockResolvedValue(makeDataSourceResponse())
     })

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -15,6 +15,7 @@ import * as RichText from '../helpers/richtext.js'
 // Cache for data source schema (properties)
 export const schemaCache = new Map<string, { properties: any; expiresAt: number }>()
 const SCHEMA_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+export const resolutionCache = new Map<string, { databaseId: string; dataSourceId: string; expiresAt: number }>()
 
 /**
  * Get data source properties with caching
@@ -251,11 +252,18 @@ export type DatabasesResponse =
 async function resolveDataSourceId(notion: Client, id: string): Promise<{ databaseId: string; dataSourceId: string }> {
   const normalized = normalizeId(id)
 
+  const cached = resolutionCache.get(normalized)
+  if (cached && Date.now() < cached.expiresAt) {
+    return { databaseId: cached.databaseId, dataSourceId: cached.dataSourceId }
+  }
+
   // Try as database container first
   try {
     const database: any = await notion.databases.retrieve({ database_id: normalized })
     if (database.data_sources?.length > 0) {
-      return { databaseId: database.id, dataSourceId: database.data_sources[0].id }
+      const result = { databaseId: database.id, dataSourceId: database.data_sources[0].id }
+      resolutionCache.set(normalized, { ...result, expiresAt: Date.now() + SCHEMA_CACHE_TTL })
+      return result
     }
     throw new NotionMCPError(
       'Database has no data sources',
@@ -269,10 +277,12 @@ async function resolveDataSourceId(notion: Client, id: string): Promise<{ databa
     if (error.code === 'object_not_found') {
       try {
         const ds: any = await (notion as any).dataSources.retrieve({ data_source_id: normalized })
-        return {
+        const result = {
           databaseId: ds.parent?.database_id || normalized,
           dataSourceId: ds.id
         }
+        resolutionCache.set(normalized, { ...result, expiresAt: Date.now() + SCHEMA_CACHE_TTL })
+        return result
       } catch {
         throw new NotionMCPError(
           `ID "${id}" is not a valid database or data source`,


### PR DESCRIPTION
Implemented a caching mechanism for database ID resolution in `resolveDataSourceId`.
This avoids redundant Notion API calls when mapping a database container ID to its primary data source ID.

Changes:
- Added `resolutionCache` Map with a 5-minute TTL in `src/tools/composite/databases.ts`.
- Updated `resolveDataSourceId` to check the cache before making API requests and populate it on success.
- Updated `src/tools/composite/databases.test.ts` to clear the cache in `beforeEach` for test isolation.

---
*PR created automatically by Jules for task [13787239808730426813](https://jules.google.com/task/13787239808730426813) started by @n24q02m*