### PR TITLE
[TEST] Missing error path test in comments.ts

### DIFF
--- a/src/tools/composite/comments.test.ts
+++ b/src/tools/composite/comments.test.ts
@@ -405,5 +405,21 @@ describe('commentsManage', () => {
         message: 'Too many requests to Notion API'
       })
     })
+
+    it('should throw generic errors during block retrieve', async () => {
+      const notFoundError = new Error('Not found')
+      ;(notFoundError as any).code = 'object_not_found'
+      mockNotion.comments.list.mockRejectedValue(notFoundError)
+
+      const genericError = new Error('Generic error')
+      mockNotion.blocks.retrieve.mockRejectedValue(genericError)
+
+      await expect(
+        commentsManage(mockNotion as any, {
+          action: 'list',
+          page_id: 'page-1'
+        })
+      ).rejects.toThrow('Generic error')
+    })
   })
 })


### PR DESCRIPTION
Add test coverage for generic error propagation in the \`verifyBlockExists\` function within \`src/tools/composite/comments.ts\`. This ensures that errors without a Notion-specific \`code\` property are correctly re-thrown by the action handler.

Verification:
- Added 'should throw generic errors during block retrieve' to \`src/tools/composite/comments.test.ts\`.
- Ran \`bun run test:coverage\` and confirmed 100% coverage for \`comments.ts\`.
- Ran \`bun run check:fix\` to ensure no linting or type-check regressions.

---
*PR created automatically by Jules for task [15285219554505968717](https://jules.google.com/task/15285219554505968717) started by @n24q02m*