### PR TITLE
[FIX] Long Function: blocks

### DIFF
--- a/src/tools/composite/blocks.test.ts
+++ b/src/tools/composite/blocks.test.ts
@@ -1,39 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as markdown from '../helpers/markdown.js'
-import { blocks } from './blocks'
+import { blocks } from './blocks.js'
 
-const mockNotion = {
-  blocks: {
-    retrieve: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-    children: {
-      list: vi.fn(),
-      append: vi.fn()
-    }
+vi.mock('../helpers/markdown.js', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    blocksToMarkdown: vi.fn().mockImplementation(actual.blocksToMarkdown),
+    markdownToBlocks: vi.fn().mockImplementation(actual.markdownToBlocks)
   }
-}
+})
 
-describe('blocks', () => {
+describe('Blocks Tool', () => {
+  let mockNotion: any
+
   beforeEach(() => {
+    mockNotion = {
+      blocks: {
+        retrieve: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        children: {
+          list: vi.fn(),
+          append: vi.fn()
+        }
+      }
+    }
     vi.clearAllMocks()
   })
 
   describe('validation', () => {
-    it('should throw without block_id', async () => {
-      await expect(blocks(mockNotion as any, { action: 'get', block_id: '' })).rejects.toThrow('block_id required')
+    it('should throw if block_id is missing', async () => {
+      await expect(blocks(mockNotion as any, { action: 'get' } as any)).rejects.toThrow('block_id required')
     })
   })
 
   describe('get', () => {
-    it('should return block info', async () => {
-      mockNotion.blocks.retrieve.mockResolvedValue({
+    it('should retrieve a block', async () => {
+      const mockBlock = {
         id: 'block-1',
         type: 'paragraph',
         has_children: false,
         archived: false,
         paragraph: { rich_text: [] }
-      })
+      }
+      mockNotion.blocks.retrieve.mockResolvedValue(mockBlock)
 
       const result = await blocks(mockNotion as any, { action: 'get', block_id: 'block-1' })
 
@@ -43,13 +54,7 @@ describe('blocks', () => {
         type: 'paragraph',
         has_children: false,
         archived: false,
-        block: {
-          id: 'block-1',
-          type: 'paragraph',
-          has_children: false,
-          archived: false,
-          paragraph: { rich_text: [] }
-        }
+        block: mockBlock
       })
       expect(mockNotion.blocks.retrieve).toHaveBeenCalledWith({ block_id: 'block-1' })
     })
@@ -63,7 +68,7 @@ describe('blocks', () => {
           rich_text: [
             {
               type: 'text',
-              text: { content: 'Hello' },
+              text: { content: 'Hello', link: null },
               annotations: {
                 bold: false,
                 italic: false,
@@ -71,7 +76,9 @@ describe('blocks', () => {
                 underline: false,
                 code: false,
                 color: 'default'
-              }
+              },
+              plain_text: 'Hello',
+              href: null
             }
           ]
         }
@@ -87,9 +94,9 @@ describe('blocks', () => {
 
       expect(result.action).toBe('children')
       expect(result.block_id).toBe('block-1')
-      expect(result.total_children).toBe(1)
-      expect(result.markdown).toBe('Hello')
-      expect(result.blocks).toHaveLength(1)
+      expect((result as any).total_children).toBe(1)
+      expect((result as any).markdown).toBe('Hello')
+      expect((result as any).blocks).toHaveLength(1)
       expect(mockNotion.blocks.children.list).toHaveBeenCalledWith({
         block_id: 'block-1',
         start_cursor: undefined,
@@ -108,9 +115,9 @@ describe('blocks', () => {
 
       expect(result.action).toBe('children')
       expect(result.block_id).toBe('block-1')
-      expect(result.total_children).toBe(0)
-      expect(result.markdown).toBe('')
-      expect(result.blocks).toHaveLength(0)
+      expect((result as any).total_children).toBe(0)
+      expect((result as any).markdown).toBe('')
+      expect((result as any).blocks).toHaveLength(0)
     })
   })
 
@@ -126,7 +133,7 @@ describe('blocks', () => {
 
       expect(result.action).toBe('append')
       expect(result.block_id).toBe('block-1')
-      expect(result.appended_count).toBe(1)
+      expect((result as any).appended_count).toBe(1)
       expect(mockNotion.blocks.children.append).toHaveBeenCalledWith({
         block_id: 'block-1',
         children: expect.any(Array)

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -20,6 +20,49 @@ const UPDATABLE_BLOCK_TYPES = new Set([
   'code'
 ])
 
+export interface GetBlockResult {
+  action: 'get'
+  block_id: string
+  type: string
+  has_children: boolean
+  archived: boolean
+  block: any
+}
+
+export interface GetBlockChildrenResult {
+  action: 'children'
+  block_id: string
+  total_children: number
+  markdown: string
+  blocks: any[]
+}
+
+export interface AppendToBlockResult {
+  action: 'append'
+  block_id: string
+  appended_count: number
+}
+
+export interface UpdateBlockResult {
+  action: 'update'
+  block_id: string
+  type: string
+  updated: true
+}
+
+export interface DeleteBlockResult {
+  action: 'delete'
+  block_id: string
+  deleted: true
+}
+
+export type BlocksResult =
+  | GetBlockResult
+  | GetBlockChildrenResult
+  | AppendToBlockResult
+  | UpdateBlockResult
+  | DeleteBlockResult
+
 export interface BlocksInput {
   action: 'get' | 'children' | 'append' | 'update' | 'delete'
   block_id: string
@@ -32,147 +75,27 @@ export interface BlocksInput {
  * Unified blocks tool
  * Maps to: GET/PATCH/DELETE /v1/blocks/{id} and GET/PATCH /v1/blocks/{id}/children
  */
-export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
+export async function blocks(notion: Client, input: BlocksInput): Promise<BlocksResult> {
   return withErrorHandling(async () => {
     if (!input.block_id) {
       throw new NotionMCPError('block_id required', 'VALIDATION_ERROR', 'Provide block_id')
     }
 
     switch (input.action) {
-      case 'get': {
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
-        return {
-          action: 'get',
-          block_id: block.id,
-          type: block.type,
-          has_children: block.has_children,
-          archived: block.archived,
-          block
-        }
-      }
+      case 'get':
+        return await getBlock(notion, input)
 
-      case 'children': {
-        const blocksList = await autoPaginate((cursor) =>
-          notion.blocks.children.list({
-            block_id: input.block_id,
-            start_cursor: cursor,
-            page_size: 100
-          })
-        )
+      case 'children':
+        return await getBlockChildren(notion, input)
 
-        // Recursively fetch children for blocks that need them (tables, toggles, columns)
-        await populateDeepChildren(notion, blocksList as any[])
+      case 'append':
+        return await appendToBlock(notion, input)
 
-        const markdown = blocksToMarkdown(blocksList as any)
-        return {
-          action: 'children',
-          block_id: input.block_id,
-          total_children: blocksList.length,
-          markdown,
-          blocks: blocksList
-        }
-      }
+      case 'update':
+        return await updateBlock(notion, input)
 
-      case 'append': {
-        if (!input.content) {
-          throw new NotionMCPError('content required for append', 'VALIDATION_ERROR', 'Provide markdown content')
-        }
-        if (input.position === 'after_block' && !input.after_block_id) {
-          throw new NotionMCPError(
-            'after_block_id required when position is after_block',
-            'VALIDATION_ERROR',
-            'Provide after_block_id with the block ID to insert after'
-          )
-        }
-        const blocksList = markdownToBlocks(input.content)
-        const appendParams: any = {
-          block_id: input.block_id,
-          children: blocksList as any
-        }
-        if (input.position === 'start') {
-          appendParams.position = { type: 'start' }
-        } else if (input.position === 'after_block' && input.after_block_id) {
-          appendParams.position = { type: 'after_block', after_block: { id: input.after_block_id } }
-        }
-        await notion.blocks.children.append(appendParams)
-        return {
-          action: 'append',
-          block_id: input.block_id,
-          appended_count: blocksList.length
-        }
-      }
-
-      case 'update': {
-        if (!input.content) {
-          throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
-        }
-        const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
-        const blockType = block.type
-        const newBlocks = markdownToBlocks(input.content)
-
-        if (newBlocks.length === 0) {
-          throw new NotionMCPError('Content must produce at least one block', 'VALIDATION_ERROR', 'Invalid markdown')
-        }
-
-        const newContent = newBlocks[0]
-
-        // Validate block type match
-        if (newContent.type !== blockType) {
-          throw new NotionMCPError(
-            `Block type mismatch: cannot update ${blockType} with content that parses to ${newContent.type}`,
-            'VALIDATION_ERROR',
-            `Provide markdown that parses to ${blockType}`
-          )
-        }
-
-        const updatePayload: any = {}
-
-        // Build update based on block type
-        if (UPDATABLE_BLOCK_TYPES.has(blockType)) {
-          if (blockType === 'to_do') {
-            updatePayload.to_do = {
-              rich_text: (newContent as any).to_do?.rich_text || [],
-              checked: (newContent as any).to_do?.checked ?? block.to_do?.checked ?? false
-            }
-          } else if (blockType === 'code') {
-            updatePayload.code = {
-              rich_text: (newContent as any).code?.rich_text || [],
-              language: (newContent as any).code?.language || block.code?.language || 'plain text'
-            }
-          } else {
-            updatePayload[blockType] = {
-              rich_text: (newContent as any)[blockType]?.rich_text || []
-            }
-          }
-        } else {
-          throw new NotionMCPError(
-            `Block type '${blockType}' cannot be updated`,
-            'VALIDATION_ERROR',
-            'Only text-based blocks (paragraph, headings, lists, quote, to_do, code) can be updated'
-          )
-        }
-
-        await notion.blocks.update({
-          block_id: input.block_id,
-          ...updatePayload
-        } as any)
-
-        return {
-          action: 'update',
-          block_id: input.block_id,
-          type: blockType,
-          updated: true
-        }
-      }
-
-      case 'delete': {
-        await notion.blocks.delete({ block_id: input.block_id })
-        return {
-          action: 'delete',
-          block_id: input.block_id,
-          deleted: true
-        }
-      }
+      case 'delete':
+        return await deleteBlock(notion, input)
 
       default:
         throw new NotionMCPError(
@@ -182,4 +105,159 @@ export async function blocks(notion: Client, input: BlocksInput): Promise<any> {
         )
     }
   })()
+}
+
+/**
+ * Retrieve single block
+ * Maps to: GET /v1/blocks/{id}
+ */
+async function getBlock(notion: Client, input: BlocksInput): Promise<GetBlockResult> {
+  const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+  return {
+    action: 'get',
+    block_id: block.id,
+    type: block.type,
+    has_children: block.has_children,
+    archived: block.archived,
+    block
+  }
+}
+
+/**
+ * List child blocks
+ * Maps to: GET /v1/blocks/{id}/children
+ */
+async function getBlockChildren(notion: Client, input: BlocksInput): Promise<GetBlockChildrenResult> {
+  const blocksList = await autoPaginate((cursor) =>
+    notion.blocks.children.list({
+      block_id: input.block_id,
+      start_cursor: cursor,
+      page_size: 100
+    })
+  )
+
+  // Recursively fetch children for blocks that need them (tables, toggles, columns)
+  await populateDeepChildren(notion, blocksList as any[])
+
+  const markdown = blocksToMarkdown(blocksList as any)
+  return {
+    action: 'children',
+    block_id: input.block_id,
+    total_children: blocksList.length,
+    markdown,
+    blocks: blocksList
+  }
+}
+
+/**
+ * Add markdown content at position
+ * Maps to: PATCH /v1/blocks/{id}/children
+ */
+async function appendToBlock(notion: Client, input: BlocksInput): Promise<AppendToBlockResult> {
+  if (!input.content) {
+    throw new NotionMCPError('content required for append', 'VALIDATION_ERROR', 'Provide markdown content')
+  }
+  if (input.position === 'after_block' && !input.after_block_id) {
+    throw new NotionMCPError(
+      'after_block_id required when position is after_block',
+      'VALIDATION_ERROR',
+      'Provide after_block_id with the block ID to insert after'
+    )
+  }
+  const blocksList = markdownToBlocks(input.content)
+  const appendParams: any = {
+    block_id: input.block_id,
+    children: blocksList as any
+  }
+  if (input.position === 'start') {
+    appendParams.position = { type: 'start' }
+  } else if (input.position === 'after_block' && input.after_block_id) {
+    appendParams.position = { type: 'after_block', after_block: { id: input.after_block_id } }
+  }
+  await notion.blocks.children.append(appendParams)
+  return {
+    action: 'append',
+    block_id: input.block_id,
+    appended_count: blocksList.length
+  }
+}
+
+/**
+ * Replace text block content
+ * Maps to: PATCH /v1/blocks/{id}
+ */
+async function updateBlock(notion: Client, input: BlocksInput): Promise<UpdateBlockResult> {
+  if (!input.content) {
+    throw new NotionMCPError('content required for update', 'VALIDATION_ERROR', 'Provide markdown content')
+  }
+  const block: any = await notion.blocks.retrieve({ block_id: input.block_id })
+  const blockType = block.type
+  const newBlocks = markdownToBlocks(input.content)
+
+  if (newBlocks.length === 0) {
+    throw new NotionMCPError('Content must produce at least one block', 'VALIDATION_ERROR', 'Invalid markdown')
+  }
+
+  const newContent = newBlocks[0]
+
+  // Validate block type match
+  if (newContent.type !== blockType) {
+    throw new NotionMCPError(
+      `Block type mismatch: cannot update ${blockType} with content that parses to ${newContent.type}`,
+      'VALIDATION_ERROR',
+      `Provide markdown that parses to ${blockType}`
+    )
+  }
+
+  const updatePayload: any = {}
+
+  // Build update based on block type
+  if (UPDATABLE_BLOCK_TYPES.has(blockType)) {
+    if (blockType === 'to_do') {
+      updatePayload.to_do = {
+        rich_text: (newContent as any).to_do?.rich_text || [],
+        checked: (newContent as any).to_do?.checked ?? block.to_do?.checked ?? false
+      }
+    } else if (blockType === 'code') {
+      updatePayload.code = {
+        rich_text: (newContent as any).code?.rich_text || [],
+        language: (newContent as any).code?.language || block.code?.language || 'plain text'
+      }
+    } else {
+      updatePayload[blockType] = {
+        rich_text: (newContent as any)[blockType]?.rich_text || []
+      }
+    }
+  } else {
+    throw new NotionMCPError(
+      `Block type '${blockType}' cannot be updated`,
+      'VALIDATION_ERROR',
+      'Only text-based blocks (paragraph, headings, lists, quote, to_do, code) can be updated'
+    )
+  }
+
+  await notion.blocks.update({
+    block_id: input.block_id,
+    ...updatePayload
+  } as any)
+
+  return {
+    action: 'update',
+    block_id: input.block_id,
+    type: blockType,
+    updated: true
+  }
+}
+
+/**
+ * Remove block
+ * Maps to: DELETE /v1/blocks/{id}
+ */
+async function deleteBlock(notion: Client, input: BlocksInput): Promise<DeleteBlockResult> {
+  await notion.blocks.delete({ block_id: input.block_id })
+  return {
+    action: 'delete',
+    block_id: input.block_id,
+    deleted: true
+  }
 }

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -343,8 +343,15 @@ describe('registerTools', () => {
 
     it('should route blocks tool correctly', async () => {
       const handler = server.getHandler(3)
-      const mockResult = { action: 'get', block_id: 'block-1', type: 'paragraph' }
-      vi.mocked(blocks).mockResolvedValue(mockResult)
+      const mockResult = {
+        action: 'get',
+        block_id: 'block-1',
+        type: 'paragraph',
+        has_children: false,
+        archived: false,
+        block: {}
+      }
+      vi.mocked(blocks).mockResolvedValue(mockResult as any)
 
       const result = await handler({
         params: { name: 'blocks', arguments: { action: 'get', block_id: 'block-1' } }


### PR DESCRIPTION
Refactored the monolithic blocks function in src/tools/composite/blocks.ts into action-specific helper functions (getBlock, getBlockChildren, appendToBlock, updateBlock, deleteBlock). 

Key changes:
- Introduced action-specific result interfaces (e.g., GetBlockResult, AppendToBlockResult).
- Simplified the main blocks() dispatcher to a clean switch statement.
- Updated src/tools/composite/blocks.test.ts and src/tools/registry.test.ts to align with the new return types.
- Verified all 861 tests pass.
- Ensured Biome linting and TSC type-checking pass.

---
*PR created automatically by Jules for task [1768826475468171907](https://jules.google.com/task/1768826475468171907) started by @n24q02m*