### PR TITLE
[TEST] Missing error path test in users.ts

### DIFF
--- a/src/tools/composite/users.test.ts
+++ b/src/tools/composite/users.test.ts
@@ -128,6 +128,23 @@ describe('users', () => {
 
       expect(result.users[0].name).toBe('Unknown')
     })
+    it('should handle null errors in list action', async () => {
+      mockNotion.users.list.mockRejectedValue(null)
+
+      await expect(users(mockNotion as any, { action: 'list' })).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'Unknown error occurred'
+      })
+    })
+
+    it('should handle string errors in list action', async () => {
+      mockNotion.users.list.mockRejectedValue('something went wrong')
+
+      await expect(users(mockNotion as any, { action: 'list' })).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        message: 'Unknown error occurred'
+      })
+    })
   })
 
   describe('get', () => {

--- a/src/tools/composite/users.ts
+++ b/src/tools/composite/users.ts
@@ -44,7 +44,7 @@ export async function users(notion: Client, input: UsersInput): Promise<any> {
           }
         } catch (error: any) {
           // Auto-suggest from_workspace when permission denied
-          if (error.code === 'restricted_resource' || error.code === 'RESTRICTED_RESOURCE') {
+          if (error?.code === 'restricted_resource' || error?.code === 'RESTRICTED_RESOURCE') {
             throw new NotionMCPError(
               'Integration does not have permission to list users',
               'RESTRICTED_RESOURCE',

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -127,6 +127,7 @@ function stripSensitiveFields(obj: any, seen = new WeakSet()): void {
  * Map network-related errors
  */
 function mapNetworkError(error: any): NotionMCPError | null {
+  if (!error || typeof error !== 'object') return null
   if (error.message?.includes('ECONNREFUSED') || error.message?.includes('ENOTFOUND')) {
     return new NotionMCPError(
       'Cannot connect to Notion API',
@@ -141,6 +142,7 @@ function mapNetworkError(error: any): NotionMCPError | null {
  * Handle validation_error separately as it has dynamic suggestions
  */
 function mapValidationError(error: any): NotionMCPError | null {
+  if (!error || typeof error !== 'object') return null
   if (error.code !== 'validation_error') return null
 
   const bodyMessage: string = error.body?.message || ''
@@ -206,6 +208,7 @@ const NOTION_ERROR_MAP: Record<string, { message: string; code: string; suggesti
  * Map Notion API errors
  */
 function mapNotionError(error: any): NotionMCPError | null {
+  if (!error || typeof error !== 'object') return null
   if (!error.code) return null
 
   const validationError = mapValidationError(error)
@@ -226,6 +229,9 @@ function mapNotionError(error: any): NotionMCPError | null {
  * Map all other errors
  */
 function mapGenericError(error: any): NotionMCPError {
+  if (!error || typeof error !== 'object') {
+    return new NotionMCPError('Unknown error occurred', 'UNKNOWN_ERROR', 'Please check your request and try again')
+  }
   return new NotionMCPError(
     error.message || 'Unknown error occurred',
     'UNKNOWN_ERROR',


### PR DESCRIPTION
This PR adds missing test coverage for error paths in `src/tools/composite/users.ts`. While adding tests, I identified and fixed a potential runtime crash when a non-object (like `null` or a `string`) is thrown in the `list` action. I also hardened the shared error mapping utilities in `src/tools/helpers/errors.ts` to ensure the entire application is robust against such errors.

---
*PR created automatically by Jules for task [6773680009338082530](https://jules.google.com/task/6773680009338082530) started by @n24q02m*