### PR TITLE
🛡️ Sentinel: [HIGH] Fix XPIA breakout vulnerability by using non-greedy regex

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -134,7 +134,7 @@ describe('Security Utilities', () => {
       const result = wrapToolResult('pages', maliciousJsonText)
 
       expect(result).not.toContain('</untrusted_notion_content >')
-      expect(result).toContain('<_/untrusted_notion_content>')
+      expect(result).toContain('<_/untrusted_notion_content >')
     })
 
     it('should sanitize XPIA breakout tags with attributes', () => {
@@ -142,7 +142,7 @@ describe('Security Utilities', () => {
       const result = wrapToolResult('pages', maliciousJsonText)
 
       expect(result).not.toContain('</untrusted_notion_content exploit="1">')
-      expect(result).toContain('<_/untrusted_notion_content>')
+      expect(result).toContain('<_/untrusted_notion_content exploit=\\"1\\">')
     })
 
     it('should wrap file_uploads output with safety markers (XPIA defense)', () => {

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -84,7 +84,7 @@ export function wrapToolResult(toolName: string, jsonText: string): string {
 
   // Sanitize the payload to prevent XPIA breakout attacks
   // If the payload contains the closing tag, it could break out of the wrapper
-  const sanitizedText = jsonText.replace(/<\/untrusted_notion_content[^>]*>/gi, '<_/untrusted_notion_content>')
+  const sanitizedText = jsonText.replace(/<[\/]?untrusted_notion_content/gi, '<_/untrusted_notion_content')
 
   return `<untrusted_notion_content>\n${sanitizedText}\n</untrusted_notion_content>\n\n${SAFETY_WARNING}`
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `wrapToolResult` function used a greedy regex `<\/untrusted_notion_content[^>]*>` to sanitize the `</untrusted_notion_content>` wrapper from untrusted external data. This greedy pattern only matches the exact closing tag (with `>`), meaning an attacker could inject an opening tag `<untrusted_notion_content>` or avoid matching by using missing brackets.
🎯 Impact: Attackers could inject breakout tags, which LLMs may interpret to confuse the wrapping mechanism. This could lead to Cross-Prompt Injection Attacks (XPIA) when unparsed untrusted JSON payloads containing these opening/closing markers are sent back from a tool.
🔧 Fix: Updated the regex to `/<[/]?untrusted_notion_content/gi` to neutralize both opening and closing tags independently of whether a closing bracket exists, without consuming excessive content (avoiding ReDoS and data loss). And updated the corresponding tests.
✅ Verification: Ran the test suite using `bun run test` to verify the modified `security.test.ts` cases passed properly with the new replacement behavior.

---
*PR created automatically by Jules for task [3617307917731553631](https://jules.google.com/task/3617307917731553631) started by @n24q02m*