### PR TITLE
fix: correct stdio config path and live deployment host in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Two transports, selected in `init-server.ts:14-15` (delegated to `main.ts`). The
 
 ## Config storage path
 
-TS servers dùng `$APPDATA\mcp\Config\config.enc` (khác Python servers `$LOCALAPPDATA\mcp\config.enc`). Khi debug, clean cả 2 paths nếu need reset state.
+TS servers (gồm better-notion-mcp) dùng `$APPDATA\mcp\Config\config.enc` — single shared encrypted store (`servers.<name>` section, machine-bound key) qua `@n24q02m/mcp-core/storage` `resolveConfig`/`deleteConfig`. Python servers (wet/mnemo/crg/imagine) dùng PerPluginStore `~/.<plugin>-mcp/config.json` (config.enc là legacy). Khi debug reset state, xóa `config.enc` của TS server.
 
 ## E2E
 
@@ -108,7 +108,7 @@ cd ../mcp-core && uv run --project scripts/e2e python -m e2e.driver <config-id>
 
 Configs for this repo: `notion-paste-token`.
 
-Note: ``notion-oauth`` reclassified out of T2 matrix 2026-04-27 — verify post-deploy via manual smoke against ``notion-mcp.n24q02m.com`` only.
+Note: ``notion-oauth`` reclassified out of T2 matrix 2026-04-27 — verify post-deploy via manual smoke against ``better-notion-mcp.n24q02m.com`` only.
 
 Tier policy:
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ This plugin implements **TC-NearZK** (in-memory, ephemeral). See [the trust mode
 |---|---|---|---|
 | HTTP n24q02m-hosted (default) | In-memory `Map<sub, OAuthToken>` | In-process only | Server process (cleared on restart) |
 | HTTP self-host | Same as hosted | Same | Only you (admin = user) |
-| stdio proxy | `~/.better-notion-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
+| stdio (local) | `config.enc` in the OS config dir (`%APPDATA%\mcp\Config\config.enc` on Windows, `~/.config/mcp/config.enc` on Linux/macOS) | AES-GCM, machine-bound key | Only your OS user |
 
 ## License
 


### PR DESCRIPTION
Two documentation fixes where the docs no longer matched the running code and deployment.

## Trust Model storage path (README)
The Trust Model table listed the stdio credential store as `~/.better-notion-mcp/config.json`. The server actually persists single-user credentials through mcp-core's shared config store, which is `config.enc` in the OS config directory:
- Windows: `%APPDATA%\mcp\Config\config.enc`
- Linux/macOS: `~/.config/mcp/config.enc`

Updated the table row to the real path and dropped the stale "proxy" wording (stdio mode talks to the MCP SDK transport directly, no proxy hop). Encryption stays AES-GCM with a machine-bound key, which is accurate.

## Post-deploy smoke host (CLAUDE.md)
The E2E note pointed the post-deploy smoke check at `notion-mcp.n24q02m.com`, which does not resolve. The live host is `better-notion-mcp.n24q02m.com` (matches `server.json` remotes and the rest of CLAUDE.md). Corrected the host.

Also clarified the config-storage note so it distinguishes the TypeScript servers (shared `config.enc` store) from the Python servers (per-plugin `~/.<plugin>-mcp/config.json` store).