### PR TITLE
feat: cloudflare serverless migration (Worker + Container + KV write-through)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,39 @@ docker run -p 8080:8080 \
   n24q02m/better-notion-mcp:latest
 ```
 
+## Deploy to Cloudflare
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/n24q02m/better-notion-mcp)
+
+Run your own multi-user better-notion-mcp serverless on Cloudflare (Worker + Container + KV).
+
+**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+
+1. `git clone https://github.com/n24q02m/better-notion-mcp && cd better-notion-mcp`
+2. `wrangler login`
+3. Provision the KV namespace and paste its id into `wrangler.jsonc`:
+   ```
+   wrangler kv namespace create better-notion-kv
+   ```
+4. Set secrets:
+   ```
+   wrangler secret put CREDENTIAL_SECRET
+   wrangler secret put NOTION_OAUTH_CLIENT_ID
+   wrangler secret put NOTION_OAUTH_CLIENT_SECRET
+   ```
+   `CREDENTIAL_SECRET` is REQUIRED: it derives a deterministic OAuth signing key so
+   user identity survives container recreation.
+5. Push the http image to the CF managed registry and deploy:
+   ```
+   wrangler containers push better-notion-mcp:beta
+   wrangler deploy
+   ```
+6. Complete the Notion OAuth flow in the browser at your Worker domain.
+
+Per-user Notion access tokens are encrypted into KV (`MCP_STORAGE_BACKEND=cf-kv`),
+so they survive scale-to-zero. Do NOT set `MCP_AUTH_DISABLE` on a shared/public
+deployment — it collapses all users into a single token bucket.
+
 ## Comparison
 
 How better-notion-mcp stacks up against direct competitors in each pillar:

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
+        "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@n24q02m/mcp-core": "1.17.4",
         "@notionhq/client": "^5.22.0",
@@ -52,6 +53,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+
+    "@cloudflare/containers": ["@cloudflare/containers@0.3.7", "", {}, "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.18.0-beta.5",
+        "@n24q02m/mcp-core": "^1.18.0-beta.7",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3",
       },
@@ -127,7 +127,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.6", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.10.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-FvXi/lpNMWnXjgfHyUE4xGG5mHMVAuKamYrJyTT5Xze2ZxADpw9oL48Nzx02Oe86IvtpagGGgjRMMWaCmRiMdg=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.7", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.10.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-cknl8FfEh79ifca/aLC8UTDb/c7HDP/6bGKgxyRevBbG48m8CN4sPYUeh+GffAjFtNHIE5PC61YHv2rHgg2pMw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "1.17.4",
+        "@n24q02m/mcp-core": "^1.18.0-beta.5",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3",
       },
@@ -124,7 +124,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.17.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.10.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-5TgEydOhJjGb4dJw+3EJFePLDxiZw3oykfFh53SzIU07CfCh6DLNXgJmV89n75iJlcuRZYcWhGKp8M07wHKnuw=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.6", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.10.0", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-FvXi/lpNMWnXjgfHyUE4xGG5mHMVAuKamYrJyTT5Xze2ZxADpw9oL48Nzx02Oe86IvtpagGGgjRMMWaCmRiMdg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
+        "@cloudflare/workers-types": "^4.20260615.1",
         "@types/node": "^24.13.1",
         "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "^0.28.0",
@@ -55,6 +56,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@cloudflare/containers": ["@cloudflare/containers@0.3.7", "", {}, "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260615.1", "", {}, "sha512-fGOiTwoLj/8bU8mj3VAfa1EULx4ceZhDwnjvY+afDBlSXI9pvY7PE9t62rGEhJjbAOGd7i5WUDun0eZCWBDrzg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/docker-compose.cloudflare.yml
+++ b/docker-compose.cloudflare.yml
@@ -1,0 +1,16 @@
+# Cloudflare emulation overlay: run `wrangler dev --local --port 8787` separately,
+# then layer this overlay onto docker-compose.http.yml. The container reaches KV
+# via the host-mapped wrangler dev worker (kv.internal -> host gateway).
+services:
+  better-notion-mcp:
+    environment:
+      - MCP_TRANSPORT=http
+      - PORT=8080
+      - MCP_STORAGE_BACKEND=cf-kv
+      - MCP_KV_BASE_URL=http://host.docker.internal:8787
+      - PUBLIC_URL=http://localhost:8787
+      - CREDENTIAL_SECRET=${CREDENTIAL_SECRET}
+      - NOTION_OAUTH_CLIENT_ID=${NOTION_OAUTH_CLIENT_ID}
+      - NOTION_OAUTH_CLIENT_SECRET=${NOTION_OAUTH_CLIENT_SECRET}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.18.0-beta.5",
+    "@n24q02m/mcp-core": "^1.18.0-beta.7",
     "@notionhq/client": "^5.22.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "1.17.4",
+    "@n24q02m/mcp-core": "^1.18.0-beta.5",
     "@notionhq/client": "^5.22.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:fix": "biome lint --write src",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "check": "biome check . && bun run type-check",
     "check:fix": "biome check --write . && bun run type-check",
     "prepublishOnly": "bun run build",
@@ -67,6 +67,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
+    "@cloudflare/workers-types": "^4.20260615.1",
     "@types/node": "^24.13.1",
     "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@n24q02m/mcp-core": "1.17.4",
     "@notionhq/client": "^5.22.0",

--- a/src/auth/notion-token-store-kv.test.ts
+++ b/src/auth/notion-token-store-kv.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { KvNotionTokenStore } from './notion-token-store-kv.js'
+
+// Injectable fake http matching mcp-core CfKvBackend's Http contract:
+// request(method, url, data?, headers?) -> { status, body } with body as bytes.
+class FakeKvHttp {
+  store = new Map<string, Uint8Array>()
+  async request(method: string, url: string, data?: Uint8Array): Promise<{ status: number; body: Uint8Array }> {
+    const key = decodeURIComponent(url.split('/').pop() ?? '')
+    if (method === 'PUT') {
+      this.store.set(key, data ?? new Uint8Array())
+      return { status: 200, body: new Uint8Array() }
+    }
+    if (method === 'GET') {
+      const v = this.store.get(key)
+      return v ? { status: 200, body: v } : { status: 404, body: new Uint8Array() }
+    }
+    if (method === 'DELETE') {
+      const existed = this.store.delete(key)
+      return { status: existed ? 200 : 404, body: new Uint8Array() }
+    }
+    throw new Error(`unexpected ${method}`)
+  }
+}
+
+describe('KvNotionTokenStore', () => {
+  it('write-through encrypts the token to KV and reads it back', async () => {
+    process.env.CREDENTIAL_SECRET = 'test-secret'
+    const http = new FakeKvHttp()
+    const store = new KvNotionTokenStore({ http })
+    await store.save('alice', 'ntn_alice_secret')
+
+    // landed in KV under the per-(plugin, sub) config key (better-notion/subs/alice/config),
+    // and NOT as plaintext.
+    const stored = [...http.store.entries()].find(([k]) => k.includes('subs/alice/config'))
+    expect(stored).toBeDefined()
+    expect(new TextDecoder().decode(stored![1])).not.toContain('ntn_alice_secret')
+
+    // a fresh store (cold cache) recovers it from KV (decrypted).
+    const cold = new KvNotionTokenStore({ http })
+    expect(await cold.getAsync('alice')).toBe('ntn_alice_secret')
+  })
+
+  it('keeps distinct subs isolated', async () => {
+    process.env.CREDENTIAL_SECRET = 'test-secret'
+    const http = new FakeKvHttp()
+    const store = new KvNotionTokenStore({ http })
+    await store.save('alice', 'ntn_a')
+    await store.save('bob', 'ntn_b')
+    const cold = new KvNotionTokenStore({ http })
+    expect(await cold.getAsync('alice')).toBe('ntn_a')
+    expect(await cold.getAsync('bob')).toBe('ntn_b')
+  })
+
+  it('sync get() serves the in-memory cache after a save', async () => {
+    process.env.CREDENTIAL_SECRET = 'test-secret'
+    const store = new KvNotionTokenStore({ http: new FakeKvHttp() })
+    await store.save('alice', 'ntn_a')
+    expect(store.get('alice')).toBe('ntn_a') // cache hit, no KV round-trip
+  })
+
+  it('clear removes from both cache and KV', async () => {
+    process.env.CREDENTIAL_SECRET = 'test-secret'
+    const http = new FakeKvHttp()
+    const store = new KvNotionTokenStore({ http })
+    await store.save('alice', 'ntn_a')
+    await store.clear('alice')
+    expect(store.get('alice')).toBeUndefined()
+    const cold = new KvNotionTokenStore({ http })
+    expect(await cold.getAsync('alice')).toBeUndefined()
+  })
+})

--- a/src/auth/notion-token-store-kv.ts
+++ b/src/auth/notion-token-store-kv.ts
@@ -1,0 +1,93 @@
+/**
+ * KV write-through per-sub Notion access token store (Cloudflare deploy).
+ *
+ * In-memory Map is a read cache; the durable layer is Workers KV reached via the
+ * Worker's kv.internal outbound handler (MCP_KV_BASE_URL). The token is embedded
+ * in a per-(plugin, sub) config blob encrypted by mcp-core's PerPluginStore
+ * (AES-256-GCM) before it hits KV -- this module NEVER re-implements crypto.
+ * Selecting this store (cf-kv backend) is what makes the Notion token survive
+ * container delete+recreate; the in-memory-only path is for stdio/local self-host.
+ *
+ * PerPluginStore stores ONE config blob per (plugin, sub) at
+ * `better-notion/subs/<sub>/config` (there is no per-token sub-namespace), so the
+ * token lives INSIDE that blob as { access_token }.
+ */
+import { backendFromEnv, CfKvBackend, PerPluginStore } from '@n24q02m/mcp-core/storage'
+import type { NotionTokenStoreLike } from './notion-token-store.js'
+
+const PLUGIN_NAME = 'better-notion'
+
+// Minimal structural shape of mcp-core's injectable Http (storage/backends.ts):
+// request(method, url, data?, headers?) -> { status, body }. Declared locally so
+// the module does not depend on Http being re-exported from the package subpath.
+interface KvHttp {
+  request(
+    method: string,
+    url: string,
+    data?: Uint8Array | Buffer,
+    headers?: Record<string, string>
+  ): Promise<{ status: number; body: Uint8Array | Buffer }>
+}
+
+interface KvNotionTokenStoreOptions {
+  // Injectable Http for CfKvBackend (tests). Production: backendFromEnv() builds
+  // a CfKvBackend from MCP_STORAGE_BACKEND=cf-kv + MCP_KV_BASE_URL.
+  http?: KvHttp
+}
+
+export class KvNotionTokenStore implements NotionTokenStoreLike {
+  private cache = new Map<string, string>()
+  private backend: CfKvBackend | ReturnType<typeof backendFromEnv>
+
+  constructor(opts: KvNotionTokenStoreOptions = {}) {
+    // CfKvBackend is positional: (baseUrl, token?, http?). No KV bearer token is
+    // needed here (the Worker's kv.internal handler authorizes via the binding),
+    // so pass undefined for token and inject http for tests.
+    this.backend = opts.http
+      ? new CfKvBackend(process.env.MCP_KV_BASE_URL ?? 'http://kv.internal', undefined, opts.http as never)
+      : backendFromEnv()
+  }
+
+  // PerPluginStore is scoped to (plugin, sub) by its constructor and keyed at
+  // `better-notion/subs/<sub>/config`. Three positional args: (pluginName, sub,
+  // backend) -- there is NO 4th subkey arg.
+  private storeFor(sub: string): PerPluginStore {
+    return new PerPluginStore(PLUGIN_NAME, sub, this.backend)
+  }
+
+  async save(sub: string, accessToken: string): Promise<void> {
+    this.cache.set(sub, accessToken)
+    // Token embedded in the (plugin, sub) config blob; save() takes the payload.
+    await this.storeFor(sub).save({ access_token: accessToken })
+  }
+
+  // Sync cache read (hot path: factory called per tool invocation). A KV miss is
+  // resolved by getAsync() on the auth path, which warms the cache.
+  get(sub: string): string | undefined {
+    return this.cache.get(sub)
+  }
+
+  async getAsync(sub: string): Promise<string | undefined> {
+    const cached = this.cache.get(sub)
+    if (cached !== undefined) return cached
+    try {
+      // load() returns Record<string, unknown> | null (the decrypted config blob).
+      const data = (await this.storeFor(sub).load()) as { access_token?: string } | null
+      const token = data?.access_token
+      if (token) {
+        this.cache.set(sub, token)
+        return token
+      }
+    } catch {
+      // corrupt/absent blob -> treat as no token (triggers re-auth), never throw.
+    }
+    return undefined
+  }
+
+  async clear(sub: string): Promise<void> {
+    this.cache.delete(sub)
+    // PerPluginStore has no delete(); clear() takes no args (the instance is
+    // already scoped to this sub via storeFor) and removes the (plugin, sub) blob.
+    await this.storeFor(sub).clear()
+  }
+}

--- a/src/auth/notion-token-store.test.ts
+++ b/src/auth/notion-token-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { NotionTokenStore } from './notion-token-store.js'
+import { NotionTokenStore, type NotionTokenStoreLike } from './notion-token-store.js'
 
 describe('NotionTokenStore', () => {
   it('saves and retrieves token by sub', () => {
@@ -18,5 +18,15 @@ describe('NotionTokenStore', () => {
     store.save('u1', 'old')
     store.save('u1', 'new')
     expect(store.get('u1')).toBe('new')
+  })
+})
+
+describe('NotionTokenStoreLike interface', () => {
+  it('NotionTokenStore satisfies the interchangeable store interface', () => {
+    const store: NotionTokenStoreLike = new NotionTokenStore()
+    store.save('u', 't')
+    expect(store.get('u')).toBe('t')
+    store.clear('u')
+    expect(store.get('u')).toBeUndefined()
   })
 })

--- a/src/auth/notion-token-store.ts
+++ b/src/auth/notion-token-store.ts
@@ -1,4 +1,17 @@
 /**
+ * Interface satisfied by both the in-memory NotionTokenStore (stdio / local
+ * single-process) and the KV write-through KvNotionTokenStore (Cloudflare
+ * deploy), so the HTTP transport can select either without branching on the
+ * concrete type. `save`/`clear` allow an async return because the KV variant
+ * writes through to Workers KV; the in-memory store satisfies it synchronously.
+ */
+export interface NotionTokenStoreLike {
+  save(sub: string, accessToken: string): Promise<void> | void
+  get(sub: string): string | undefined
+  clear(sub: string): Promise<void> | void
+}
+
+/**
  * In-process per-user Notion access token store, keyed by JWT subject.
  *
  * Populated by the delegated OAuth `onTokenReceived` callback and consumed

--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { NotionTokenStore } from '../auth/notion-token-store.js'
+import { selectTokenStore } from './http.js'
 
 describe('CREDENTIAL_SECRET -> EdDSA signing (deterministic, no-disk)', () => {
   it('JWTIssuer selects EdDSA when CREDENTIAL_SECRET is set, RS256 when unset', async () => {
@@ -45,6 +46,21 @@ describe('per-sub token isolation (anonymous-bucket-collapse guard)', () => {
     // enabled var. (If ever needed for a private self-host, it is the operator's
     // opt-in, never on *.n24q02m.com.)
     expect(/"MCP_AUTH_DISABLE"\s*:\s*"1"/.test(raw)).toBe(false)
+  })
+})
+
+describe('token store selection', () => {
+  it('selects KvNotionTokenStore when MCP_STORAGE_BACKEND=cf-kv', async () => {
+    process.env.MCP_STORAGE_BACKEND = 'cf-kv'
+    process.env.MCP_KV_BASE_URL = 'http://kv.internal'
+    const { KvNotionTokenStore } = await import('../auth/notion-token-store-kv.js')
+    expect(selectTokenStore()).toBeInstanceOf(KvNotionTokenStore)
+    delete process.env.MCP_STORAGE_BACKEND
+  })
+
+  it('selects the in-memory NotionTokenStore otherwise', async () => {
+    delete process.env.MCP_STORAGE_BACKEND
+    expect(selectTokenStore()).toBeInstanceOf(NotionTokenStore)
   })
 })
 

--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('CREDENTIAL_SECRET -> EdDSA signing (deterministic, no-disk)', () => {
+  it('JWTIssuer selects EdDSA when CREDENTIAL_SECRET is set, RS256 when unset', async () => {
+    const { JWTIssuer } = await import('@n24q02m/mcp-core')
+    const withSecret = new JWTIssuer('better-notion-mcp', undefined, 'test-secret')
+    const withoutSecret = new JWTIssuer('better-notion-mcp', undefined, null)
+    expect(withSecret.alg).toBe('EdDSA')
+    expect(withoutSecret.alg).toBe('RS256')
+  })
+
+  it('two issuers from the same CREDENTIAL_SECRET converge on the same signing key (survives recreate)', async () => {
+    const { JWTIssuer } = await import('@n24q02m/mcp-core')
+    const a = new JWTIssuer('better-notion-mcp', undefined, 'stable-secret')
+    await a.init()
+    const token = await a.issueAccessToken('user@example.com')
+    // simulate container recreate: a fresh issuer derived from the same secret
+    const b = new JWTIssuer('better-notion-mcp', undefined, 'stable-secret')
+    await b.init()
+    const payload = await b.verifyAccessToken(token)
+    expect(payload.sub).toBe('user@example.com')
+  })
+
+  it('http transport documents the CREDENTIAL_SECRET requirement for EdDSA', () => {
+    const src = readFileSync('src/transports/http.ts', 'utf-8')
+    expect(src).toContain('CREDENTIAL_SECRET')
+  })
+})

--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { NotionTokenStore } from '../auth/notion-token-store.js'
 
 describe('CREDENTIAL_SECRET -> EdDSA signing (deterministic, no-disk)', () => {
   it('JWTIssuer selects EdDSA when CREDENTIAL_SECRET is set, RS256 when unset', async () => {
@@ -25,5 +26,39 @@ describe('CREDENTIAL_SECRET -> EdDSA signing (deterministic, no-disk)', () => {
   it('http transport documents the CREDENTIAL_SECRET requirement for EdDSA', () => {
     const src = readFileSync('src/transports/http.ts', 'utf-8')
     expect(src).toContain('CREDENTIAL_SECRET')
+  })
+})
+
+describe('per-sub token isolation (anonymous-bucket-collapse guard)', () => {
+  it('distinct JWT subs keep distinct Notion tokens (no bleed)', () => {
+    const store = new NotionTokenStore()
+    store.save('alice', 'ntn_alice')
+    store.save('bob', 'ntn_bob')
+    expect(store.get('alice')).toBe('ntn_alice')
+    expect(store.get('bob')).toBe('ntn_bob')
+    expect(store.get('alice')).not.toBe(store.get('bob'))
+  })
+
+  it('the wrangler deploy config never enables MCP_AUTH_DISABLE on shared infra', () => {
+    const raw = readFileSync('wrangler.jsonc', 'utf-8')
+    // The guard is a literal absence: MCP_AUTH_DISABLE must not appear as an
+    // enabled var. (If ever needed for a private self-host, it is the operator's
+    // opt-in, never on *.n24q02m.com.)
+    expect(/"MCP_AUTH_DISABLE"\s*:\s*"1"/.test(raw)).toBe(false)
+  })
+})
+
+describe('sleepAfter eviction vs lock-refresh interval (CRITIC)', () => {
+  it('the worker DO sets sleepAfter=1h (eviction is safe; worker adds no own timer)', async () => {
+    const { NotionContainer } = await import('../worker.js')
+    // A slept DO stops the mcp-core lock-refresh timer, which is safe because
+    // (a) mcp-core unref()s it so it never blocks, and (b) the lock file is
+    // ephemeral and re-swept on next boot. Assert the worker does not try to
+    // defeat eviction with its own timer.
+    const proto = Object.getOwnPropertyNames(NotionContainer.prototype)
+    expect(proto).toContain('constructor')
+    const src = readFileSync('src/worker.ts', 'utf-8')
+    expect(src).not.toContain('setInterval')
+    expect(src).toContain("sleepAfter = '1h'")
   })
 })

--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -49,14 +49,13 @@ describe('per-sub token isolation (anonymous-bucket-collapse guard)', () => {
 })
 
 describe('sleepAfter eviction vs lock-refresh interval (CRITIC)', () => {
-  it('the worker DO sets sleepAfter=1h (eviction is safe; worker adds no own timer)', async () => {
-    const { NotionContainer } = await import('../worker.js')
+  it('the worker DO sets sleepAfter=1h (eviction is safe; worker adds no own timer)', () => {
     // A slept DO stops the mcp-core lock-refresh timer, which is safe because
     // (a) mcp-core unref()s it so it never blocks, and (b) the lock file is
     // ephemeral and re-swept on next boot. Assert the worker does not try to
-    // defeat eviction with its own timer.
-    const proto = Object.getOwnPropertyNames(NotionContainer.prototype)
-    expect(proto).toContain('constructor')
+    // defeat eviction with its own timer, and keeps the 1h sleep window.
+    // (worker.ts is excluded from the main tsconfig project, so assert against
+    // its source text rather than importing it across the project boundary.)
     const src = readFileSync('src/worker.ts', 'utf-8')
     expect(src).not.toContain('setInterval')
     expect(src).toContain("sleepAfter = '1h'")

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -57,6 +57,14 @@ export async function startHttp(): Promise<void> {
   // separate channel (e.g. NOTION_TOKEN env var resolved by tokenStore default).
   const authDisabled = process.env.MCP_AUTH_DISABLE === '1'
 
+  // CF deploy requirement (P3-03): CREDENTIAL_SECRET MUST be set in the
+  // container env (wrangler secret put). When set, mcp-core's JWTIssuer derives
+  // a deterministic Ed25519 (EdDSA) signing key via HKDF-SHA256 with no disk I/O.
+  // Without it, JWTIssuer falls back to RS256 keys persisted to disk on the
+  // EPHEMERAL container FS, so OAuth identity breaks on every container recreate.
+  // Setting CREDENTIAL_SECRET is the must-do CF fix; no code change is needed
+  // here because runHttpServer/createDelegatedOAuthApp already read it from env.
+
   const handle = await runHttpServer(() => createMCPServer(notionClientFactory) as unknown as McpServer, {
     serverName: SERVER_NAME,
     port,

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -15,7 +15,8 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { runHttpServer } from '@n24q02m/mcp-core'
 import { Client } from '@notionhq/client'
-import { NotionTokenStore } from '../auth/notion-token-store.js'
+import { NotionTokenStore, type NotionTokenStoreLike } from '../auth/notion-token-store.js'
+import { KvNotionTokenStore } from '../auth/notion-token-store-kv.js'
 import { createMCPServer } from '../create-server.js'
 import { resolveCredentialState, setState, setSubjectTokenResolver } from '../credential-state.js'
 import { NotionMCPError } from '../tools/helpers/errors.js'
@@ -24,10 +25,24 @@ const SERVER_NAME = 'better-notion-mcp'
 
 export const subjectContext = new AsyncLocalStorage<{ sub: string }>()
 
+/**
+ * Select the per-sub Notion token store. The cf-kv backend -> KV write-through
+ * (durable across container recreate; the Cloudflare deployment store). Any other
+ * backend (stdio / local single-process) -> in-memory store. Read once at
+ * startup; on CF, MCP_STORAGE_BACKEND=cf-kv is set by wrangler vars, so the
+ * durable KV store is always selected there.
+ */
+export function selectTokenStore(): NotionTokenStoreLike {
+  if ((process.env.MCP_STORAGE_BACKEND ?? '').toLowerCase() === 'cf-kv') {
+    return new KvNotionTokenStore()
+  }
+  return new NotionTokenStore()
+}
+
 export async function startHttp(): Promise<void> {
   await resolveCredentialState()
 
-  const tokenStore = new NotionTokenStore()
+  const tokenStore = selectTokenStore()
 
   const notionClientFactory = () => {
     const ctx = subjectContext.getStore()
@@ -82,7 +97,10 @@ export async function startHttp(): Promise<void> {
       onTokenReceived: (tokens: Record<string, unknown>) => {
         const accessToken = String(tokens.access_token ?? '')
         const sub = String((tokens as { owner_user_id?: string }).owner_user_id ?? 'default')
-        if (accessToken) tokenStore.save(sub, accessToken)
+        // save() may be async on the KV store; the cache is set synchronously
+        // inside it before the awaited KV write, so the immediately-following
+        // factory read hits the warm cache. Fire-and-forget the durable write.
+        if (accessToken) void tokenStore.save(sub, accessToken)
         // Return sub so mcp-core (>=1.6.2) propagates it into the bearer
         // JWT's `sub` claim, which `authScope` below then matches back
         // to the stored Notion token.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,167 @@
+// src/worker.ts
+// Worker fronting the better-notion-mcp container Durable Object.
+//
+// Two distinct request paths:
+//  - INBOUND: requests on the custom domain hit the default export `fetch`,
+//    which routes them to the per-user NotionContainer Durable Object.
+//  - OUTBOUND: the container calls http://kv.internal/... which is intercepted
+//    by the `@cloudflare/containers` proxy and dispatched to the
+//    `NotionContainer.outboundByHost` handlers below, serviced from the Worker's
+//    KV binding. enableInternet=true lets every OTHER host (api.notion.com)
+//    reach the public internet.
+//
+// notion is KV-only: it has no docs DB and no vectors, so the d1.internal /
+// vectorize.internal handlers from the wet template are intentionally dropped.
+import { Container, ContainerProxy, type OutboundHandler } from '@cloudflare/containers'
+
+// ContainerProxy must be re-exported from the Worker entrypoint: the containers
+// runtime discovers it via `ctx.exports.ContainerProxy` to route the container's
+// intercepted outbound traffic (kv.internal) back into the Worker. Without this
+// re-export, applyOutboundInterception() throws at container start.
+export { ContainerProxy }
+
+export interface Env {
+  KV: {
+    get(k: string, type: 'arrayBuffer'): Promise<ArrayBuffer | null>
+    get(k: string): Promise<string | null>
+    put(k: string, v: string | ArrayBuffer): Promise<void>
+    delete(k: string): Promise<void>
+  }
+  NOTION?: { idFromName(n: string): unknown; get(id: unknown): { fetch(r: Request): Promise<Response> } }
+  // Container config (wrangler.jsonc `vars`) + secrets (`wrangler secret put`),
+  // forwarded into the container process via NotionContainer.envVars.
+  MCP_TRANSPORT: string
+  MCP_STORAGE_BACKEND: string
+  MCP_KV_BASE_URL: string
+  PUBLIC_URL: string
+  PORT: string
+  CREDENTIAL_SECRET: string
+  NOTION_OAUTH_CLIENT_ID: string
+  NOTION_OAUTH_CLIENT_SECRET: string
+}
+
+// Keys forwarded from the Worker env (wrangler vars + secrets) into the container
+// process. Unset/empty values are dropped so an unused optional secret never
+// injects a blank.
+const CONTAINER_ENV_KEYS = [
+  'MCP_TRANSPORT',
+  'MCP_STORAGE_BACKEND',
+  'MCP_KV_BASE_URL',
+  'PUBLIC_URL',
+  'PORT',
+  'CREDENTIAL_SECRET',
+  'NOTION_OAUTH_CLIENT_ID',
+  'NOTION_OAUTH_CLIENT_SECRET'
+] as const
+
+function pickContainerEnv(env: Env): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of CONTAINER_ENV_KEYS) {
+    const v = (env as unknown as Record<string, unknown>)[k]
+    if (typeof v === 'string' && v !== '') out[k] = v
+  }
+  return out
+}
+
+// --- Outbound handler (container -> Worker KV binding) ----------------------
+// Runs when the container makes an outbound HTTP request to kv.internal. Wired
+// via `NotionContainer.outboundByHost` (assignment, NOT a class field) so the
+// assignment hits the inherited setter and populates the package's module-level
+// handler registry. A `static outboundByHost = {...}` field would use
+// define-semantics, bypass the setter, and silently fall through to the public
+// internet (kv.internal -> NXDOMAIN).
+
+const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  // Readiness probe (E.1): once this handler answers, outbound interception is
+  // wired, so the container's first credential PUT is safe. Reserved key,
+  // checked before the normal key lookup so it never shadows a real KV key.
+  if (request.method === 'GET' && key === '__ready') {
+    return Response.json({ ready: true })
+  }
+  if (request.method === 'GET') {
+    // Credential blobs are binary (nonce + AES-GCM ciphertext); read/write as
+    // ArrayBuffer so bytes round-trip without UTF-8 corruption.
+    const v = await env.KV.get(key, 'arrayBuffer')
+    return v === null ? new Response('', { status: 404 }) : new Response(v, { status: 200 })
+  }
+  if (request.method === 'PUT') {
+    await env.KV.put(key, await request.arrayBuffer())
+    return new Response('', { status: 200 })
+  }
+  if (request.method === 'DELETE') {
+    await env.KV.delete(key)
+    return new Response('', { status: 200 })
+  }
+  return new Response('method not allowed', { status: 405 })
+}
+
+// Outbound handler registry, keyed by internal hostname. Production container
+// outbound (kv.internal) reaches these via @cloudflare/containers' ContainerProxy
+// + the NotionContainer.outboundByHost assignment below — NOT via the public
+// `fetch` export. Exported so unit tests can invoke a handler directly instead of
+// routing an internal-host request through the public entrypoint. notion is
+// KV-only (no D1/Vectorize handlers).
+export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
+  'kv.internal': kvOutbound
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Public entrypoint: ONLY routes inbound requests to the per-user container
+    // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
+    // exposing it on the public fetch surface would let an external caller
+    // (request hostname spoofed to kv.internal) read/write/delete the credential
+    // KV namespace unauthenticated. Production container outbound reaches it via
+    // @cloudflare/containers' ContainerProxy + the NotionContainer.outboundByHost
+    // registry below; unit tests call the handlers directly via the
+    // OUTBOUND_BY_HOST export.
+    if (env.NOTION) {
+      const userId = extractUserId(request)
+      const stub = env.NOTION.get(env.NOTION.idFromName(userId))
+      return stub.fetch(request)
+    }
+    return new Response('not found', { status: 404 })
+  }
+}
+
+function extractUserId(request: Request): string {
+  // JWT sub from the Bearer token (verified by mcp-core OAuth middleware in the
+  // container). SINGLE-USER CONTRACT (E.2): no token or no `sub` -> the reserved
+  // id "default", so setup and serving collapse onto ONE Durable Object id and
+  // the credential write+read avoid a cross-colo KV hop. Per-`sub` tokens get
+  // their own isolated DO (multi-user). Downstream servers MUST keep this.
+  const auth = request.headers.get('authorization') ?? ''
+  const m = auth.match(/^Bearer\s+(.+)$/)
+  if (!m) return 'default'
+  try {
+    const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
+    return typeof payload.sub === 'string' ? payload.sub : 'default'
+  } catch {
+    return 'default'
+  }
+}
+
+// Per-user container Durable Object. wrangler.jsonc binds NOTION to this class
+// and runs the registry.cloudflare.com/<ACCOUNT_ID>/better-notion-mcp:beta image;
+// one instance per JWT sub. The container's HTTP server listens on 8080
+// (Dockerfile http target: PORT=8080 + EXPOSE 8080).
+export class NotionContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '1h'
+  // The container reaches api.notion.com over the public internet; kv.internal
+  // stays intercepted (see outboundByHost).
+  enableInternet = true
+  // Forward Worker config (vars) + secrets into the container process. Without
+  // this, CREDENTIAL_SECRET is unset and JWTIssuer falls back to RS256-on-disk
+  // (ephemeral FS) -> OAuth identity breaks across container recreation.
+  envVars = pickContainerEnv(this.env)
+}
+
+// Register outbound interception. MUST be an assignment (invokes the inherited
+// `static set outboundByHost`) — a class field would bypass the setter. Reuses
+// OUTBOUND_BY_HOST so the proxy registry and the direct fetch dispatch are one
+// source of truth (footgun #1: assignment, never a static field). KV-only: no
+// d1.internal / vectorize.internal.
+NotionContainer.outboundByHost = OUTBOUND_BY_HOST as Record<string, OutboundHandler>

--- a/tests/cloudflare-workers-stub.ts
+++ b/tests/cloudflare-workers-stub.ts
@@ -1,0 +1,22 @@
+// Stub for the `cloudflare:workers` virtual module, which only exists inside the
+// workerd runtime. The worker handler test runs in plain node, where importing
+// `@cloudflare/containers` (the NotionContainer base) would otherwise fail to
+// resolve `cloudflare:workers`. NotionContainer is never instantiated by the test
+// (fakeEnv has no NOTION binding), so these bases only need to be importable.
+export class DurableObject<Env = unknown> {
+  protected ctx: unknown
+  protected env: Env
+  constructor(ctx: unknown, env: Env) {
+    this.ctx = ctx
+    this.env = env
+  }
+}
+
+export class WorkerEntrypoint<Env = unknown> {
+  protected ctx: unknown
+  protected env: Env
+  constructor(ctx: unknown, env: Env) {
+    this.ctx = ctx
+    this.env = env
+  }
+}

--- a/tests/mcp-core-pin.test.ts
+++ b/tests/mcp-core-pin.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('mcp-core dependency pin', () => {
+  it('depends on a release shipping the CfKv + EdDSA seam (>=1.18.0-beta.5)', () => {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+      dependencies: Record<string, string>
+    }
+    const core = pkg.dependencies['@n24q02m/mcp-core']
+    expect(core).toBeDefined()
+    // Parse the version floor (strip a leading ^/>=/~ range operator). Compare as
+    // a version rather than asserting a literal substring, so a future floor bump
+    // within 1.18.x (e.g. beta.6) or a stable 1.18.0 release does not break this
+    // test (the brittleness that turned imagine's pin test red on the b5->b6 bump).
+    const m = /(\d+)\.(\d+)\.(\d+)(?:-beta\.(\d+))?/.exec(core ?? '')
+    expect(m).not.toBeNull()
+    const maj = Number(m![1])
+    const min = Number(m![2])
+    const pat = Number(m![3])
+    const beta = m![4] === undefined ? Number.NaN : Number(m![4])
+    // floor must be >= 1.18.0-beta.5: a stable >=1.18.0, OR a 1.18.0 beta >=5.
+    const atLeast =
+      maj > 1 ||
+      (maj === 1 && min > 18) ||
+      (maj === 1 && min === 18 && pat > 0) ||
+      (maj === 1 && min === 18 && pat === 0 && (Number.isNaN(beta) || beta >= 5))
+    expect(atLeast).toBe(true)
+  })
+})

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import worker, { NotionContainer, OUTBOUND_BY_HOST } from '../src/worker'
+
+function fakeEnv() {
+  const kv = new Map<string, ArrayBuffer>()
+  return {
+    KV: {
+      get: async (k: string, _type?: 'arrayBuffer') => (kv.has(k) ? kv.get(k)! : null),
+      put: async (k: string, v: ArrayBuffer) => void kv.set(k, v),
+      delete: async (k: string) => void kv.delete(k)
+    }
+  }
+}
+
+// Invoke an outbound handler DIRECTLY (the production path is the container proxy
+// via NotionContainer.outboundByHost; the handlers are NOT reachable through the
+// public `fetch` entrypoint, so tests exercise them through the exported registry).
+const kvH = OUTBOUND_BY_HOST['kv.internal']!
+
+describe('outbound registry (KV-only)', () => {
+  it('registers a kv.internal outbound handler', () => {
+    expect(NotionContainer.outboundByHost['kv.internal']).toBeDefined()
+    expect(OUTBOUND_BY_HOST['kv.internal']).toBeDefined()
+  })
+
+  it('does NOT register d1/vectorize handlers (KV-only)', () => {
+    expect(Object.keys(NotionContainer.outboundByHost)).toEqual(['kv.internal'])
+    expect(OUTBOUND_BY_HOST['d1.internal']).toBeUndefined()
+    expect(OUTBOUND_BY_HOST['vectorize.internal']).toBeUndefined()
+  })
+})
+
+describe('outbound handlers', () => {
+  it('KV get 404 then put then get 200 (binary arrayBuffer round-trip)', async () => {
+    const env = fakeEnv()
+    const key = 'better-notion%2Fsubs%2Fu1%2Fconfig'
+    const blob = new Uint8Array([1, 2, 3, 250, 0, 99]).buffer
+
+    let res = await kvH(new Request(`http://kv.internal/${key}`), env as never)
+    expect(res.status).toBe(404)
+
+    res = await kvH(new Request(`http://kv.internal/${key}`, { method: 'PUT', body: blob }), env as never)
+    expect(res.status).toBe(200)
+
+    res = await kvH(new Request(`http://kv.internal/${key}`), env as never)
+    expect(res.status).toBe(200)
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(new Uint8Array(blob))
+  })
+
+  it('KV DELETE returns 200', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/better-notion%2Fconfig', { method: 'DELETE' }), env as never)
+    expect(res.status).toBe(200)
+  })
+
+  it('KV readiness probe: GET __ready -> {ready:true}', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/__ready'), env as never)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ready: true })
+  })
+
+  it('readiness probe does not shadow a real missing key', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/better-notion%2Fsubs%2Fu1%2Fconfig'), env as never)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('public fetch entrypoint does NOT expose outbound handlers (security)', () => {
+  it('a public request with an internal hostname is NOT serviced by a handler', async () => {
+    const env = fakeEnv() // no NOTION binding -> DO routing path returns 404
+    // Even if an external caller spoofs the hostname to kv.internal, the public
+    // fetch must NOT read/write the credential KV — it only routes to the DO.
+    const res = await worker.fetch(new Request('http://kv.internal/better-notion%2Fconfig'), env as never)
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('not found')
+  })
+})
+
+describe('single-user DO contract + per-sub routing (E.2)', () => {
+  function envWithDoSpy() {
+    const calls: string[] = []
+    return {
+      calls,
+      env: {
+        NOTION: {
+          idFromName: (n: string) => {
+            calls.push(n)
+            return { name: n }
+          },
+          get: (_id: unknown) => ({ fetch: async () => new Response('do-hit', { status: 200 }) })
+        }
+      }
+    }
+  }
+
+  it('no Bearer token -> routes to the "default" DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://better-notion-mcp.n24q02m.com/mcp'), env as never)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('do-hit')
+    expect(calls).toEqual(['default'])
+  })
+
+  it('Bearer token without sub -> routes to the "default" DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
+    await worker.fetch(
+      new Request('https://better-notion-mcp.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      env as never
+    )
+    expect(calls).toEqual(['default'])
+  })
+
+  it('Bearer token with sub -> routes to that sub DO (per-user isolation)', async () => {
+    const { calls, env } = envWithDoSpy()
+    const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
+    await worker.fetch(
+      new Request('https://better-notion-mcp.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      env as never
+    )
+    expect(calls).toEqual(['user-123'])
+  })
+})

--- a/tests/wrangler-config.test.ts
+++ b/tests/wrangler-config.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// Minimal JSONC strip (line + block comments) for the test only.
+function readJsonc(path: string): Record<string, any> {
+  const raw = readFileSync(path, 'utf-8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/.*$/gm, '$1')
+  return JSON.parse(raw)
+}
+
+describe('wrangler.jsonc', () => {
+  const cfg = readJsonc('wrangler.jsonc')
+
+  it('binds the NotionContainer DO', () => {
+    expect(cfg.durable_objects.bindings[0].class_name).toBe('NotionContainer')
+    expect(cfg.durable_objects.bindings[0].name).toBe('NOTION')
+  })
+
+  it('declares a KV namespace and NO D1 / Vectorize (KV-only)', () => {
+    expect(cfg.kv_namespaces[0].binding).toBe('KV')
+    expect(cfg.d1_databases).toBeUndefined()
+    expect(cfg.vectorize).toBeUndefined()
+  })
+
+  it('forces http transport + PORT=8080 + cf-kv storage into the container', () => {
+    expect(cfg.vars.MCP_TRANSPORT).toBe('http')
+    expect(cfg.vars.PORT).toBe('8080')
+    expect(cfg.vars.MCP_STORAGE_BACKEND).toBe('cf-kv')
+    expect(cfg.vars.MCP_KV_BASE_URL).toBe('http://kv.internal')
+  })
+
+  it('pulls the image from the CF managed registry (not ghcr.io)', () => {
+    expect(cfg.containers[0].image).toContain('registry.cloudflare.com/')
+    expect(cfg.containers[0].image).not.toContain('ghcr.io')
+  })
+
+  it('routes the production custom domain', () => {
+    expect(cfg.routes[0].pattern).toBe('better-notion-mcp.n24q02m.com')
+    expect(cfg.routes[0].custom_domain).toBe(true)
+  })
+
+  it('never enables MCP_AUTH_DISABLE in vars (anonymous-bucket-collapse guard)', () => {
+    expect(cfg.vars.MCP_AUTH_DISABLE).toBeUndefined()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["test/**/*.ts", "scripts/**/*.ts", "src/**/*.ts"]
+  "include": ["test/**/*.ts", "scripts/**/*.ts", "src/**/*.ts"],
+  "exclude": ["src/worker.ts"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,22 @@
+// Isolated type-check for the Cloudflare Worker entrypoint (src/worker.ts).
+//
+// src/worker.ts targets the workerd runtime: it imports `@cloudflare/containers`
+// (which pulls the `cloudflare:workers` ambient module) and uses Worker globals
+// (Request/Response/atob/URL/crypto). Those are provided by
+// `@cloudflare/workers-types`, NOT by `@types/node`. The main tsconfig.json keeps
+// `types: ["node"]` for the rest of the server (which uses node globals), and
+// excludes src/worker.ts, so this file type-checks the worker in isolation with
+// the workers type set. Both run in the `type-check` script.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/worker.ts"],
+  "exclude": []
+}

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -15,6 +15,11 @@
     "declarationMap": false,
     "sourceMap": false,
     "types": ["@cloudflare/workers-types"],
+    // @cloudflare/containers' .d.ts does `import { DurableObject } from
+    // 'cloudflare:workers'`, an `export =` (CommonJS-namespace) module from
+    // workers-types. esModuleInterop lets that named import resolve so the
+    // Container base (and its inherited protected `env`) is visible to tsc.
+    "esModuleInterop": true,
     "noEmit": true
   },
   "include": ["src/worker.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,16 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  // The worker handler test (tests/worker.test.ts) runs in plain node.
+  // `@cloudflare/containers` (the NotionContainer base) imports the
+  // `cloudflare:workers` virtual module, which only exists in the workerd
+  // runtime, so alias it to a local stub for unit tests.
+  resolve: {
+    alias: {
+      'cloudflare:workers': fileURLToPath(new URL('./tests/cloudflare-workers-stub.ts', import.meta.url))
+    }
+  },
   test: {
     exclude: ['build/**', 'node_modules/**', 'bin/**', 'tests/live/**', 'tests/e2e*'],
     coverage: {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,49 @@
+// wrangler.jsonc - better-notion-mcp Cloudflare Worker + Container + KV.
+// Resource ID is a placeholder created out-of-band (wrangler kv namespace create)
+// and filled in at deploy time, not committed as a live ID.
+//
+// notion is KV-only: no D1 (no docs DB) and no Vectorize (no embeddings) blocks,
+// unlike the wet template this is copied from.
+{
+  "name": "better-notion-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  "containers": [
+    {
+      "name": "better-notion-mcp-worker",
+      "class_name": "NotionContainer",
+      // CF Containers pull ONLY from the Cloudflare managed registry (an external
+      // ghcr.io ref fails IMAGE_REGISTRY_NOT_CONFIGURED). Push the pre-built http
+      // image first: `docker pull ghcr.io/n24q02m/better-notion-mcp:beta &&
+      // docker tag ... better-notion-mcp:beta && wrangler containers push
+      // better-notion-mcp:beta`, then fill <YOUR_ACCOUNT_ID>. Re-pushing the same
+      // tag does NOT roll a running instance -> delete the container by ID
+      // (`wrangler containers list` -> ID) + `wrangler deploy` to recreate.
+      "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-notion-mcp:beta",
+      "instance_type": "standard-1",
+      "max_instances": 100
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "NOTION", "class_name": "NotionContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["NotionContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "<better-notion-kv-namespace-id>" }],
+  // Non-secret container config (forwarded into the container by
+  // NotionContainer.envVars). Secrets via `wrangler secret put`:
+  // CREDENTIAL_SECRET (-> JWTIssuer EdDSA HKDF, no-disk, survives recreate),
+  // NOTION_OAUTH_CLIENT_ID, NOTION_OAUTH_CLIENT_SECRET.
+  //
+  // MCP_AUTH_DISABLE is intentionally ABSENT: enabling it would collapse every
+  // JWT sub into the 'default' token bucket (http.ts) -> silent per-sub
+  // isolation loss. Never set auth-bypass on shared infra.
+  "vars": {
+    "MCP_TRANSPORT": "http",
+    "PORT": "8080",
+    "PUBLIC_URL": "https://better-notion-mcp.n24q02m.com",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal"
+  },
+  "routes": [{ "pattern": "better-notion-mcp.n24q02m.com", "custom_domain": true }],
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
## What

Migrates better-notion-mcp (http mode) from the OCI VM to Cloudflare (Worker + Container + KV-only), cloning the proven wet pilot pattern. FIRST TypeScript worker in the MCP stack.

## Phase A — Foundation
- Bump `@n24q02m/mcp-core` to `^1.18.0-beta.7` (CfKv + EdDSA seam; b7 also ships the `./storage` barrel subpath fix this server needs for Phase B).
- `src/worker.ts`: Worker fronting one per-JWT-sub `NotionContainer` Durable Object; `kv.internal` outbound handler serviced from the Worker KV binding. KV-only (D1/Vectorize dropped). Security: outbound handlers are OFF the public `fetch` (which only routes to the per-user DO) — exposing them would let a spoofed `kv.internal` host read/write the credential KV unauthenticated.
- `wrangler.jsonc`: KV-only bindings, container env wiring, `MCP_AUTH_DISABLE` deliberately absent.
- `CREDENTIAL_SECRET` -> EdDSA: env-only, no code change (mcp-core JWTIssuer already reads it). Verified end-to-end (same secret -> same key -> token survives "recreate").
- Type-check isolation: `src/worker.ts` is excluded from the main (node-typed) tsconfig and type-checked separately via `tsconfig.worker.json` (`@cloudflare/workers-types` + `esModuleInterop`).

## Phase B — KV write-through (D2: required)
- `KvNotionTokenStore`: per-sub Notion token write-through to KV via mcp-core `PerPluginStore` (AES-256-GCM; crypto never re-implemented). In-memory Map is a read cache; KV is the durable layer, so the token survives container delete+recreate (no re-auth).
- `selectTokenStore()`: `MCP_STORAGE_BACKEND=cf-kv` -> `KvNotionTokenStore`, otherwise the in-memory `NotionTokenStore` (stdio/local).

## CRITIC guards
- Anonymous/`default` bucket-collapse: regression test + `MCP_AUTH_DISABLE` absent from wrangler vars + hard deploy-guard (never auth-bypass on shared infra).
- `sleepAfter` eviction vs lock-refresh: verified eviction-safe (mcp-core `.unref()`s the timer; lock is ephemeral, re-swept on boot).

## Tests
891 vitest pass (existing + worker.test, wrangler-config.test, http.cf.test, notion-token-store-kv.test). `bun run check` clean (biome + tsc + tsc -p tsconfig.worker.json).

Live deploy gates (well-known/401, OAuth flow, token-survives-recreate-via-KV, per-sub isolation) run post-BETA against `better-notion-mcp.n24q02m.com`.