### PR TITLE
feat: deploy notion to Cloudflare at notion.n24q02m.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ package-lock.json
 *.bak
 /*.patch
 /*.diff
+
+# cf_full_flow.py per-run OAuth state (PKCE verifier + bearer JWT) — never commit
+scripts/.notion_cf_token*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ mise run fix                # bun run check:fix
 - CD: workflow_dispatch, chon beta/stable
 - Pipeline: PSR v10 -> npm publish (`@n24q02m/better-notion-mcp`) -> Docker multi-arch (amd64 + arm64) -> DockerHub + GHCR -> MCP Registry
 - OCI VM deploy: Docker Compose + Watchtower. Prod `:latest` 0.125G, Staging `:beta` 0.0625G
-- Domain: `better-notion-mcp.n24q02m.com` (prod), `better-notion-mcp-staging.n24q02m.com` (staging)
+- Cloudflare deploy (canonical, manual via wrangler): `notion.n24q02m.com` (Worker + Container + KV). Legacy OCI VM: `better-notion-mcp.n24q02m.com` (prod) / `better-notion-mcp-staging.n24q02m.com` (staging) — fallback until decommission.
 
 ## Pre-commit hooks
 
@@ -92,7 +92,7 @@ mise run fix                # bun run check:fix
 Two transports, selected in `init-server.ts:14-15` (delegated to `main.ts`). There is no `MCP_MODE` env var; the old `local-relay` / `remote-oauth` distinction was removed (see `transports/http.ts:4-9`).
 
 - **stdio (default)**: MCP SDK `StdioServerTransport` directly. Single-user; requires `NOTION_TOKEN`. Fails fast with a stderr message if the token is unset (`main.ts:76-91`). No local relay spawn.
-- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Always delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access token stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. Deploy at `https://better-notion-mcp.n24q02m.com`.
+- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Always delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access token stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. Deploy at `https://notion.n24q02m.com` (Cloudflare Worker + Container; legacy OCI VM at `https://better-notion-mcp.n24q02m.com`).
 
 ## Config storage path
 
@@ -108,7 +108,7 @@ cd ../mcp-core && uv run --project scripts/e2e python -m e2e.driver <config-id>
 
 Configs for this repo: `notion-paste-token`.
 
-Note: ``notion-oauth`` reclassified out of T2 matrix 2026-04-27 — verify post-deploy via manual smoke against ``better-notion-mcp.n24q02m.com`` only.
+Note: ``notion-oauth`` reclassified out of T2 matrix 2026-04-27 — verify post-deploy via manual smoke against ``notion.n24q02m.com`` (Cloudflare) only.
 
 Tier policy:
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — Better Notion MCP
 
-**Last updated:** 2026-03-08
+**Last updated:** 2026-06-16
 
 ## Data Collection
 
@@ -8,10 +8,11 @@ Better Notion MCP acts as a proxy between MCP clients (Claude, Cursor, etc.) and
 
 ## OAuth Mode (Remote Server)
 
-When using the remote server at `better-notion-mcp.n24q02m.com`:
+When using the remote server at `notion.n24q02m.com`:
 
-- **Authentication**: Uses Notion OAuth 2.0. Your Notion access token is used only for the duration of each request and is never stored on disk.
-- **No database**: The server is stateless. No user data, tokens, or session information is persisted between requests.
+- **Authentication**: Uses Notion OAuth 2.0.
+- **Token storage**: Your Notion access token is encrypted (AES-GCM) and stored in Cloudflare KV, scoped to your authenticated session (keyed by your OAuth identity) so that no other user can read it and so you do not have to re-authorize after a server restart. It is used only to call the Notion API on your behalf and is never logged.
+- **No content database**: Beyond the encrypted access token above, no Notion page content or session history is persisted between requests.
 - **Logging**: Only anonymous request metadata (timestamps, status codes) is logged for operational monitoring. No Notion content is logged.
 
 ## Stdio Mode (Local)
@@ -24,8 +25,7 @@ When running locally via npm or Docker:
 ## Third-Party Services
 
 - **Notion API** (`api.notion.com`): Your data is subject to [Notion's Privacy Policy](https://www.notion.so/Privacy-Policy-3468d120cf614d4c9014c09f6aab3571).
-- **Oracle Cloud Infrastructure**: The remote server runs on OCI. See [Oracle Cloud Privacy](https://www.oracle.com/legal/privacy/services-privacy-policy.html).
-- **Cloudflare**: DNS proxy for DDoS protection. See [Cloudflare Privacy](https://www.cloudflare.com/privacypolicy/).
+- **Cloudflare**: The remote server runs on Cloudflare (Workers + Containers + KV), which also provides DNS proxy and DDoS protection. See [Cloudflare Privacy](https://www.cloudflare.com/privacypolicy/).
 
 ## Contact
 

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -1,0 +1,201 @@
+"""CF better-notion-mcp live OAuth full-flow self-test harness.
+
+Drives the deployed better-notion-mcp Cloudflare Worker (Worker + Container + KV)
+end-to-end against a public endpoint. Unlike wet/imagine (local-form password
+grant, fully autonomous), notion uses DELEGATED Notion OAuth: the /authorize
+endpoint 302-redirects the user to Notion, who must APPROVE in their workspace.
+That approval is a genuine user gate -- this harness drives everything around it
+but cannot (and must not) automate the Notion "Allow" click.
+
+Flow (delegated authorization_code + PKCE, public client `local-browser`):
+  1. bootstrap  -- gen PKCE, GET /authorize -> capture the Notion authorize URL,
+                   persist the code_verifier; print the URL for the user to open.
+  2. (user)     -- open the URL, approve in Notion. The browser lands on
+                   <endpoint>/callback-done?code=<server_code>&state=... (a
+                   terminal "tab can be closed" page). Copy that final URL (or
+                   just the code value).
+  3. exchange   -- POST /token (code + code_verifier) -> bearer JWT; persist it;
+                   then an authenticated MCP round-trip: config(status) asserts
+                   has_token=true, users(me) returns the Notion bot user.
+  4. recreate-verify -- after `wrangler containers delete <id> && wrangler deploy`,
+                   REUSE the persisted JWT (EdDSA key is HKDF-deterministic from
+                   CREDENTIAL_SECRET, so the old JWT still verifies after recreate)
+                   and call config(status). has_token MUST still be true WITHOUT
+                   re-approving Notion -- proof the access token survived in KV
+                   (KvNotionTokenStore -> PerPluginStore, D2 KV write-through).
+
+The two-sub isolation gate (plan Task 8.6) needs TWO distinct Notion identities
+(two workspaces/accounts), so run `bootstrap`+`exchange` twice with --token-file
+pointed at two different files and confirm each sub's users(me) differs.
+
+Examples:
+  python scripts/cf_full_flow.py bootstrap
+  python scripts/cf_full_flow.py exchange --landing "https://notion.n24q02m.com/callback-done?code=...&state=..."
+  python scripts/cf_full_flow.py recreate-verify
+  python scripts/cf_full_flow.py bootstrap --token-file .notion_cf_token_b   # 2nd sub
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json as _json
+import secrets
+import sys
+import urllib.parse
+from pathlib import Path
+
+DEFAULT_ENDPOINT = "https://notion.n24q02m.com"
+CLIENT_ID = "local-browser"
+
+
+def _pkce_path(token_file: str) -> Path:
+    return Path(__file__).with_name(f"{token_file}.pkce")
+
+
+def _token_path(token_file: str) -> Path:
+    return Path(__file__).with_name(token_file)
+
+
+def _b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def _sub_of(token: str) -> str:
+    payload = _json.loads(base64.urlsafe_b64decode(token.split(".")[1] + "=="))
+    return payload.get("sub", "?")
+
+
+def bootstrap(endpoint: str, token_file: str) -> None:
+    import httpx  # lazy so --help works without deps
+
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+    state = _b64url(secrets.token_bytes(16))
+    redirect_uri = f"{endpoint}/callback-done"
+
+    with httpx.Client(timeout=60, follow_redirects=False) as c:
+        r = c.get(
+            f"{endpoint}/authorize",
+            params={
+                "client_id": CLIENT_ID,
+                "redirect_uri": redirect_uri,
+                "response_type": "code",
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+        )
+    if r.status_code != 302:
+        raise SystemExit(f"bootstrap: expected 302 from /authorize, got {r.status_code}: {r.text[:300]}")
+    notion_url = r.headers.get("location", "")
+    if "api.notion.com" not in notion_url:
+        raise SystemExit(f"bootstrap: /authorize did not redirect to Notion, got: {notion_url[:300]}")
+
+    _pkce_path(token_file).write_text(_json.dumps({"verifier": verifier, "state": state, "redirect_uri": redirect_uri}))
+    print("=" * 70)
+    print("OPEN THIS URL AND APPROVE IN NOTION:")
+    print(notion_url)
+    print("=" * 70)
+    print("After approving you land on a 'tab can be closed' page. Copy that full")
+    print("URL (it contains ?code=...) and run:")
+    print(f'  python scripts/cf_full_flow.py exchange --landing "<that URL>"')
+    print(f"(PKCE verifier saved to {_pkce_path(token_file).name})")
+
+
+def _extract_code(landing: str) -> str:
+    if "code=" not in landing:
+        # allow pasting the bare code too
+        return landing.strip()
+    q = urllib.parse.urlparse(landing).query or landing.split("?", 1)[-1]
+    code = urllib.parse.parse_qs(q).get("code", [""])[0]
+    if not code:
+        raise SystemExit(f"could not extract ?code= from: {landing[:200]}")
+    return code
+
+
+def exchange(endpoint: str, token_file: str, landing: str) -> None:
+    import httpx
+
+    pkce = _json.loads(_pkce_path(token_file).read_text())
+    code = _extract_code(landing)
+    with httpx.Client(timeout=60, follow_redirects=False) as c:
+        tok = c.post(
+            f"{endpoint}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "code_verifier": pkce["verifier"],
+                "redirect_uri": pkce["redirect_uri"],
+                "client_id": CLIENT_ID,
+            },
+        )
+    if tok.status_code != 200:
+        raise SystemExit(f"exchange: /token {tok.status_code}: {tok.text[:300]}")
+    jwt = tok.json()["access_token"]
+    _token_path(token_file).write_text(jwt)
+    print(f"TOKEN OK len={len(jwt)} sub={_sub_of(jwt)} (saved to {token_file})")
+    _run_session(endpoint, jwt, expect_has_token=True, probe_me=True)
+    print("EXCHANGE + AUTHENTICATED ROUND-TRIP PASS.")
+
+
+def recreate_verify(endpoint: str, token_file: str) -> None:
+    jwt = _token_path(token_file).read_text().strip()
+    print(f"Reusing JWT sub={_sub_of(jwt)} (no re-auth) after container recreate...")
+    _run_session(endpoint, jwt, expect_has_token=True, probe_me=True)
+    print("RECREATE-VERIFY PASS: JWT identity + Notion token survived recreate via KV (no re-auth).")
+
+
+def _run_session(endpoint: str, jwt: str, *, expect_has_token: bool, probe_me: bool) -> None:
+    import anyio
+
+    async def _go() -> None:
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        async with streamablehttp_client(
+            f"{endpoint}/mcp", headers={"Authorization": f"Bearer {jwt}"}
+        ) as (r, w, _), ClientSession(r, w) as s:
+            await s.initialize()
+            tools = await s.list_tools()
+            print("TOOLS:", [t.name for t in tools.tools])
+            st = await s.call_tool("config", {"action": "status"})
+            st_txt = "".join(getattr(b, "text", "") for b in st.content)
+            print("CONFIG_STATUS:", st_txt[:300].replace("\n", " "))
+            if expect_has_token:
+                assert '"has_token": true' in st_txt or '"has_token":true' in st_txt, (
+                    f"has_token is NOT true -- token did not survive / not saved: {st_txt[:300]}"
+                )
+                print("ASSERT OK: has_token=true.")
+            if probe_me:
+                me = await s.call_tool("users", {"action": "me"})
+                me_txt = "".join(getattr(b, "text", "") for b in me.content)
+                print("USERS_ME:", me_txt[:300].replace("\n", " "))
+                assert "error" not in me_txt.lower() or "bot" in me_txt.lower(), (
+                    f"users(me) failed -- Notion token not usable: {me_txt[:300]}"
+                )
+
+    anyio.run(_go)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="CF better-notion-mcp live OAuth full-flow harness")
+    ap.add_argument("mode", choices=["bootstrap", "exchange", "recreate-verify"])
+    ap.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    ap.add_argument("--landing", default="", help="the /callback-done URL (or bare code) for `exchange`")
+    ap.add_argument("--token-file", default=".notion_cf_token", help="per-sub token state file (use 2 for isolation)")
+    a = ap.parse_args()
+
+    if a.mode == "bootstrap":
+        bootstrap(a.endpoint, a.token_file)
+    elif a.mode == "exchange":
+        if not a.landing:
+            sys.exit("exchange requires --landing '<callback-done URL or code>'")
+        exchange(a.endpoint, a.token_file, a.landing)
+    else:
+        recreate_verify(a.endpoint, a.token_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.json
+++ b/server.json
@@ -45,7 +45,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://better-notion-mcp.n24q02m.com/mcp"
+      "url": "https://notion.n24q02m.com/mcp"
     }
   ]
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,6 +35,11 @@ export interface Env {
   MCP_KV_BASE_URL: string
   PUBLIC_URL: string
   PORT: string
+  // mcp-core core-ts defaults the listen host to 127.0.0.1 (local-server.ts).
+  // The CF container is reachable only when the server binds 0.0.0.0:8080, so
+  // HOST=0.0.0.0 is forwarded (matching the OCI VM compose). Without it the
+  // container "is not listening in the TCP address 10.0.0.1:8080".
+  HOST: string
   CREDENTIAL_SECRET: string
   NOTION_OAUTH_CLIENT_ID: string
   NOTION_OAUTH_CLIENT_SECRET: string
@@ -42,17 +47,26 @@ export interface Env {
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
 // process. Unset/empty values are dropped so an unused optional secret never
-// injects a blank.
-const CONTAINER_ENV_KEYS = [
+// injects a blank. Exported for the env-forwarding regression test (HOST must
+// stay in the list or the container binds 127.0.0.1 and CF can't reach it).
+export const CONTAINER_ENV_KEYS = [
   'MCP_TRANSPORT',
   'MCP_STORAGE_BACKEND',
   'MCP_KV_BASE_URL',
   'PUBLIC_URL',
   'PORT',
+  'HOST',
   'CREDENTIAL_SECRET',
   'NOTION_OAUTH_CLIENT_ID',
   'NOTION_OAUTH_CLIENT_SECRET'
 ] as const
+
+// CF Containers readiness-probe target (NotionContainer.pingEndpoint). The
+// default 'ping' hits path '/', which the delegated-OAuth server 302-redirects
+// through /authorize to api.notion.com (https) — the redirect-following probe
+// then dies on the https hop. The well-known doc answers 200 with no redirect.
+// Exported so the regression test pins it away from the default.
+export const CONTAINER_PING_ENDPOINT = 'ping/.well-known/oauth-protected-resource'
 
 function pickContainerEnv(env: Env): Record<string, string> {
   const out: Record<string, string> = {}
@@ -150,6 +164,10 @@ function extractUserId(request: Request): string {
 export class NotionContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '1h'
+  // Readiness-probe path override (see CONTAINER_PING_ENDPOINT): the default
+  // 'ping' redirect-chains through delegated Notion OAuth to an external https
+  // URL and breaks the CF container health check.
+  pingEndpoint = CONTAINER_PING_ENDPOINT
   // The container reaches api.notion.com over the public internet; kv.internal
   // stays intercepted (see outboundByHost).
   enableInternet = true

--- a/tests/live/full-notion.full.test.ts
+++ b/tests/live/full-notion.full.test.ts
@@ -19,7 +19,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 // ---------------------------------------------------------------------------
 
 const NOTION_TOKEN = process.env.NOTION_TOKEN ?? ''
-const PUBLIC_URL = 'https://better-notion-mcp.n24q02m.com'
+const PUBLIC_URL = 'https://notion.n24q02m.com'
 
 const TOOL_NAMES = [
   'pages',

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import worker, { NotionContainer, OUTBOUND_BY_HOST } from '../src/worker'
+import worker, { CONTAINER_ENV_KEYS, CONTAINER_PING_ENDPOINT, NotionContainer, OUTBOUND_BY_HOST } from '../src/worker'
 
 function fakeEnv() {
   const kv = new Map<string, ArrayBuffer>()
@@ -67,6 +67,23 @@ describe('outbound handlers', () => {
   })
 })
 
+describe('CF container readiness (TS-on-CF regressions)', () => {
+  // mcp-core core-ts binds 127.0.0.1 by default (local-server.ts). HOST must be
+  // forwarded so the container binds 0.0.0.0:8080 and CF can reach it
+  // (otherwise: "container is not listening in the TCP address 10.0.0.1:8080").
+  it('forwards HOST into the container env', () => {
+    expect(CONTAINER_ENV_KEYS).toContain('HOST')
+  })
+
+  // The default Container ping ('/') redirect-chains through delegated Notion
+  // OAuth to an external https URL, which the redirect-following readiness probe
+  // cannot connect to. Probe a static, non-redirecting 200 instead.
+  it('pings a non-redirecting well-known doc, not the default "/"', () => {
+    expect(CONTAINER_PING_ENDPOINT).toContain('.well-known/oauth-protected-resource')
+    expect(CONTAINER_PING_ENDPOINT).not.toBe('ping')
+  })
+})
+
 describe('public fetch entrypoint does NOT expose outbound handlers (security)', () => {
   it('a public request with an internal hostname is NOT serviced by a handler', async () => {
     const env = fakeEnv() // no NOTION binding -> DO routing path returns 404
@@ -97,7 +114,7 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
 
   it('no Bearer token -> routes to the "default" DO', async () => {
     const { calls, env } = envWithDoSpy()
-    const res = await worker.fetch(new Request('https://better-notion-mcp.n24q02m.com/mcp'), env as never)
+    const res = await worker.fetch(new Request('https://notion.n24q02m.com/mcp'), env as never)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('do-hit')
     expect(calls).toEqual(['default'])
@@ -107,7 +124,7 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
     await worker.fetch(
-      new Request('https://better-notion-mcp.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
       env as never
     )
     expect(calls).toEqual(['default'])
@@ -117,7 +134,7 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
     await worker.fetch(
-      new Request('https://better-notion-mcp.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
       env as never
     )
     expect(calls).toEqual(['user-123'])

--- a/tests/wrangler-config.test.ts
+++ b/tests/wrangler-config.test.ts
@@ -30,13 +30,17 @@ describe('wrangler.jsonc', () => {
     expect(cfg.vars.MCP_KV_BASE_URL).toBe('http://kv.internal')
   })
 
+  it('binds the container to 0.0.0.0 (TS mcp-core defaults to 127.0.0.1, unreachable on CF)', () => {
+    expect(cfg.vars.HOST).toBe('0.0.0.0')
+  })
+
   it('pulls the image from the CF managed registry (not ghcr.io)', () => {
     expect(cfg.containers[0].image).toContain('registry.cloudflare.com/')
     expect(cfg.containers[0].image).not.toContain('ghcr.io')
   })
 
   it('routes the production custom domain', () => {
-    expect(cfg.routes[0].pattern).toBe('better-notion-mcp.n24q02m.com')
+    expect(cfg.routes[0].pattern).toBe('notion.n24q02m.com')
     expect(cfg.routes[0].custom_domain).toBe(true)
   })
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -40,10 +40,14 @@
   "vars": {
     "MCP_TRANSPORT": "http",
     "PORT": "8080",
-    "PUBLIC_URL": "https://better-notion-mcp.n24q02m.com",
+    // mcp-core core-ts binds 127.0.0.1 by default; the CF container is only
+    // reachable when the http server binds 0.0.0.0:8080 (same as the OCI VM
+    // compose). Without HOST the container "is not listening on 10.0.0.1:8080".
+    "HOST": "0.0.0.0",
+    "PUBLIC_URL": "https://notion.n24q02m.com",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal"
   },
-  "routes": [{ "pattern": "better-notion-mcp.n24q02m.com", "custom_domain": true }],
+  "routes": [{ "pattern": "notion.n24q02m.com", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
Lands the better-notion-mcp Cloudflare Worker+Container+KV deployment (live at https://notion.n24q02m.com) and fixes two TS-on-CF startup bugs not covered by the wet/Python template.

## What
- **Bind 0.0.0.0**: mcp-core core-ts defaults the listen host to `127.0.0.1`, so the container was unreachable on CF (`not listening on 10.0.0.1:8080`). Forward `HOST=0.0.0.0` (wrangler var + `CONTAINER_ENV_KEYS`), matching the OCI VM compose.
- **Readiness ping**: the CF Container readiness probe GETs `/` and follows redirects; for this delegated-OAuth server `/` -> `/authorize` -> `https://api.notion.com/...`, and the probe dies on the external https hop. Override `pingEndpoint` to the static `/.well-known/oauth-protected-resource` (200, no redirect).
- **Hostname**: custom domain `notion.n24q02m.com` (short, fresh). The legacy `better-notion-mcp.n24q02m.com` keeps serving the OCI VM until decommission.
- **Docs**: `server.json` remote URL, `PRIVACY.md` (Cloudflare + encrypted per-sub token at rest in KV, replacing the stale "stateless/OCI" wording), `CLAUDE.md`.
- **Harness**: `scripts/cf_full_flow.py` drives the delegated-OAuth full flow + the token-survives-recreate gate.

## Verified live (2026-06-16)
- `/.well-known/oauth-protected-resource` -> 200
- `/mcp` no token -> 401 + `WWW-Authenticate`
- JWKS -> EdDSA (kid HKDF-deterministic from `CREDENTIAL_SECRET`)
- `cf_full_flow.py bootstrap` -> valid Notion authorize URL through the deployed Worker+container

## Tests
905/905 pass; new regression guards for HOST forwarding, pingEndpoint, and the hostname.