### PR TITLE
fix: persist per-sub Notion token to KV so it survives container recreate

### DIFF
--- a/src/auth/notion-token-store-kv.test.ts
+++ b/src/auth/notion-token-store-kv.test.ts
@@ -69,4 +69,24 @@ describe('KvNotionTokenStore', () => {
     const cold = new KvNotionTokenStore({ http })
     expect(await cold.getAsync('alice')).toBeUndefined()
   })
+
+  it('ready() resolves when the kv.internal outbound path is reachable', async () => {
+    process.env.CREDENTIAL_SECRET = 'test-secret'
+    const store = new KvNotionTokenStore({ http: new FakeKvHttp() })
+    // A reachable backend (200/404 both count as "answered") -> no throw.
+    await expect(store.ready()).resolves.toBeUndefined()
+  })
+
+  it('ready() rejects when the container -> Worker outbound is not wired', async () => {
+    process.env.CREDENTIAL_SECRET = 'test-secret'
+    // Simulate broken outbound interception: the fetch to kv.internal fails at
+    // the transport layer (NXDOMAIN / connection refused) instead of answering.
+    const brokenHttp = {
+      async request(): Promise<{ status: number; body: Uint8Array }> {
+        throw new Error('getaddrinfo ENOTFOUND kv.internal')
+      }
+    }
+    const store = new KvNotionTokenStore({ http: brokenHttp })
+    await expect(store.ready()).rejects.toThrow(/kv\.internal/)
+  })
 })

--- a/src/auth/notion-token-store-kv.ts
+++ b/src/auth/notion-token-store-kv.ts
@@ -90,4 +90,14 @@ export class KvNotionTokenStore implements NotionTokenStoreLike {
     // already scoped to this sub via storeFor) and removes the (plugin, sub) blob.
     await this.storeFor(sub).clear()
   }
+
+  // Startup readiness probe: confirm the container -> Worker `kv.internal`
+  // outbound path is wired BEFORE the first credential write. Hits the Worker's
+  // kvOutbound `__ready` branch (reserved key, returns 200) via the backend; a
+  // broken outbound interception makes the underlying fetch to kv.internal fail
+  // (NXDOMAIN / connection refused) and this throws, so the HTTP transport can
+  // log it loudly at startup instead of losing the first token write silently.
+  async ready(): Promise<void> {
+    await this.backend.get('__ready')
+  }
 }

--- a/src/auth/notion-token-store.ts
+++ b/src/auth/notion-token-store.ts
@@ -7,8 +7,27 @@
  */
 export interface NotionTokenStoreLike {
   save(sub: string, accessToken: string): Promise<void> | void
+  /**
+   * Synchronous read of the in-memory cache only (hot path: the Notion client
+   * factory runs per tool invocation). The durable KV variant returns the
+   * cached value here; a cold cache after container recreate is warmed by
+   * ``getAsync`` (called once per request in the HTTP transport's authScope).
+   */
   get(sub: string): string | undefined
+  /**
+   * Read through to the durable layer, warming the cache on a hit. The
+   * in-memory store has no durable layer so this resolves to the cached value.
+   * The KV store loads + decrypts the per-(plugin, sub) blob from Workers KV,
+   * which is what makes a token survive container delete+recreate.
+   */
+  getAsync(sub: string): Promise<string | undefined>
   clear(sub: string): Promise<void> | void
+  /**
+   * Optional durable-store readiness probe (KV deploy). When present, the HTTP
+   * transport calls it at startup so a broken container -> Worker outbound path
+   * surfaces in deploy logs instead of silently dropping the first token write.
+   */
+  ready?(): Promise<void>
 }
 
 /**
@@ -27,6 +46,12 @@ export class NotionTokenStore {
   }
 
   get(sub: string): string | undefined {
+    return this.tokens.get(sub)
+  }
+
+  // No durable layer: the cache IS the source of truth, so getAsync just mirrors
+  // the synchronous read (satisfies NotionTokenStoreLike uniformly).
+  async getAsync(sub: string): Promise<string | undefined> {
     return this.tokens.get(sub)
   }
 

--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { NotionTokenStore } from '../auth/notion-token-store.js'
-import { selectTokenStore } from './http.js'
+import { deriveSubject, selectTokenStore } from './http.js'
 
 describe('CREDENTIAL_SECRET -> EdDSA signing (deterministic, no-disk)', () => {
   it('JWTIssuer selects EdDSA when CREDENTIAL_SECRET is set, RS256 when unset', async () => {
@@ -61,6 +61,36 @@ describe('token store selection', () => {
   it('selects the in-memory NotionTokenStore otherwise', async () => {
     delete process.env.MCP_STORAGE_BACKEND
     expect(selectTokenStore()).toBeInstanceOf(NotionTokenStore)
+  })
+
+  it('only the durable KV store exposes a readiness probe (startup self-validation)', async () => {
+    process.env.MCP_STORAGE_BACKEND = 'cf-kv'
+    process.env.MCP_KV_BASE_URL = 'http://kv.internal'
+    expect(typeof selectTokenStore().ready).toBe('function')
+    delete process.env.MCP_STORAGE_BACKEND
+    // the in-memory store has no durable layer -> no probe -> startup skips it
+    expect(selectTokenStore().ready).toBeUndefined()
+  })
+})
+
+describe('deriveSubject (Notion token response -> JWT sub, per-sub isolation)', () => {
+  it('prefers owner.user.id (the human user)', () => {
+    expect(deriveSubject({ owner: { user: { id: 'usr-1' } }, workspace_id: 'ws-1', bot_id: 'bot-1' })).toBe('usr-1')
+  })
+
+  it('falls back to workspace_id, then bot_id', () => {
+    expect(deriveSubject({ workspace_id: 'ws-1', bot_id: 'bot-1' })).toBe('ws-1')
+    expect(deriveSubject({ bot_id: 'bot-1' })).toBe('bot-1')
+  })
+
+  it('never reads the (non-existent) owner_user_id field', () => {
+    // Guards the prior bug: Notion has no owner_user_id, so reading it collapsed
+    // every caller onto the shared 'default' bucket (isolation loss).
+    expect(deriveSubject({ owner_user_id: 'ghost' } as Record<string, unknown>)).toBe('default')
+  })
+
+  it('returns the default bucket only for a malformed response', () => {
+    expect(deriveSubject({ access_token: 'x' })).toBe('default')
   })
 })
 

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -12,6 +12,7 @@ vi.mock('@n24q02m/mcp-core', () => ({
 
 const mockTokenStoreInstance = {
   get: vi.fn(),
+  getAsync: vi.fn().mockResolvedValue(undefined),
   save: vi.fn(),
   clear: vi.fn()
 }
@@ -223,26 +224,35 @@ describe('startHttp', () => {
     const onTokenReceived = options.delegatedOAuth?.onTokenReceived
     const authScope = options.authScope
 
-    // Test onTokenReceived - success
-    const sub = onTokenReceived!({ access_token: 'new-token', owner_user_id: 'user2' })
+    // Test onTokenReceived - success. Notion's token response identifies the
+    // user by owner.user.id (NOT owner_user_id), so the derived sub is that id.
+    const sub = await onTokenReceived!({ access_token: 'new-token', owner: { user: { id: 'user2' } } })
     expect(sub).toBe('user2')
     expect(mockTokenStoreInstance.save).toHaveBeenCalledWith('user2', 'new-token')
 
     // Test onTokenReceived - missing access_token (should not save)
     mockTokenStoreInstance.save.mockClear()
-    const sub2 = onTokenReceived!({ owner_user_id: 'user3' })
+    const sub2 = await onTokenReceived!({ owner: { user: { id: 'user3' } } })
     expect(sub2).toBe('user3')
     expect(mockTokenStoreInstance.save).not.toHaveBeenCalled()
 
-    // Test onTokenReceived - missing owner_user_id (should default to 'default')
-    const sub3 = onTokenReceived!({ access_token: 'token-3' })
-    expect(sub3).toBe('default')
-    expect(mockTokenStoreInstance.save).toHaveBeenCalledWith('default', 'token-3')
+    // Test onTokenReceived - no owner: fall back to workspace_id, then bot_id.
+    const sub3 = await onTokenReceived!({ access_token: 'token-3', workspace_id: 'ws-9' })
+    expect(sub3).toBe('ws-9')
+    expect(mockTokenStoreInstance.save).toHaveBeenCalledWith('ws-9', 'token-3')
 
-    // Test authScope - normal
+    // Test onTokenReceived - malformed (no identity field) -> 'default'
+    mockTokenStoreInstance.save.mockClear()
+    const sub3b = await onTokenReceived!({ access_token: 'token-4' })
+    expect(sub3b).toBe('default')
+    expect(mockTokenStoreInstance.save).toHaveBeenCalledWith('default', 'token-4')
+
+    // Test authScope - normal + warms the per-sub cache from the durable store
     const next = vi.fn().mockResolvedValue(undefined)
+    mockTokenStoreInstance.getAsync.mockClear()
     await authScope!({ sub: 'user3' }, next)
     expect(next).toHaveBeenCalled()
+    expect(mockTokenStoreInstance.getAsync).toHaveBeenCalledWith('user3')
 
     // Test authScope - captured sub
     let capturedSub: string | undefined

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -39,10 +39,50 @@ export function selectTokenStore(): NotionTokenStoreLike {
   return new NotionTokenStore()
 }
 
+/**
+ * Derive the JWT subject from the upstream Notion token response.
+ *
+ * Notion's OAuth token payload identifies the authorizing principal by
+ * ``owner.user.id`` (user-level integrations) and ALWAYS carries
+ * ``workspace_id`` + ``bot_id``. There is NO ``owner_user_id`` field. Prefer the
+ * human user id for per-user isolation, then fall back to the workspace, then
+ * the bot, so the JWT ``sub`` (and thus the per-sub Durable Object + KV token
+ * bucket) is a stable real identity rather than the shared ``'default'`` bucket
+ * — collapsing every caller onto ``'default'`` would silently break multi-user
+ * isolation. ``'default'`` is reserved for a malformed response only.
+ */
+export function deriveSubject(tokens: Record<string, unknown>): string {
+  const owner = tokens.owner as { user?: { id?: unknown } } | undefined
+  const userId = owner?.user?.id
+  if (typeof userId === 'string' && userId) return userId
+  const workspaceId = tokens.workspace_id
+  if (typeof workspaceId === 'string' && workspaceId) return workspaceId
+  const botId = tokens.bot_id
+  if (typeof botId === 'string' && botId) return botId
+  return 'default'
+}
+
 export async function startHttp(): Promise<void> {
   await resolveCredentialState()
 
   const tokenStore = selectTokenStore()
+
+  // Self-validating deploy: when the durable KV store is selected (Cloudflare),
+  // confirm the container -> Worker `kv.internal` outbound path is wired at
+  // startup. If it is NOT, the fire path of the first token write would vanish
+  // silently and the token would never survive a container recreate. Log the
+  // outcome loudly; non-fatal so /authorize still runs, but a broken outbound
+  // path is now visible in `wrangler tail` instead of being invisible.
+  if (tokenStore.ready) {
+    try {
+      await tokenStore.ready()
+      console.error(`[${SERVER_NAME}] durable KV store reachable (kv.internal outbound wired)`)
+    } catch (err) {
+      console.error(
+        `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+  }
 
   const notionClientFactory = () => {
     const ctx = subjectContext.getStore()
@@ -94,16 +134,23 @@ export async function startHttp(): Promise<void> {
         clientSecret,
         scopes: []
       },
-      onTokenReceived: (tokens: Record<string, unknown>) => {
+      onTokenReceived: async (tokens: Record<string, unknown>) => {
         const accessToken = String(tokens.access_token ?? '')
-        const sub = String((tokens as { owner_user_id?: string }).owner_user_id ?? 'default')
-        // save() may be async on the KV store; the cache is set synchronously
-        // inside it before the awaited KV write, so the immediately-following
-        // factory read hits the warm cache. Fire-and-forget the durable write.
-        if (accessToken) void tokenStore.save(sub, accessToken)
-        // Return sub so mcp-core (>=1.6.2) propagates it into the bearer
-        // JWT's `sub` claim, which `authScope` below then matches back
-        // to the stored Notion token.
+        const sub = deriveSubject(tokens)
+        // Structural breadcrumb (KEY NAMES + derived sub only, NEVER token
+        // values) so the Notion token response shape is verifiable in deploy
+        // logs without leaking the access token.
+        console.error(`[${SERVER_NAME}] onTokenReceived keys=[${Object.keys(tokens).join(',')}] sub=${sub}`)
+        // AWAIT the durable write (do not fire-and-forget). The KV store sets
+        // its in-memory cache synchronously before the awaited KV PUT, so the
+        // same-request factory read still hits the warm cache. mcp-core wraps
+        // this callback in try/catch and returns a 500 "Failed to persist
+        // tokens" to the browser if it throws — so a broken KV write surfaces
+        // at auth time instead of silently losing the token once the in-memory
+        // cache evaporates on container recreate.
+        if (accessToken) await tokenStore.save(sub, accessToken)
+        // Return sub so mcp-core propagates it into the bearer JWT's `sub`
+        // claim, which `authScope` below then matches back to the stored token.
         return sub
       }
     },
@@ -111,6 +158,18 @@ export async function startHttp(): Promise<void> {
       // Anonymous caller (auth-disabled mode behind gateway): use 'default'
       // bucket so a single deployment can serve one Notion token via env.
       const sub = claims.anonymous === true ? 'default' : typeof claims.sub === 'string' ? claims.sub : 'default'
+      // Warm the per-sub cache from the durable store (KV) BEFORE the tool
+      // dispatch reads it synchronously via the factory/resolver. After a
+      // container delete+recreate the in-memory cache is empty; without this a
+      // freshly-recreated container would report no token (forcing needless
+      // re-auth) even though the encrypted token is still in KV. No-op for the
+      // in-memory store. A KV read failure is treated as a cache miss (re-auth)
+      // and never blocks the request.
+      try {
+        await tokenStore.getAsync(sub)
+      } catch {
+        // durable read failed -> fall through to cache-miss handling downstream
+      }
       await subjectContext.run({ sub }, next)
     }
   })


### PR DESCRIPTION
## Problem

On the Cloudflare deploy (Worker + Container + KV) the per-sub Notion access token did not survive a container delete+recreate: a recreated container reported `has_token=false` and forced the user to re-authorize, defeating the durable KV write-through.

## Root causes

- **Read (primary):** after a container recreate the in-memory cache is empty, but the Notion client factory and the subject-token resolver only read the cache synchronously — nothing loaded the token back from KV. The encrypted blob was in KV the whole time; it was just never read. Fix: warm the per-sub cache from KV in `authScope` (async, per request) before tool dispatch.
- **Subject:** Notion's OAuth token response has no `owner_user_id`; reading it collapsed every caller onto the shared `default` bucket (per-sub isolation loss). Derive the JWT `sub` from `owner.user.id`, then `workspace_id`, then `bot_id`.
- **Write:** `onTokenReceived` fire-and-forgot the KV save (`void tokenStore.save`), so any write failure was swallowed while the in-memory cache still reported `has_token=true`. Await the save — mcp-core wraps the callback in try/catch and returns 500 on failure, so a broken write surfaces at auth time.

Also adds a startup KV readiness probe (`__ready`) so a broken container->Worker outbound path is logged at startup.

## Live verification (notion.n24q02m.com)

- well-known 200, /mcp 401, /health 200
- Delegated Notion OAuth: real user approval -> JWT `sub` = real Notion user id (not `default`) -> `config(status).has_token=true` + `users(me)` returns the bot
- KEY GATE: deleted + recreated the container, reused the existing JWT (no re-auth) -> `has_token=true`, token still usable. Tail confirms the cache-miss `GET kv.internal/.../config` read after recreate.
- 912/912 unit tests pass, type-check clean.