### PR TITLE
fix: forward MCP_RELAY_PASSWORD into CF container so Gate A is enforced

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -41,6 +41,10 @@ export interface Env {
   // container "is not listening in the TCP address 10.0.0.1:8080".
   HOST: string
   CREDENTIAL_SECRET: string
+  // Gate A (shared relay-password front door). Forwarding it gates /authorize
+  // behind /login like the OCI VM; omitting it leaves an open self-service relay
+  // even though the OAuth step itself is delegated to Notion.
+  MCP_RELAY_PASSWORD: string
   NOTION_OAUTH_CLIENT_ID: string
   NOTION_OAUTH_CLIENT_SECRET: string
 }
@@ -57,6 +61,7 @@ export const CONTAINER_ENV_KEYS = [
   'PORT',
   'HOST',
   'CREDENTIAL_SECRET',
+  'MCP_RELAY_PASSWORD',
   'NOTION_OAUTH_CLIENT_ID',
   'NOTION_OAUTH_CLIENT_SECRET'
 ] as const

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -75,6 +75,13 @@ describe('CF container readiness (TS-on-CF regressions)', () => {
     expect(CONTAINER_ENV_KEYS).toContain('HOST')
   })
 
+  // Gate A (shared relay-password). Dropping it from the forwarded env turns the
+  // deployed server into an open self-service relay -- /authorize stops gating
+  // behind /login even though the OAuth step is delegated to Notion.
+  it('forwards MCP_RELAY_PASSWORD (Gate A) into the container env', () => {
+    expect(CONTAINER_ENV_KEYS).toContain('MCP_RELAY_PASSWORD')
+  })
+
   // The default Container ping ('/') redirect-chains through delegated Notion
   // OAuth to an external https URL, which the redirect-following readiness probe
   // cannot connect to. Probe a static, non-redirecting 200 instead.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,6 +32,7 @@
   // Non-secret container config (forwarded into the container by
   // NotionContainer.envVars). Secrets via `wrangler secret put`:
   // CREDENTIAL_SECRET (-> JWTIssuer EdDSA HKDF, no-disk, survives recreate),
+  // MCP_RELAY_PASSWORD (Gate A shared relay-password front door),
   // NOTION_OAUTH_CLIENT_ID, NOTION_OAUTH_CLIENT_SECRET.
   //
   // MCP_AUTH_DISABLE is intentionally ABSENT: enabling it would collapse every


### PR DESCRIPTION
## Security fix (verified live 2026-06-16)

`notion.n24q02m.com` served `/authorize` straight to Notion OAuth **without** the shared relay-password `/login` front door (Gate A) — an open self-service relay: anyone could attach their own Notion to the deployed server. Per-sub isolation separates data between members but does not limit *who* becomes a member; that is Gate A's job.

### Root cause
`CONTAINER_ENV_KEYS` in `src/worker.ts` is the only allowlist that injects env/secrets into the container (`pickContainerEnv` drops anything not listed). `MCP_RELAY_PASSWORD` was missing → mcp-core saw it empty → Gate A disabled. wet/email/imagine had it; telegram had the same bug (fixed separately).

### Fix
- Add `MCP_RELAY_PASSWORD` to the `Env` interface + `CONTAINER_ENV_KEYS`.
- Regression test: `CONTAINER_ENV_KEYS` must contain `MCP_RELAY_PASSWORD`.

### Verified live
After deploy + `wrangler secret put MCP_RELAY_PASSWORD` + container recreate: `curl -sIL .../authorize?...` now lands on `/login` (relay-password form), matching the OCI VM. `/mcp` 401, well-known 200.