### PR TITLE
fix: neutral default endpoint + env-first secrets in CF self-host scripts

### DIFF
--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -46,7 +46,10 @@ import sys
 import urllib.parse
 from pathlib import Path
 
-DEFAULT_ENDPOINT = "https://notion.n24q02m.com"
+# No hardcoded host: set CF_ENDPOINT or pass --endpoint https://<your-worker-domain>.
+# This self-tests YOUR deployed CF server; creds come from env (MCP_RELAY_PASSWORD +
+# provider keys) -- the maintainer injects them via skret, but any export works.
+DEFAULT_ENDPOINT = os.environ.get("CF_ENDPOINT", "")
 CLIENT_ID = "local-browser"
 
 
@@ -88,12 +91,20 @@ def bootstrap(endpoint: str, token_file: str) -> None:
             },
         )
     if r.status_code != 302:
-        raise SystemExit(f"bootstrap: expected 302 from /authorize, got {r.status_code}: {r.text[:300]}")
+        raise SystemExit(
+            f"bootstrap: expected 302 from /authorize, got {r.status_code}: {r.text[:300]}"
+        )
     notion_url = r.headers.get("location", "")
     if "api.notion.com" not in notion_url:
-        raise SystemExit(f"bootstrap: /authorize did not redirect to Notion, got: {notion_url[:300]}")
+        raise SystemExit(
+            f"bootstrap: /authorize did not redirect to Notion, got: {notion_url[:300]}"
+        )
 
-    _pkce_path(token_file).write_text(_json.dumps({"verifier": verifier, "state": state, "redirect_uri": redirect_uri}))
+    _pkce_path(token_file).write_text(
+        _json.dumps(
+            {"verifier": verifier, "state": state, "redirect_uri": redirect_uri}
+        )
+    )
     print("=" * 70)
     print("OPEN THIS URL AND APPROVE IN NOTION:")
     print(notion_url)
@@ -144,19 +155,26 @@ def recreate_verify(endpoint: str, token_file: str) -> None:
     jwt = _token_path(token_file).read_text().strip()
     print(f"Reusing JWT sub={_sub_of(jwt)} (no re-auth) after container recreate...")
     _run_session(endpoint, jwt, expect_has_token=True, probe_me=True)
-    print("RECREATE-VERIFY PASS: JWT identity + Notion token survived recreate via KV (no re-auth).")
+    print(
+        "RECREATE-VERIFY PASS: JWT identity + Notion token survived recreate via KV (no re-auth)."
+    )
 
 
-def _run_session(endpoint: str, jwt: str, *, expect_has_token: bool, probe_me: bool) -> None:
+def _run_session(
+    endpoint: str, jwt: str, *, expect_has_token: bool, probe_me: bool
+) -> None:
     import anyio
 
     async def _go() -> None:
         from mcp import ClientSession
         from mcp.client.streamable_http import streamablehttp_client
 
-        async with streamablehttp_client(
-            f"{endpoint}/mcp", headers={"Authorization": f"Bearer {jwt}"}
-        ) as (r, w, _), ClientSession(r, w) as s:
+        async with (
+            streamablehttp_client(
+                f"{endpoint}/mcp", headers={"Authorization": f"Bearer {jwt}"}
+            ) as (r, w, _),
+            ClientSession(r, w) as s,
+        ):
             await s.initialize()
             tools = await s.list_tools()
             print("TOOLS:", [t.name for t in tools.tools])
@@ -180,11 +198,21 @@ def _run_session(endpoint: str, jwt: str, *, expect_has_token: bool, probe_me: b
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="CF better-notion-mcp live OAuth full-flow harness")
+    ap = argparse.ArgumentParser(
+        description="CF better-notion-mcp live OAuth full-flow harness"
+    )
     ap.add_argument("mode", choices=["bootstrap", "exchange", "recreate-verify"])
     ap.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
-    ap.add_argument("--landing", default="", help="the /callback-done URL (or bare code) for `exchange`")
-    ap.add_argument("--token-file", default=".notion_cf_token", help="per-sub token state file (use 2 for isolation)")
+    ap.add_argument(
+        "--landing",
+        default="",
+        help="the /callback-done URL (or bare code) for `exchange`",
+    )
+    ap.add_argument(
+        "--token-file",
+        default=".notion_cf_token",
+        help="per-sub token state file (use 2 for isolation)",
+    )
     a = ap.parse_args()
 
     if a.mode == "bootstrap":

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -8,17 +8,20 @@ managed registry, deploys, waits for the container rollout to finish
 (STATE=ready) so you never verify against a half-rolled old image, then runs a
 **credential-free canary gate** and **auto-rolls-back** if it fails.
 
-Run from the repo root, with the CF dev token injected by skret:
+Set CLOUDFLARE_API_TOKEN in the environment (any secret manager works), then run
+from the repo root:
 
-    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- \\
-        python scripts/deploy_cf.py            # tag defaults to b-<short-sha>
-    ... python scripts/deploy_cf.py --tag b10-abc1234   # explicit tag
-    ... python scripts/deploy_cf.py --skip-build         # reuse a built image
-    ... python scripts/deploy_cf.py --dry-run            # print the plan only
-    ... python scripts/deploy_cf.py --no-canary          # skip the post-deploy gate
+    export CLOUDFLARE_API_TOKEN=...                       # however you store secrets
+    python scripts/deploy_cf.py                           # tag defaults to b-<short-sha>
+    ... python scripts/deploy_cf.py --tag b10-abc1234     # explicit tag
+    ... python scripts/deploy_cf.py --skip-build          # reuse a built image
+    ... python scripts/deploy_cf.py --dry-run             # print the plan only
+    ... python scripts/deploy_cf.py --no-canary           # skip the post-deploy gate
 
-Requires: CLOUDFLARE_API_TOKEN in env (skret /n24q02m/dev CF_DEV_TOKEN ->
-export CLOUDFLARE_API_TOKEN), docker, and ``bunx wrangler``. The CF container
+The maintainer injects the token via ``skret`` (one option), e.g.:
+    MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- python scripts/deploy_cf.py
+
+Requires: CLOUDFLARE_API_TOKEN in env, docker, and ``bunx wrangler``. The CF container
 registry only pulls from registry.cloudflare.com/<account>/... (not ghcr), so the
 local image is tagged to that path before ``wrangler containers push``.
 


### PR DESCRIPTION
Polishes the public CF self-host scripts so they are neutral for any self-hoster (per README 'Run your own ... instance on Cloudflare' + docs/cf-deploy.md placeholder runbook): (1) cf_full_flow.py no longer defaults to a maintainer-specific *.n24q02m.com host — it reads CF_ENDPOINT or requires --endpoint; (2) docstrings frame secrets env-first (CLOUDFLARE_API_TOKEN / MCP_RELAY_PASSWORD / provider keys set via any manager) with skret shown only as the maintainer's convenience. No behaviour change for the maintainer (export CF_ENDPOINT) and no functional change to the deploy/canary flow.