### PR TITLE
fix: right-size CF container to cut GiB-second cost

### DIFF
--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -95,15 +95,15 @@ describe('deriveSubject (Notion token response -> JWT sub, per-sub isolation)', 
 })
 
 describe('sleepAfter eviction vs lock-refresh interval (CRITIC)', () => {
-  it('the worker DO sets sleepAfter=1h (eviction is safe; worker adds no own timer)', () => {
+  it('the worker DO sets sleepAfter=5m (eviction is safe; worker adds no own timer)', () => {
     // A slept DO stops the mcp-core lock-refresh timer, which is safe because
     // (a) mcp-core unref()s it so it never blocks, and (b) the lock file is
     // ephemeral and re-swept on next boot. Assert the worker does not try to
-    // defeat eviction with its own timer, and keeps the 1h sleep window.
+    // defeat eviction with its own timer, and keeps the 5m sleep window.
     // (worker.ts is excluded from the main tsconfig project, so assert against
     // its source text rather than importing it across the project boundary.)
     const src = readFileSync('src/worker.ts', 'utf-8')
     expect(src).not.toContain('setInterval')
-    expect(src).toContain("sleepAfter = '1h'")
+    expect(src).toContain("sleepAfter = '5m'")
   })
 })

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -168,7 +168,7 @@ function extractUserId(request: Request): string {
 // (Dockerfile http target: PORT=8080 + EXPOSE 8080).
 export class NotionContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '1h'
+  sleepAfter = '5m'
   // Readiness-probe path override (see CONTAINER_PING_ENDPOINT): the default
   // 'ping' redirect-chains through delegated Notion OAuth to an external https
   // URL and breaks the CF container health check.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,8 +20,8 @@
       // tag does NOT roll a running instance -> delete the container by ID
       // (`wrangler containers list` -> ID) + `wrangler deploy` to recreate.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-notion-mcp:beta",
-      "instance_type": "standard-1",
-      "max_instances": 100
+      "instance_type": "basic",
+      "max_instances": 10
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Why

Container memory per GiB-second is ~95% of the Cloudflare bill for this server and is currently ~189% over the \$10 budget. The cloud-mode MCP server is stateless and loads no local model, so the 4 GiB `standard-1` instance is heavily over-provisioned.

## Changes (config-only)

- **`wrangler.jsonc`** (`containers[]`):
  - `instance_type`: `standard-1` (4 GiB) -> `basic` (1 GiB) — stateless cloud-mode MCP needs <1 GiB.
  - `max_instances`: `100` -> `10`.
- **`src/worker.ts`** (`NotionContainer` DO):
  - `sleepAfter`: `1h` -> `5m` — HTTP transport is OAuth-delegated with the token held in KV, so there is no in-RAM session window to preserve; the DO can be evicted sooner to stop billing idle GiB-seconds.
- **`src/transports/http.cf.test.ts`**: updated the config-guard assertion + comments to pin the new `sleepAfter = '5m'` value.

No application logic changed.

## Verification

- `bun run check` (Biome + tsc, the CI command): pass.
- `bun run test` (vitest): 916/916 pass.
- `npx wrangler deploy --dry-run`: config validates with no schema/parse error (exits before needing real account/image auth).