### PR TITLE
fix: pin CF container max_instances to 3

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,7 @@
       // (`wrangler containers list` -> ID) + `wrangler deploy` to recreate.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-notion-mcp:beta",
       "instance_type": "basic",
-      "max_instances": 10
+      "max_instances": 3
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
Align committed CF Worker container config with the live deployment.

The live CF app for `better-notion-mcp` was PATCHed to `max_instances=3`, but `wrangler.jsonc` still declared `max_instances: 10`. A future `wrangler deploy` would have regressed the live instance cap back to 10. This pins the committed value to 3 to match live (config drift fix).

Scope: a single number change on the `containers[]` entry. `instance_type`, `image`, and all other config are untouched.