### PR TITLE
fix: bump mcp-core to 1.18.0b19 (relay model-search catalog + OAuth refresh-TTL)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.18.0-beta.17",
+        "@n24q02m/mcp-core": "^1.18.0-beta.19",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3",
       },
@@ -127,7 +127,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.17", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-364I30PsYDaH9H0/37s8viV78JxjHN8ynmd8MbCQ02ZrdzgHxNGW6Tj1Jze7PGv2T1GocktI73mGrWko4zpR1w=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.19", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-GFP3tA6ijuc5NvRyLq/6EcWlu0dbNUti9eBSVqSRBrUeVeADMqtf0FlenL/6XxcyizMP3G136Ili+ndeRLt+fQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.18.0-beta.17",
+    "@n24q02m/mcp-core": "^1.18.0-beta.19",
     "@notionhq/client": "^5.22.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
Bump the `@n24q02m/mcp-core` dependency pin from `^1.18.0-beta.17` to `^1.18.0-beta.19` and regenerate `bun.lock` so the resolved version is `1.18.0-beta.19`.

## Why

The committed `bun.lock` resolved mcp-core to `1.18.0-beta.17`, so the published npm package and the `:beta` Docker image (`Dockerfile` runs `bun install --frozen-lockfile`) bundled the OLD mcp-core. mcp-core `1.18.0-beta.19` contains the relay model-search catalog fix (F2) and the OAuth refresh-TTL fix.

Because `cd.yml` only builds + publishes when PSR cuts a release (which needs a new releasable commit), and there had been no new commit since the last beta, re-dispatching CD was a no-op and the `:beta` image kept the stale mcp-core. This `fix:` commit gives PSR a releasable change so a fresh beta release + multi-arch Docker build resolves the new mcp-core.

## Changes

- `package.json`: `@n24q02m/mcp-core` `^1.18.0-beta.17` -> `^1.18.0-beta.19`
- `bun.lock`: resolution updated to `@n24q02m/mcp-core@1.18.0-beta.19`

## Verification

- `bun run type-check` -> clean (no mcp-core API breakage)
- `bun run test` -> 916 passed (35 files)