### PR TITLE
[CLEANUP] Remove debug logging in HTTP transport token received

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -137,10 +137,6 @@ export async function startHttp(): Promise<void> {
       onTokenReceived: async (tokens: Record<string, unknown>) => {
         const accessToken = String(tokens.access_token ?? '')
         const sub = deriveSubject(tokens)
-        // Structural breadcrumb (KEY NAMES + derived sub only, NEVER token
-        // values) so the Notion token response shape is verifiable in deploy
-        // logs without leaking the access token.
-        console.error(`[${SERVER_NAME}] onTokenReceived keys=[${Object.keys(tokens).join(',')}] sub=${sub}`)
         // AWAIT the durable write (do not fire-and-forget). The KV store sets
         // its in-memory cache synchronously before the awaited KV PUT, so the
         // same-request factory read still hits the warm cache. mcp-core wraps


### PR DESCRIPTION
Removed debug logging and associated comments in the onTokenReceived callback of the HTTP transport to keep the server output clean. This log was previously used to verify the Notion token response shape but is no longer needed.

---
*PR created automatically by Jules for task [1414599177002528633](https://jules.google.com/task/1414599177002528633) started by @n24q02m*