### PR TITLE
[CLEANUP] Remove debug logging in HTTP transport

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -76,7 +76,6 @@ export async function startHttp(): Promise<void> {
   if (tokenStore.ready) {
     try {
       await tokenStore.ready()
-      console.error(`[${SERVER_NAME}] durable KV store reachable (kv.internal outbound wired)`)
     } catch (err) {
       console.error(
         `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`
@@ -137,10 +136,6 @@ export async function startHttp(): Promise<void> {
       onTokenReceived: async (tokens: Record<string, unknown>) => {
         const accessToken = String(tokens.access_token ?? '')
         const sub = deriveSubject(tokens)
-        // Structural breadcrumb (KEY NAMES + derived sub only, NEVER token
-        // values) so the Notion token response shape is verifiable in deploy
-        // logs without leaking the access token.
-        console.error(`[${SERVER_NAME}] onTokenReceived keys=[${Object.keys(tokens).join(',')}] sub=${sub}`)
         // AWAIT the durable write (do not fire-and-forget). The KV store sets
         // its in-memory cache synchronously before the awaited KV PUT, so the
         // same-request factory read still hits the warm cache. mcp-core wraps


### PR DESCRIPTION
Removed debug logging and breadcrumb comments from the HTTP transport implementation in `src/transports/http.ts`. 

Specifically:
- Removed the success log for the KV store readiness probe at startup.
- Removed the `onTokenReceived` breadcrumb log which printed token response keys and subjects.
- Cleaned up associated comments that were no longer relevant after log removal.

These changes ensure that the HTTP transport only emits necessary operational logs (startup confirmation) and actionable errors.

---
*PR created automatically by Jules for task [11725123661035321948](https://jules.google.com/task/11725123661035321948) started by @n24q02m*