### PR TITLE
⚡ Bolt: O(N) Map call for Valid Tools list on every Default Switch Case

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -440,9 +440,14 @@ const TOOLS = [
   }
 ]
 
+// Pre-compute valid tool names to avoid allocations on every call
+// BOLT OPTIMIZATION: Cache tool name list and string representation
+const ALL_TOOL_NAMES = TOOLS.map((t) => t.name)
+const ALL_TOOL_NAMES_STRING = ALL_TOOL_NAMES.join(', ')
+
 // Pre-compute valid tool names for the help endpoint to avoid allocations on every call
 // BOLT OPTIMIZATION: Use Set for O(1) lookups instead of dynamic array creation
-const VALID_HELP_TOOL_NAMES = new Set(TOOLS.map((t) => t.name).filter((name) => name !== 'help'))
+const VALID_HELP_TOOL_NAMES = new Set(ALL_TOOL_NAMES.filter((name) => name !== 'help'))
 const VALID_HELP_TOOLS_STRING = Array.from(VALID_HELP_TOOL_NAMES).join(', ')
 /**
  * Register all tools with MCP server
@@ -588,13 +593,12 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         }
         default: {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, ALL_TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new NotionMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'UNKNOWN_TOOL',
-            `Available tools: ${validTools.join(', ')}`
+            `Available tools: ${ALL_TOOL_NAMES_STRING}`
           )
         }
       }


### PR DESCRIPTION
💡 What
Cached the list of valid tool names (`ALL_TOOL_NAMES`) and their string representation (`ALL_TOOL_NAMES_STRING`) at the module level in `src/tools/registry.ts`.

🎯 Why
Previously, the `default` case in the tool dispatcher was calling `TOOLS.map((t) => t.name)` on every unknown tool call. This resulted in O(N) allocations and redundant work for each invalid request.

📊 Impact
Prevents repeated array allocation and mapping on invalid tool calls, reducing garbage collection pressure and improving response latency for error cases.

🔬 Measurement
Ran the full test suite (`bun run test`) including `src/tools/registry.test.ts` to ensure functionality remains intact.

---
*PR created automatically by Jules for task [5747547325519206598](https://jules.google.com/task/5747547325519206598) started by @n24q02m*