### PR TITLE
[TEST] Untested Public Function resolveCredentialState in credential-state.ts

### DIFF
--- a/src/credential-state.test.ts
+++ b/src/credential-state.test.ts
@@ -88,6 +88,17 @@ describe('credential-state', () => {
       const state = await resolveCredentialState()
       expect(state).toBe('awaiting_setup')
     })
+
+    it('stays in awaiting_setup when config file exists but is missing NOTION_TOKEN', async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {}, // Missing NOTION_TOKEN
+        source: 'file'
+      } as never)
+      const state = await resolveCredentialState()
+      expect(state).toBe('awaiting_setup')
+      expect(getNotionToken()).toBeNull()
+    })
+
     it('clears notion token when resolveCredentialState falls back to awaiting_setup', async () => {
       // 1. Setup a configured state
       process.env.NOTION_TOKEN = 'initial-token'

--- a/src/credential-state.ts
+++ b/src/credential-state.ts
@@ -88,7 +88,7 @@ export async function resolveCredentialState(): Promise<CredentialState> {
   // here without env, see main.ts startServer('stdio') guard).
   try {
     const result = await resolveConfig(SERVER_NAME, REQUIRED_FIELDS)
-    if (result.config !== null) {
+    if (result.config !== null && result.config[CREDENTIAL_KEY]) {
       _notionToken = result.config[CREDENTIAL_KEY]
       _state = 'configured'
       return _state


### PR DESCRIPTION
Fixed a logic gap in `resolveCredentialState` within `src/credential-state.ts`. The previous implementation would set the state to 'configured' if the configuration file existed, even if it didn't contain the `NOTION_TOKEN` key. This could lead to the server entering a configured state without a valid credential.

Changes:
- Updated the condition in `resolveCredentialState` to verify `result.config[CREDENTIAL_KEY]` is truthy before transitioning to the 'configured' state.
- Added a regression test case in `src/credential-state.test.ts` to ensure the state remains 'awaiting_setup' when the config file is missing the required token.
- Verified that all 917 tests in the codebase pass.

---
*PR created automatically by Jules for task [7336327207492681073](https://jules.google.com/task/7336327207492681073) started by @n24q02m*