### PR TITLE
[FIX] P0 fork-bomb fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -137,8 +137,6 @@ export async function bootstrap(selectedMode: string = mode) {
     process.exit(1)
   }
 }
-// Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)
-
 // Only execute bootstrap if we're the main module and not in a test environment.
 if (isMain(import.meta.url) && process.env.NODE_ENV !== 'test') {
   bootstrap()


### PR DESCRIPTION
Removed the stale and misleading comment "// Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)" from src/main.ts. The fork-bomb protection is already implemented in the code (via process.env.BETTER_NOTION_MCP_BOOTSTRAPPED) and the current mcp-core dependency (v1.18.0-beta.19) is much newer than the version referenced in the comment. Verified that existing tests for fork-bomb protection still pass.

---
*PR created automatically by Jules for task [5425506299233740489](https://jules.google.com/task/5425506299233740489) started by @n24q02m*