### PR TITLE
[SECURITY] Direct KV Mapping in Cloudflare Worker Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@
 **Vulnerability:** The `startsWith(DOCS_DIR)` containment check in the documentation resource and help-tool handlers had two flaws: (1) without a trailing separator it permitted access to adjacent directories sharing the prefix (e.g. `DOCS_DIR` `/app/docs` matched `/app/docs-hacked/`); (2) string-prefix checks are separator-sensitive, so a naive `startsWith(DOCS_DIR + sep)` fix rejected legitimate reads on Windows where the path separator differs from forward-slash mocks/resolved paths.
 **Learning:** String-prefix comparison is the wrong primitive for directory containment. It conflates lexical prefixes with directory boundaries and is inherently OS-separator-sensitive.
 **Prevention:** Compute `const rel = relative(DOCS_DIR, fullPath)` and reject when `rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)`. This is separator-agnostic (uses `path` internals), correctly rejects adjacent and parent directories, and passes uniformly across Linux, macOS, and Windows.
+
+## 2025-05-22 - Direct KV Mapping in Cloudflare Worker Proxy
+**Vulnerability:** Direct path-to-key mapping in a KV outbound handler allowed potentially unauthorized access to the KV namespace from the container.
+**Learning:** Even internal interception layers should validate their inputs (like KV keys) against an allowed namespace or prefix, as the "path" part of the URL is often directly derived from untrusted application-level data.
+**Prevention:** Enforce strict key prefix validation and reject directory traversal sequences (e.g., `/../`) in any handler that maps URLs to a flat key-value store.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -96,6 +96,11 @@ const kvOutbound: OutboundHandler<Env> = async (request, env) => {
   // Readiness probe (E.1): once this handler answers, outbound interception is
   // wired, so the container's first credential PUT is safe. Reserved key,
   // checked before the normal key lookup so it never shadows a real KV key.
+  // Security (Sentinel): restrict KV access to the app's own namespace.
+  // Directly mapping untrusted paths to KV keys is a vulnerability (E.3).
+  if (key !== '__ready' && (!key.startsWith('better-notion/') || key.includes('/../') || key.includes('/..'))) {
+    return new Response('forbidden: invalid KV key prefix', { status: 403 })
+  }
   if (request.method === 'GET' && key === '__ready') {
     return Response.json({ ready: true })
   }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -147,3 +147,31 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     expect(calls).toEqual(['user-123'])
   })
 })
+
+describe('KV security (Sentinel)', () => {
+  it('allows keys with better-notion/ prefix', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/better-notion/config'), env as never)
+    // 404 means it passed the prefix check and hit the missing KV key
+    expect(res.status).toBe(404)
+  })
+
+  it('allows the __ready reserved key', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/__ready'), env as never)
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects keys without better-notion/ prefix (403)', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/other-plugin/config'), env as never)
+    expect(res.status).toBe(403)
+    expect(await res.text()).toContain('forbidden')
+  })
+
+  it('rejects path traversal attempts that try to escape the prefix (403)', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/better-notion/../secret'), env as never)
+    expect(res.status).toBe(403)
+  })
+})


### PR DESCRIPTION
The `kvOutbound` handler in `src/worker.ts` was directly mapping untrusted URL paths to KV keys. This posed a security risk as it could allow unauthorized access to the KV namespace or potentially other keys if the container was compromised or if the path was influenced by untrusted data.

This fix implements:
1. **Key Prefix Validation**: All keys (except the reserved `__ready` key used for readiness probes) must now start with the `better-notion/` prefix.
2. **Traversal Protection**: The handler now explicitly rejects keys containing `/../` or ending with `/..` to prevent any potential path traversal or escaping of the allowed namespace.
3. **Comprehensive Testing**: New security test cases were added to `tests/worker.test.ts` to verify the prefix enforcement and traversal rejection.
4. **Security Journaling**: The fix was recorded in `.jules/sentinel.md` as per the security agent protocol.

---
*PR created automatically by Jules for task [3301258315466111247](https://jules.google.com/task/3301258315466111247) started by @n24q02m*