### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute MCP handler constants

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2024-11-20 - Optimize property extraction hot paths
 **Learning:** Large `if/else if` chains checking a single string discriminator (e.g., `type === 'title'`, `type === 'rich_text'`) prevent JavaScript engines like V8 from using optimized O(1) jump tables, resulting in O(N) linear lookups on every iteration. Additionally, repeated string concatenation (`str +=`) within loops causes excessive garbage collection pressure due to string reallocation.
 **Action:** When evaluating a single string discriminator, use `switch (type)` statements. For string building, particularly when extracting property values in hot paths, use pre-allocated arrays (`new Array(len)`) combined with `.join('')` to minimize memory overhead.
+## 2025-05-27 - Request Handler Hot Paths
+**Learning:** Request handlers that execute on every MCP interaction (like listing resources or checking unknown tool requests) incur measurable garbage collection overhead if they dynamically map objects (`.map()`) and join strings (`.join()`) that are actually constant for the lifetime of the process.
+**Action:** Extract maps, joined strings, and lookup maps to pre-computed module-level constants. Replace array `find` with a pre-computed `Map.get` for O(1) lookups on constant resource arrays.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -444,6 +444,20 @@ const TOOLS = [
 // BOLT OPTIMIZATION: Use Set for O(1) lookups instead of dynamic array creation
 const VALID_HELP_TOOL_NAMES = new Set(TOOLS.map((t) => t.name).filter((name) => name !== 'help'))
 const VALID_HELP_TOOLS_STRING = Array.from(VALID_HELP_TOOL_NAMES).join(', ')
+
+// BOLT OPTIMIZATION: Pre-compute handler arrays and strings to avoid allocations on hot paths
+const ALL_TOOL_NAMES = TOOLS.map((t) => t.name)
+const ALL_TOOL_NAMES_STRING = ALL_TOOL_NAMES.join(', ')
+
+const PRECOMPUTED_RESOURCES = RESOURCES.map((r) => ({
+  uri: r.uri,
+  name: r.name,
+  mimeType: 'text/markdown'
+}))
+
+const RESOURCE_MAP = new Map(RESOURCES.map((r) => [r.uri, r]))
+const AVAILABLE_RESOURCE_URIS = RESOURCES.map((r) => r.uri).join(', ')
+
 /**
  * Register all tools with MCP server
  * @param notionClientFactory - Returns a Notion Client.
@@ -456,22 +470,18 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
 
   // Resources handlers for full documentation
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-    resources: RESOURCES.map((r) => ({
-      uri: r.uri,
-      name: r.name,
-      mimeType: 'text/markdown'
-    }))
+    resources: PRECOMPUTED_RESOURCES
   }))
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     const { uri } = request.params
-    const resource = RESOURCES.find((r) => r.uri === uri)
+    const resource = RESOURCE_MAP.get(uri)
 
     if (!resource) {
       throw new NotionMCPError(
         `Resource not found: ${uri}`,
         'RESOURCE_NOT_FOUND',
-        `Available: ${RESOURCES.map((r) => r.uri).join(', ')}`
+        `Available: ${AVAILABLE_RESOURCE_URIS}`
       )
     }
 
@@ -588,13 +598,12 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         }
         default: {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, ALL_TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new NotionMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'UNKNOWN_TOOL',
-            `Available tools: ${validTools.join(', ')}`
+            `Available tools: ${ALL_TOOL_NAMES_STRING}`
           )
         }
       }


### PR DESCRIPTION
💡 What: Extracted dynamic `.map().join()` calls and `.find()` array traversals within MCP handlers (`ListResourcesRequestSchema`, `ReadResourceRequestSchema`, `CallToolRequestSchema`) in `src/tools/registry.ts` to module-level pre-computed constants and O(1) Maps.

🎯 Why: Request handlers run on every interaction. Dynamically allocating mapping arrays, joining strings, and performing linear array scans for data that never changes throughout the server lifecycle generates unnecessary garbage collection pressure and CPU overhead on high-throughput paths.

📊 Impact: Converts O(N) array mapping to O(1) object reference returns and O(N) linear lookups to O(1) Map lookups for resource documentation, minimizing per-request allocation overhead to near zero.

🔬 Measurement: `bun run test` verified behavior matches identically, and `bun run check:fix` ensures style stability. CPU profiling would show no time spent allocating arrays or resolving `.find()` array methods inside the `registry.ts` handlers.

---
*PR created automatically by Jules for task [14572812655865083539](https://jules.google.com/task/14572812655865083539) started by @n24q02m*