### PR TITLE
⚡ Bolt: precompute static tool mappings in registry

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -444,6 +444,17 @@ const TOOLS = [
 // BOLT OPTIMIZATION: Use Set for O(1) lookups instead of dynamic array creation
 const VALID_HELP_TOOL_NAMES = new Set(TOOLS.map((t) => t.name).filter((name) => name !== 'help'))
 const VALID_HELP_TOOLS_STRING = Array.from(VALID_HELP_TOOL_NAMES).join(', ')
+
+// Pre-compute resource and tool mappings to avoid redundant array allocations on every call
+const PRECOMPUTED_RESOURCES = RESOURCES.map((r) => ({
+  uri: r.uri,
+  name: r.name,
+  mimeType: 'text/markdown'
+}))
+const AVAILABLE_RESOURCE_URIS = RESOURCES.map((r) => r.uri).join(', ')
+const ALL_TOOL_NAMES = TOOLS.map((t) => t.name)
+const ALL_TOOL_NAMES_STRING = ALL_TOOL_NAMES.join(', ')
+
 /**
  * Register all tools with MCP server
  * @param notionClientFactory - Returns a Notion Client.
@@ -456,11 +467,7 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
 
   // Resources handlers for full documentation
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-    resources: RESOURCES.map((r) => ({
-      uri: r.uri,
-      name: r.name,
-      mimeType: 'text/markdown'
-    }))
+    resources: PRECOMPUTED_RESOURCES
   }))
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
@@ -471,7 +478,7 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
       throw new NotionMCPError(
         `Resource not found: ${uri}`,
         'RESOURCE_NOT_FOUND',
-        `Available: ${RESOURCES.map((r) => r.uri).join(', ')}`
+        `Available: ${AVAILABLE_RESOURCE_URIS}`
       )
     }
 
@@ -588,13 +595,12 @@ export function registerTools(server: Server, notionClientFactory: () => Client)
           break
         }
         default: {
-          const validTools = TOOLS.map((t) => t.name)
-          const closest = findClosestMatch(name, validTools)
+          const closest = findClosestMatch(name, ALL_TOOL_NAMES)
           const suggestion = closest ? ` Did you mean '${closest}'?` : ''
           throw new NotionMCPError(
             `Unknown tool: ${name}.${suggestion}`,
             'UNKNOWN_TOOL',
-            `Available tools: ${validTools.join(', ')}`
+            `Available tools: ${ALL_TOOL_NAMES_STRING}`
           )
         }
       }


### PR DESCRIPTION
💡 What: Precompute `.map()` and `.join()` results for static `TOOLS` and `RESOURCES` array constants in `src/tools/registry.ts`.
🎯 Why: Prevents redundant array mapping, string construction, and unnecessary garbage collection overhead inside high-frequency MCP server request handlers.
📊 Impact: Faster tool dispatching and smaller memory footprint per-request (O(1) memory instead of O(N) allocations for mappings).
🔬 Measurement: Verify tests run and complete successfully `bun run test src/tools/registry.test.ts`. Inspect the `ReadResourceRequestSchema` handler inside `src/tools/registry.ts` which no longer uses dynamic maps/joins in the hot path.

---
*PR created automatically by Jules for task [12584528576112302986](https://jules.google.com/task/12584528576112302986) started by @n24q02m*