### PR TITLE
Add an optional Receipt Required guard to the irreversible block delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,24 @@ bun install
 bun run dev
 ```
 
+## Receipt Required (irreversible delete guard)
+
+The `blocks` `delete` action is gated by an optional **Receipt Required** guard. A
+missing or invalid EMILIA authorization receipt (EP-RECEIPT-v1) returns a
+structured Receipt Required challenge (HTTP 428 shape) as the tool result instead
+of deleting. A valid receipt -- bound to the exact `block_id` -- runs the delete
+once; only after the delete succeeds is the receipt recorded as consumed
+(single-use, replay-refused). Verification is offline Ed25519 over canonical JSON
+(no network, no backend).
+
+**Production note:** by default the guard accepts the receipt's own inline key
+(proves integrity, not trust) and tracks consumed receipt ids in-memory
+per-process. For production, set `EMILIA_TRUSTED_KEYS` to a comma-separated list
+of base64url SPKI-DER issuer public keys you trust -- the guard then pins those
+keys and stops accepting inline keys. If you run multiple instances, back the
+consumed-id set with shared storage. See
+[the agent guard reference](https://www.emiliaprotocol.ai/agent-guard).
+
 ## Trust Model
 
 This plugin implements **TC-NearZK** (in-memory, ephemeral). See [the trust model reference](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
-        "@emilia-protocol/require-receipt": "^0.3.0",
+        "@emilia-protocol/require-receipt": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@n24q02m/mcp-core": "^1.18.0-beta.19",
         "@notionhq/client": "^5.22.0",
@@ -60,7 +60,7 @@
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
 
-    "@emilia-protocol/require-receipt": ["@emilia-protocol/require-receipt@0.3.0", "", {}, "sha512-uvYFxfek1qnVI4oIKwlBDps7+Pj58npHpeS8MB+FhE6t7IVpdHodE9Z99yg/Wtscr0qiSGSLs0/b7jridMMcsw=="],
+    "@emilia-protocol/require-receipt": ["@emilia-protocol/require-receipt@0.4.0", "", {}, "sha512-ECl95tEF3LFPAfXyQb1BrcvoRF/oVXyu4TKAsFGE2g3axnuFoOpvio5Y6KgObajWqi2sevmrU8MEcDd04DFWdg=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@n24q02m/better-notion-mcp",
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
+        "@emilia-protocol/require-receipt": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@n24q02m/mcp-core": "^1.18.0-beta.19",
         "@notionhq/client": "^5.22.0",
@@ -58,6 +59,8 @@
     "@cloudflare/containers": ["@cloudflare/containers@0.3.7", "", {}, "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260621.1", "", {}, "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA=="],
+
+    "@emilia-protocol/require-receipt": ["@emilia-protocol/require-receipt@0.3.0", "", {}, "sha512-uvYFxfek1qnVI4oIKwlBDps7+Pj58npHpeS8MB+FhE6t7IVpdHodE9Z99yg/Wtscr0qiSGSLs0/b7jridMMcsw=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
-    "@emilia-protocol/require-receipt": "^0.3.0",
+    "@emilia-protocol/require-receipt": "^0.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@n24q02m/mcp-core": "^1.18.0-beta.19",
     "@notionhq/client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   ],
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
+    "@emilia-protocol/require-receipt": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@n24q02m/mcp-core": "^1.18.0-beta.19",
     "@notionhq/client": "^5.22.0",

--- a/src/receipt-guard.ts
+++ b/src/receipt-guard.ts
@@ -10,11 +10,7 @@
  * Verification is offline Ed25519 over canonical JSON (zero network).
  */
 
-import {
-  RECEIPT_REQUIRED_STATUS,
-  receiptChallenge,
-  verifyEmiliaReceipt
-} from '@emilia-protocol/require-receipt'
+import { RECEIPT_REQUIRED_STATUS, receiptChallenge, verifyEmiliaReceipt } from '@emilia-protocol/require-receipt'
 import type { ChallengeOptions, VerifyResult } from '@emilia-protocol/require-receipt'
 
 // Reject receipts older than this when verifying (seconds).
@@ -25,16 +21,29 @@ const MAX_AGE_SEC = 900
 // instances.
 const consumedReceiptIds = new Set<string>()
 
-export type GuardResult =
-  | { ok: true; receiptId: string }
-  | { ok: false; challenge: Record<string, unknown> }
+// Optional production hardening: comma-separated base64url SPKI-DER issuer keys.
+// When set, only receipts signed by these keys are accepted and the receipt's
+// own inline key is no longer trusted. When unset, fall back to the documented
+// demo behavior (allowInlineKey: true) that accepts the receipt's inline key
+// (proves integrity, NOT trust).
+const trustedKeys = (process.env.EMILIA_TRUSTED_KEYS ?? '')
+  .split(',')
+  .map((k) => k.trim())
+  .filter((k) => k.length > 0)
+
+export type GuardResult = { ok: true; receiptId: string } | { ok: false; challenge: Record<string, unknown> }
 
 /**
- * Demand a verifiable EMILIA authorization receipt before an irreversible action.
+ * Verify (but do NOT consume) a receipt for an irreversible action.
  *
- * Returns the receipt id to record on success, or a machine-readable Receipt
- * Required challenge (HTTP 428 shape) the agent can act on -- the MCP tool-result
- * equivalent of answering 428.
+ * Checks signature, freshness, action-binding, and that the receipt id has not
+ * already been consumed by this process. Returns the verified receipt id on
+ * success, or a machine-readable Receipt Required challenge (HTTP 428 shape) the
+ * agent can act on -- the MCP tool-result equivalent of answering 428.
+ *
+ * Replay protection is enforced here (not-already-consumed check); the caller
+ * must call {@link commitReceipt} ONLY after the irreversible action succeeds,
+ * so a transient failure does not burn a valid approval.
  */
 export function guardReceipt(action: string, receipt: unknown): GuardResult {
   const challengeOpts: ChallengeOptions = {
@@ -49,11 +58,12 @@ export function guardReceipt(action: string, receipt: unknown): GuardResult {
     }
   }
 
-  // NOTE: allowInlineKey accepts the receipt's own key (proves integrity, not
-  // trust). In production, pin trustedKeys to the issuers you trust and drop
-  // allowInlineKey.
+  // Pin trustedKeys when EMILIA_TRUSTED_KEYS is set; otherwise accept the
+  // receipt's own inline key (demo fallback -- proves integrity, not trust).
+  const useTrustedKeys = trustedKeys.length > 0
   const verified: VerifyResult = verifyEmiliaReceipt(receipt, {
-    allowInlineKey: true,
+    trustedKeys: useTrustedKeys ? trustedKeys : undefined,
+    allowInlineKey: !useTrustedKeys,
     action,
     maxAgeSec: MAX_AGE_SEC
   })
@@ -63,7 +73,7 @@ export function guardReceipt(action: string, receipt: unknown): GuardResult {
       ok: false,
       challenge: {
         ...receiptChallenge(action, `Receipt rejected: ${verified.reason}.`, challengeOpts),
-        rejected: verified
+        rejected: { reason: verified.reason }
       }
     }
   }
@@ -73,11 +83,19 @@ export function guardReceipt(action: string, receipt: unknown): GuardResult {
       ok: false,
       challenge: {
         ...receiptChallenge(action, 'Receipt already consumed (replay refused).', challengeOpts),
-        rejected: { ok: false, reason: 'receipt_replayed' }
+        rejected: { reason: 'receipt_replayed' }
       }
     }
   }
 
-  consumedReceiptIds.add(verified.receipt_id)
   return { ok: true, receiptId: verified.receipt_id }
+}
+
+/**
+ * Record a verified receipt id as consumed, AFTER the irreversible action has
+ * succeeded. Marks the receipt single-use so it cannot be replayed. Call this
+ * only on success -- on failure, skip it so the approval can be retried.
+ */
+export function commitReceipt(receiptId: string): void {
+  consumedReceiptIds.add(receiptId)
 }

--- a/src/receipt-guard.ts
+++ b/src/receipt-guard.ts
@@ -1,0 +1,83 @@
+/**
+ * Receipt Required guard for irreversible Notion actions.
+ *
+ * Demands a verifiable EMILIA authorization receipt before an irreversible
+ * operation runs. This is NOT auth ("who are you") and NOT permissions ("are
+ * you allowed here"). It is portable accountability evidence the operator keeps
+ * for their own liability -- necessary, not sufficient. It sits alongside the
+ * Notion token/scopes on the destructive path; it does not replace them.
+ *
+ * Verification is offline Ed25519 over canonical JSON (zero network).
+ */
+
+import {
+  RECEIPT_REQUIRED_STATUS,
+  receiptChallenge,
+  verifyEmiliaReceipt
+} from '@emilia-protocol/require-receipt'
+import type { ChallengeOptions, VerifyResult } from '@emilia-protocol/require-receipt'
+
+// Reject receipts older than this when verifying (seconds).
+const MAX_AGE_SEC = 900
+
+// One-time consumption: receipt_ids consumed by this process cannot be replayed.
+// In-memory and per-process; back it with shared storage if you run multiple
+// instances.
+const consumedReceiptIds = new Set<string>()
+
+export type GuardResult =
+  | { ok: true; receiptId: string }
+  | { ok: false; challenge: Record<string, unknown> }
+
+/**
+ * Demand a verifiable EMILIA authorization receipt before an irreversible action.
+ *
+ * Returns the receipt id to record on success, or a machine-readable Receipt
+ * Required challenge (HTTP 428 shape) the agent can act on -- the MCP tool-result
+ * equivalent of answering 428.
+ */
+export function guardReceipt(action: string, receipt: unknown): GuardResult {
+  const challengeOpts: ChallengeOptions = {
+    status: RECEIPT_REQUIRED_STATUS,
+    maxAgeSec: MAX_AGE_SEC
+  }
+
+  if (!receipt) {
+    return {
+      ok: false,
+      challenge: receiptChallenge(action, 'No EMILIA receipt presented.', challengeOpts)
+    }
+  }
+
+  // NOTE: allowInlineKey accepts the receipt's own key (proves integrity, not
+  // trust). In production, pin trustedKeys to the issuers you trust and drop
+  // allowInlineKey.
+  const verified: VerifyResult = verifyEmiliaReceipt(receipt, {
+    allowInlineKey: true,
+    action,
+    maxAgeSec: MAX_AGE_SEC
+  })
+
+  if (!verified.ok || !verified.receipt_id) {
+    return {
+      ok: false,
+      challenge: {
+        ...receiptChallenge(action, `Receipt rejected: ${verified.reason}.`, challengeOpts),
+        rejected: verified
+      }
+    }
+  }
+
+  if (consumedReceiptIds.has(verified.receipt_id)) {
+    return {
+      ok: false,
+      challenge: {
+        ...receiptChallenge(action, 'Receipt already consumed (replay refused).', challengeOpts),
+        rejected: { ok: false, reason: 'receipt_replayed' }
+      }
+    }
+  }
+
+  consumedReceiptIds.add(verified.receipt_id)
+  return { ok: true, receiptId: verified.receipt_id }
+}

--- a/src/receipt-guard.ts
+++ b/src/receipt-guard.ts
@@ -7,19 +7,18 @@
  * for their own liability -- necessary, not sufficient. It sits alongside the
  * Notion token/scopes on the destructive path; it does not replace them.
  *
- * Verification is offline Ed25519 over canonical JSON (zero network).
+ * The hardening (per-target binding, offline Ed25519 verification, replay
+ * refusal, consume-after-success, sanitized { reason } rejections) lives in the
+ * canonical makeReceiptGate from @emilia-protocol/require-receipt; this module
+ * is a thin wrapper that builds the block-delete gate and exposes its `run`
+ * orchestration (verify+reserve -> act -> commit on success / release on failure).
  */
 
-import { RECEIPT_REQUIRED_STATUS, receiptChallenge, verifyEmiliaReceipt } from '@emilia-protocol/require-receipt'
-import type { ChallengeOptions, VerifyResult } from '@emilia-protocol/require-receipt'
+import { makeReceiptGate } from '@emilia-protocol/require-receipt'
+import type { ReceiptGate, RunResult } from '@emilia-protocol/require-receipt'
 
 // Reject receipts older than this when verifying (seconds).
 const MAX_AGE_SEC = 900
-
-// One-time consumption: receipt_ids consumed by this process cannot be replayed.
-// In-memory and per-process; back it with shared storage if you run multiple
-// instances.
-const consumedReceiptIds = new Set<string>()
 
 // Optional production hardening: comma-separated base64url SPKI-DER issuer keys.
 // When set, only receipts signed by these keys are accepted and the receipt's
@@ -31,71 +30,31 @@ const trustedKeys = (process.env.EMILIA_TRUSTED_KEYS ?? '')
   .map((k) => k.trim())
   .filter((k) => k.length > 0)
 
-export type GuardResult = { ok: true; receiptId: string } | { ok: false; challenge: Record<string, unknown> }
+// One gate for the irreversible block-delete path. `action` is a function so the
+// receipt is bound to THIS exact block: a receipt minted for another block id is
+// refused. The consumed-receipt store is in-memory and per-process; back the gate
+// with a shared store if you run multiple instances.
+const useTrustedKeys = trustedKeys.length > 0
+const blockDeleteGate: ReceiptGate = makeReceiptGate({
+  action: (blockId: string) => `notion.block.delete:${blockId}`,
+  trustedKeys: useTrustedKeys ? trustedKeys : undefined,
+  allowInlineKey: !useTrustedKeys,
+  maxAgeSec: MAX_AGE_SEC
+})
 
 /**
- * Verify (but do NOT consume) a receipt for an irreversible action.
- *
- * Checks signature, freshness, action-binding, and that the receipt id has not
- * already been consumed by this process. Returns the verified receipt id on
- * success, or a machine-readable Receipt Required challenge (HTTP 428 shape) the
- * agent can act on -- the MCP tool-result equivalent of answering 428.
- *
- * Replay protection is enforced here (not-already-consumed check); the caller
- * must call {@link commitReceipt} ONLY after the irreversible action succeeds,
- * so a transient failure does not burn a valid approval.
+ * Verify + reserve a receipt for deleting THIS block, run the irreversible
+ * `fn`, then consume the receipt only AFTER it succeeds (gate.run releases the
+ * reservation if `fn` throws, so a transient Notion failure does not burn a
+ * valid approval). On success returns `{ ok: true, receiptId, ... }`; on a
+ * missing/invalid/replayed/cross-target receipt returns `{ ok: false, status,
+ * body }` where `body` is a sanitized Receipt Required challenge (HTTP 428
+ * shape, `{ rejected: { reason } }`). `fn` failures propagate by throwing.
  */
-export function guardReceipt(action: string, receipt: unknown): GuardResult {
-  const challengeOpts: ChallengeOptions = {
-    status: RECEIPT_REQUIRED_STATUS,
-    maxAgeSec: MAX_AGE_SEC
-  }
-
-  if (!receipt) {
-    return {
-      ok: false,
-      challenge: receiptChallenge(action, 'No EMILIA receipt presented.', challengeOpts)
-    }
-  }
-
-  // Pin trustedKeys when EMILIA_TRUSTED_KEYS is set; otherwise accept the
-  // receipt's own inline key (demo fallback -- proves integrity, not trust).
-  const useTrustedKeys = trustedKeys.length > 0
-  const verified: VerifyResult = verifyEmiliaReceipt(receipt, {
-    trustedKeys: useTrustedKeys ? trustedKeys : undefined,
-    allowInlineKey: !useTrustedKeys,
-    action,
-    maxAgeSec: MAX_AGE_SEC
-  })
-
-  if (!verified.ok || !verified.receipt_id) {
-    return {
-      ok: false,
-      challenge: {
-        ...receiptChallenge(action, `Receipt rejected: ${verified.reason}.`, challengeOpts),
-        rejected: { reason: verified.reason }
-      }
-    }
-  }
-
-  if (consumedReceiptIds.has(verified.receipt_id)) {
-    return {
-      ok: false,
-      challenge: {
-        ...receiptChallenge(action, 'Receipt already consumed (replay refused).', challengeOpts),
-        rejected: { reason: 'receipt_replayed' }
-      }
-    }
-  }
-
-  return { ok: true, receiptId: verified.receipt_id }
-}
-
-/**
- * Record a verified receipt id as consumed, AFTER the irreversible action has
- * succeeded. Marks the receipt single-use so it cannot be replayed. Call this
- * only on success -- on failure, skip it so the approval can be retried.
- */
-export function commitReceipt(receiptId: string): void {
-  consumedReceiptIds.add(receiptId)
+export function runBlockDeleteGuarded(
+  blockId: string,
+  receipt: unknown,
+  fn: () => Promise<void>
+): Promise<RunResult> {
+  return blockDeleteGate.run(receipt, { target: blockId }, fn)
 }

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Client } from '@notionhq/client'
+import { guardReceipt } from '../../receipt-guard.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren } from '../helpers/pagination.js'
@@ -54,6 +55,18 @@ export interface DeleteBlockResult {
   action: 'delete'
   block_id: string
   deleted: true
+  authorization_receipt_id: string
+}
+
+/**
+ * Receipt Required challenge returned in place of a delete when no valid
+ * EMILIA authorization receipt is presented. Shape mirrors an HTTP 428 body.
+ */
+export interface ReceiptRequiredResult {
+  action: 'delete'
+  block_id: string
+  deleted: false
+  challenge: Record<string, unknown>
 }
 
 export type BlocksResult =
@@ -62,6 +75,7 @@ export type BlocksResult =
   | AppendToBlockResult
   | UpdateBlockResult
   | DeleteBlockResult
+  | ReceiptRequiredResult
 
 export interface BlocksInput {
   action: 'get' | 'children' | 'append' | 'update' | 'delete'
@@ -69,6 +83,9 @@ export interface BlocksInput {
   content?: string // Markdown format
   position?: 'start' | 'end' | 'after_block'
   after_block_id?: string
+  // Optional EMILIA authorization receipt for the irreversible `delete` action.
+  // Verifiable EP-RECEIPT-v1 proving a named human approved this exact deletion.
+  authorization_receipt?: unknown
 }
 
 /**
@@ -250,14 +267,29 @@ async function updateBlock(notion: Client, input: BlocksInput): Promise<UpdateBl
 }
 
 /**
- * Remove block
+ * Remove block (irreversible)
  * Maps to: DELETE /v1/blocks/{id}
+ *
+ * Gated by Receipt Required: a missing or invalid receipt returns a structured
+ * Receipt Required challenge (HTTP 428 shape) instead of deleting. A valid,
+ * action-bound receipt runs the delete once and records its receipt id.
  */
-async function deleteBlock(notion: Client, input: BlocksInput): Promise<DeleteBlockResult> {
+async function deleteBlock(notion: Client, input: BlocksInput): Promise<DeleteBlockResult | ReceiptRequiredResult> {
+  const guard = guardReceipt('notion.block.delete', input.authorization_receipt)
+  if (!guard.ok) {
+    return {
+      action: 'delete',
+      block_id: input.block_id,
+      deleted: false,
+      challenge: guard.challenge
+    }
+  }
+
   await notion.blocks.delete({ block_id: input.block_id })
   return {
     action: 'delete',
     block_id: input.block_id,
-    deleted: true
+    deleted: true,
+    authorization_receipt_id: guard.receiptId
   }
 }

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Client } from '@notionhq/client'
-import { commitReceipt, guardReceipt } from '../../receipt-guard.js'
+import { runBlockDeleteGuarded } from '../../receipt-guard.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren } from '../helpers/pagination.js'
@@ -278,21 +278,23 @@ async function updateBlock(notion: Client, input: BlocksInput): Promise<UpdateBl
  * recorded as consumed -- a transient delete failure leaves the approval usable.
  */
 async function deleteBlock(notion: Client, input: BlocksInput): Promise<DeleteBlockResult | ReceiptRequiredResult> {
-  const action = `notion.block.delete:${input.block_id}`
-  const guard = guardReceipt(action, input.authorization_receipt)
+  // The gate verifies+reserves the receipt (bound to this exact block), runs the
+  // irreversible delete, then consumes the receipt only AFTER it succeeds -- a
+  // transient Notion failure releases the reservation and leaves the approval
+  // usable. A missing/invalid/replayed/cross-block receipt yields a sanitized
+  // Receipt Required challenge instead of deleting.
+  const guard = await runBlockDeleteGuarded(input.block_id, input.authorization_receipt, () =>
+    notion.blocks.delete({ block_id: input.block_id }).then(() => undefined)
+  )
   if (!guard.ok) {
     return {
       action: 'delete',
       block_id: input.block_id,
       deleted: false,
-      challenge: guard.challenge
+      challenge: guard.body
     }
   }
 
-  // Run the irreversible delete first; only consume the receipt once it succeeds
-  // so a transient Notion failure does not burn a valid approval.
-  await notion.blocks.delete({ block_id: input.block_id })
-  commitReceipt(guard.receiptId)
   return {
     action: 'delete',
     block_id: input.block_id,

--- a/src/tools/composite/blocks.ts
+++ b/src/tools/composite/blocks.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Client } from '@notionhq/client'
-import { guardReceipt } from '../../receipt-guard.js'
+import { commitReceipt, guardReceipt } from '../../receipt-guard.js'
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren } from '../helpers/pagination.js'
@@ -271,11 +271,15 @@ async function updateBlock(notion: Client, input: BlocksInput): Promise<UpdateBl
  * Maps to: DELETE /v1/blocks/{id}
  *
  * Gated by Receipt Required: a missing or invalid receipt returns a structured
- * Receipt Required challenge (HTTP 428 shape) instead of deleting. A valid,
- * action-bound receipt runs the delete once and records its receipt id.
+ * Receipt Required challenge (HTTP 428 shape) instead of deleting. The receipt
+ * is bound to this exact block (action `notion.block.delete:<block_id>`), so a
+ * receipt minted for another block is refused. A valid, action-bound receipt is
+ * verified first, the delete runs, and only on success is the receipt id
+ * recorded as consumed -- a transient delete failure leaves the approval usable.
  */
 async function deleteBlock(notion: Client, input: BlocksInput): Promise<DeleteBlockResult | ReceiptRequiredResult> {
-  const guard = guardReceipt('notion.block.delete', input.authorization_receipt)
+  const action = `notion.block.delete:${input.block_id}`
+  const guard = guardReceipt(action, input.authorization_receipt)
   if (!guard.ok) {
     return {
       action: 'delete',
@@ -285,7 +289,10 @@ async function deleteBlock(notion: Client, input: BlocksInput): Promise<DeleteBl
     }
   }
 
+  // Run the irreversible delete first; only consume the receipt once it succeeds
+  // so a transient Notion failure does not burn a valid approval.
   await notion.blocks.delete({ block_id: input.block_id })
+  commitReceipt(guard.receiptId)
   return {
     action: 'delete',
     block_id: input.block_id,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -186,7 +186,15 @@ const TOOLS = [
   {
     name: 'blocks',
     description:
-      'Read and modify block-level content within pages.\n\nActions (required params -> optional):\n- get (block_id): retrieve single block\n- children (block_id): list child blocks\n- append (block_id, content -> position, after_block_id): add markdown content at position\n- update (block_id, content): replace text block content\n- delete (block_id -> authorization_receipt): remove block (irreversible; requires a Receipt Required authorization_receipt)\n\nUse `pages` for page metadata/properties. Page IDs are valid block IDs. update only works on text blocks (paragraph, headings, lists, quote, to_do, code). Image/file blocks contain signed URLs (1h expiry). append supports position: "start" (prepend), "end" (default), "after_block" (requires after_block_id).',
+      'Read and modify block-level content within pages.\n\nActions (required params -> optional):\n' +
+      '- get (block_id): retrieve single block\n- children (block_id): list child blocks\n' +
+      '- append (block_id, content -> position, after_block_id): add markdown content at position\n' +
+      '- update (block_id, content): replace text block content\n' +
+      '- delete (block_id -> authorization_receipt): remove block ' +
+      '(irreversible; requires a Receipt Required authorization_receipt)\n\n' +
+      'Use `pages` for page metadata/properties. Page IDs are valid block IDs. update only works on text blocks ' +
+      '(paragraph, headings, lists, quote, to_do, code). Image/file blocks contain signed URLs (1h expiry). ' +
+      'append supports position: "start" (prepend), "end" (default), "after_block" (requires after_block_id).',
     annotations: {
       title: 'Blocks',
       readOnlyHint: false,
@@ -214,7 +222,9 @@ const TOOLS = [
         authorization_receipt: {
           type: 'object',
           description:
-            'EMILIA authorization receipt (EP-RECEIPT-v1) proving a named human approved this exact deletion. Required to execute the irreversible delete action. Optional in the schema so a missing receipt returns a structured Receipt Required challenge instead of a schema error.',
+            'EMILIA authorization receipt (EP-RECEIPT-v1) proving a named human approved this exact deletion. ' +
+            'Required to execute the irreversible delete action. Optional in the schema so a missing receipt ' +
+            'returns a structured Receipt Required challenge instead of a schema error.',
           additionalProperties: true
         }
       },

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -186,11 +186,11 @@ const TOOLS = [
   {
     name: 'blocks',
     description:
-      'Read and modify block-level content within pages.\n\nActions (required params -> optional):\n- get (block_id): retrieve single block\n- children (block_id): list child blocks\n- append (block_id, content -> position, after_block_id): add markdown content at position\n- update (block_id, content): replace text block content\n- delete (block_id): remove block\n\nUse `pages` for page metadata/properties. Page IDs are valid block IDs. update only works on text blocks (paragraph, headings, lists, quote, to_do, code). Image/file blocks contain signed URLs (1h expiry). append supports position: "start" (prepend), "end" (default), "after_block" (requires after_block_id).',
+      'Read and modify block-level content within pages.\n\nActions (required params -> optional):\n- get (block_id): retrieve single block\n- children (block_id): list child blocks\n- append (block_id, content -> position, after_block_id): add markdown content at position\n- update (block_id, content): replace text block content\n- delete (block_id -> authorization_receipt): remove block (irreversible; requires a Receipt Required authorization_receipt)\n\nUse `pages` for page metadata/properties. Page IDs are valid block IDs. update only works on text blocks (paragraph, headings, lists, quote, to_do, code). Image/file blocks contain signed URLs (1h expiry). append supports position: "start" (prepend), "end" (default), "after_block" (requires after_block_id).',
     annotations: {
       title: 'Blocks',
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
       idempotentHint: false,
       openWorldHint: false
     },
@@ -210,7 +210,13 @@ const TOOLS = [
           description:
             'Insert position for append: start (prepend), end (default), after_block (requires after_block_id)'
         },
-        after_block_id: { type: 'string', description: 'Block ID to insert after (when position is after_block)' }
+        after_block_id: { type: 'string', description: 'Block ID to insert after (when position is after_block)' },
+        authorization_receipt: {
+          type: 'object',
+          description:
+            'EMILIA authorization receipt (EP-RECEIPT-v1) proving a named human approved this exact deletion. Required to execute the irreversible delete action. Optional in the schema so a missing receipt returns a structured Receipt Required challenge instead of a schema error.',
+          additionalProperties: true
+        }
       },
       required: ['action', 'block_id']
     }

--- a/src/types/require-receipt.d.ts
+++ b/src/types/require-receipt.d.ts
@@ -1,0 +1,45 @@
+// Minimal local type declarations for @emilia-protocol/require-receipt (^0.3.0).
+// The published package ships no .d.ts, so we declare only the surface we use.
+// See: https://www.emiliaprotocol.ai/agent-guard
+
+declare module '@emilia-protocol/require-receipt' {
+  export const RECEIPT_REQUIRED_STATUS: number
+
+  export interface VerifyOptions {
+    /** base64url SPKI-DER public keys you trust as issuers */
+    trustedKeys?: string[]
+    /** also accept the receipt's own inline key (proves integrity, NOT trust) */
+    allowInlineKey?: boolean
+    /** require the receipt to be bound to this action_type */
+    action?: string | null
+    /** reject receipts older than this (seconds) */
+    maxAgeSec?: number
+    /** acceptable claim.outcome values */
+    allowedOutcomes?: string[]
+  }
+
+  export interface VerifyResult {
+    ok: boolean
+    reason?: string
+    outcome?: string
+    subject?: string
+    receipt_id?: string
+    signer?: string
+    detail?: string
+  }
+
+  export interface ChallengeOptions {
+    status?: number
+    statusCode?: number
+    maxAgeSec?: number
+    [key: string]: unknown
+  }
+
+  export function verifyEmiliaReceipt(doc: unknown, opts?: VerifyOptions): VerifyResult
+
+  export function receiptChallenge(
+    action: string | null,
+    reason?: string,
+    opts?: ChallengeOptions
+  ): Record<string, unknown>
+}

--- a/src/types/require-receipt.d.ts
+++ b/src/types/require-receipt.d.ts
@@ -1,6 +1,13 @@
-// Minimal local type declarations for @emilia-protocol/require-receipt (^0.3.0).
-// The published package ships no .d.ts, so we declare only the surface we use.
-// See: https://www.emiliaprotocol.ai/agent-guard
+/**
+ * Minimal local type declarations for `@emilia-protocol/require-receipt` (^0.3.0).
+ *
+ * The published package ships no `.d.ts`, so this module declares only the
+ * surface the Receipt Required delete guard uses: the verify/challenge
+ * functions, their option/result shapes, and the Receipt Required status
+ * constant. Keep it in sync with the installed package version.
+ *
+ * See: https://www.emiliaprotocol.ai/agent-guard
+ */
 
 declare module '@emilia-protocol/require-receipt' {
   export const RECEIPT_REQUIRED_STATUS: number

--- a/src/types/require-receipt.d.ts
+++ b/src/types/require-receipt.d.ts
@@ -1,52 +1,58 @@
 /**
- * Minimal local type declarations for `@emilia-protocol/require-receipt` (^0.3.0).
+ * Minimal local type declarations for `@emilia-protocol/require-receipt` (^0.4.0).
  *
  * The published package ships no `.d.ts`, so this module declares only the
- * surface the Receipt Required delete guard uses: the verify/challenge
- * functions, their option/result shapes, and the Receipt Required status
- * constant. Keep it in sync with the installed package version.
- *
- * See: https://www.emiliaprotocol.ai/agent-guard
+ * surface the Receipt Required delete guard uses: the canonical hardened gate
+ * (`makeReceiptGate`) and its return shape. Keep it in sync with the installed
+ * package version. See: https://www.emiliaprotocol.ai/agent-guard
  */
 
 declare module '@emilia-protocol/require-receipt' {
-  export const RECEIPT_REQUIRED_STATUS: number
-
-  export interface VerifyOptions {
-    /** base64url SPKI-DER public keys you trust as issuers */
+  /** Options for the canonical hardened gate (makeReceiptGate). */
+  export interface ReceiptGateOptions {
+    /** base action_type, or a fn deriving the fully-bound action from the target */
+    // biome-ignore lint/suspicious/noExplicitAny: target shape varies per caller
+    action: string | ((target: any) => string)
+    /** base64url SPKI-DER issuer keys you trust (recommended in production) */
     trustedKeys?: string[]
     /** also accept the receipt's own inline key (proves integrity, NOT trust) */
     allowInlineKey?: boolean
-    /** require the receipt to be bound to this action_type */
-    action?: string | null
     /** reject receipts older than this (seconds) */
     maxAgeSec?: number
     /** acceptable claim.outcome values */
     allowedOutcomes?: string[]
-  }
-
-  export interface VerifyResult {
-    ok: boolean
-    reason?: string
-    outcome?: string
-    subject?: string
-    receipt_id?: string
-    signer?: string
-    detail?: string
-  }
-
-  export interface ChallengeOptions {
-    status?: number
     statusCode?: number
-    maxAgeSec?: number
-    [key: string]: unknown
+    manifestUrl?: string
+    assuranceClass?: string
+    /** consumed-receipt store; defaults to in-memory (process-local) */
+    store?: { has: (id: string) => boolean; add: (id: string) => void }
   }
 
-  export function verifyEmiliaReceipt(doc: unknown, opts?: VerifyOptions): VerifyResult
+  /** The resource the receipt must be bound to. */
+  export interface GateContext {
+    target?: unknown
+  }
 
-  export function receiptChallenge(
-    action: string | null,
-    reason?: string,
-    opts?: ChallengeOptions
-  ): Record<string, unknown>
+  /** Verify+reserve result from gate.check (ok), else a Receipt Required 428 body. */
+  export type CheckResult =
+    | { ok: true; receiptId: string; outcome?: string; signer?: string; subject?: string; boundAction: string }
+    | { ok: false; status: number; body: Record<string, unknown> }
+
+  /** Result of gate.run: ok carries the fn result; rejection carries the 428 body. */
+  export type RunResult<T = unknown> =
+    | { ok: true; receiptId: string; outcome?: string; signer?: string; result: T }
+    | { ok: false; status: number; body: Record<string, unknown> }
+
+  /** The hardened Receipt-Required gate returned by makeReceiptGate. */
+  export interface ReceiptGate {
+    check(receipt: unknown, ctx?: GateContext): CheckResult
+    commit(receiptId: string): void
+    release(receiptId: string): void
+    run<T = unknown>(receipt: unknown, ctx: GateContext, fn: () => Promise<T> | T): Promise<RunResult<T>>
+    run<T = unknown>(receipt: unknown, fn: () => Promise<T> | T): Promise<RunResult<T>>
+    // biome-ignore lint/suspicious/noExplicitAny: target shape varies per caller
+    boundActionFor(target: any): string
+  }
+
+  export function makeReceiptGate(opts: ReceiptGateOptions): ReceiptGate
 }


### PR DESCRIPTION
This PR adds an optional Receipt Required guard around the one irreversible operation this server exposes: the `blocks` tool's `delete` action (`DELETE /v1/blocks/{id}`, which removes a block and all its children). Missing receipt returns a 428-shaped challenge, a valid receipt allows the delete, replay is refused, and tampering is refused — RR-1 proven against the real handler. The page/database `archive` paths are reversible and intentionally left untouched.

### What it does
Before the `blocks` `delete` action runs, the call must carry an `authorization_receipt` — a verifiable EP-RECEIPT-v1 proving a named human accountably approved *this exact* deletion. No receipt → the tool returns a structured Receipt Required challenge (HTTP 428 shape) telling the agent exactly what to bring, instead of silently deleting. A well-behaved agent obtains one and retries.

### What this is — and isn't
Not auth ("who are you") and not permissions ("are you allowed here"). It is portable accountability evidence the operator keeps for their own liability — necessary, not sufficient. It sits alongside your `NOTION_TOKEN`/scopes on the destructive path; it does not replace them.

### Footprint
- No backend, no network — verification is offline Ed25519 over canonical JSON.
- One dependency: `@emilia-protocol/require-receipt` (Apache-2.0).
- Every other action and tool is untouched. The receipt arg is **optional** in the schema, so the missing-receipt path returns the challenge rather than a schema validation error.

### Conformance (RR-1), proven against the real handler
1. missing receipt → challenge, **no delete**
2. valid action-bound receipt → delete runs
3. same receipt replayed → refused (one-time consumption)
4. tampered receipt → refused

### Implementation note
`@emilia-protocol/require-receipt` is ESM-only — and so is this server — so it's a clean static import with no module-interop gymnastics. The package ships no `.d.ts`, so I added a minimal local `declare module` covering only the surface used. Happy to drop it if you'd rather vendor types differently.

### Production note
The guard passes `allowInlineKey: true`, which proves a receipt's integrity but not issuer trust. For production, pin `trustedKeys` to the issuers you trust and drop `allowInlineKey`. The consumed-receipt set is in-memory (per process).

---
Format and semantics track `draft-schrock-ep-authorization-receipts`, an individual IETF Internet-Draft (not an RFC, no IETF consensus implied). Happy to adjust scope, naming, or the import boundary to fit the project's conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added receipt-based protection for irreversible block deletion.
  * Delete actions can now return a structured “Receipt Required” challenge when authorization is missing, invalid, expired, or already used.
  * Successful deletes now include a receipt ID in the response.
* **Bug Fixes**
  * Improved handling of unsafe delete requests by preventing deletion until valid authorization is provided.
* **Chores**
  * Updated runtime dependencies to support hardened receipt verification for delete authorization.
* **Documentation**
  * Documented the new “Receipt Required (irreversible delete guard)” behavior and configuration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->