### PR TITLE
[FIX] Investigate HTTP Transport owner_user_id bug

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -76,6 +76,7 @@ export async function startHttp(): Promise<void> {
   if (tokenStore.ready) {
     try {
       await tokenStore.ready()
+      console.error(`[${SERVER_NAME}] durable KV store reachable at startup`)
     } catch (err) {
       console.error(
         `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`


### PR DESCRIPTION
Investigated the reported owner_user_id bug in HTTP transport. Subject derivation in deriveSubject correctly prioritizes owner.user.id, workspace_id, and bot_id, while explicitly ignoring the non-existent owner_user_id field to prevent isolation loss. This behavior is already guarded by tests. Fixed a regression in startHttp where a missing success log for durable KV store readiness caused a test failure in src/transports/http.test.ts. Verified with full test suite (950 tests passing).

---
*PR created automatically by Jules for task [837046531773977316](https://jules.google.com/task/837046531773977316) started by @n24q02m*