### PR TITLE
[SECURITY] Authentication Bypass Option (MCP_AUTH_DISABLE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ mise run fix                # bun run check:fix
 ## Env vars
 
 - **stdio mode** (default): `NOTION_TOKEN` (bat buoc; stdio fails fast if unset, see `main.ts:76`)
-- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET` (bat buoc, validated `transports/http.ts:51-53`), `PUBLIC_URL` (OAuth redirect URLs), `MCP_AUTH_DISABLE=1` (optional, skip Bearer JWT verification behind external gateway)
+- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET` (bat buoc, validated `transports/http.ts:51-53`), `PUBLIC_URL` (OAuth redirect URLs)
 - `PORT` (default `0` = OS-assigned random port), `HOST` (optional bind address)
 - Secrets: skret SSM namespace `/better-notion-mcp/prod` (region `ap-southeast-1`)
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ Eight composite Notion tools (39 actions) plus three infrastructure tools (`conf
 | `PUBLIC_URL` | No (http) | - | Server's public URL for OAuth redirect links |
 | `NOTION_OAUTH_CLIENT_ID` | Yes (http) | - | Notion Public Integration client ID |
 | `NOTION_OAUTH_CLIENT_SECRET` | Yes (http) | - | Notion Public Integration client secret |
-| `MCP_AUTH_DISABLE` | No (http) | - | Set to `1` to skip Bearer JWT verification when behind an external auth gateway |
 | `PORT` | No | `0` (OS-assigned) | Server port; set explicitly (e.g. `8080`) to bind a fixed port |
 | `HOST` | No | - | Bind address (http mode) |
 
@@ -222,7 +221,6 @@ Run your own multi-user better-notion-mcp serverless on Cloudflare (Worker + Con
 6. Complete the Notion OAuth flow in the browser at your Worker domain.
 
 Per-user Notion access tokens are encrypted into KV (`MCP_STORAGE_BACKEND=cf-kv`),
-so they survive scale-to-zero. Do NOT set `MCP_AUTH_DISABLE` on a shared/public
 deployment — it collapses all users into a single token bucket.
 
 ## Comparison

--- a/src/transports/http.cf.test.ts
+++ b/src/transports/http.cf.test.ts
@@ -39,14 +39,6 @@ describe('per-sub token isolation (anonymous-bucket-collapse guard)', () => {
     expect(store.get('bob')).toBe('ntn_bob')
     expect(store.get('alice')).not.toBe(store.get('bob'))
   })
-
-  it('the wrangler deploy config never enables MCP_AUTH_DISABLE on shared infra', () => {
-    const raw = readFileSync('wrangler.jsonc', 'utf-8')
-    // The guard is a literal absence: MCP_AUTH_DISABLE must not appear as an
-    // enabled var. (If ever needed for a private self-host, it is the operator's
-    // opt-in, never on *.n24q02m.com.)
-    expect(/"MCP_AUTH_DISABLE"\s*:\s*"1"/.test(raw)).toBe(false)
-  })
 })
 
 describe('token store selection', () => {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -58,8 +58,7 @@ describe('startHttp', () => {
       NOTION_OAUTH_CLIENT_ID: 'id',
       NOTION_OAUTH_CLIENT_SECRET: 'secret',
       PORT: undefined,
-      HOST: undefined,
-      MCP_AUTH_DISABLE: undefined
+      HOST: undefined
     }
     // Prevent logs during tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -147,35 +146,6 @@ describe('startHttp', () => {
       expect.objectContaining({
         port: 8080,
         host: '0.0.0.0'
-      })
-    )
-
-    if (handlers.SIGINT) await handlers.SIGINT()
-    await startPromise
-  })
-
-  it('uses MCP_AUTH_DISABLE environment variable', async () => {
-    process.env.MCP_AUTH_DISABLE = '1'
-
-    vi.mocked(mcpCore.runHttpServer).mockResolvedValue({
-      host: 'localhost',
-      port: 3000,
-      close: vi.fn().mockResolvedValue(undefined)
-    } as any)
-
-    const handlers: Record<string, (...args: any[]) => any> = {}
-    vi.spyOn(process, 'once').mockImplementation((event, handler) => {
-      handlers[event as string] = handler as (...args: any[]) => any
-      return process
-    })
-
-    const startPromise = startHttp()
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
-    expect(mcpCore.runHttpServer).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({
-        authDisabled: true
       })
     )
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -76,6 +76,7 @@ export async function startHttp(): Promise<void> {
   if (tokenStore.ready) {
     try {
       await tokenStore.ready()
+      console.error(`[${SERVER_NAME}] durable KV store reachable at startup`)
     } catch (err) {
       console.error(
         `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`
@@ -105,12 +106,6 @@ export async function startHttp(): Promise<void> {
     throw new Error('NOTION_OAUTH_CLIENT_ID and NOTION_OAUTH_CLIENT_SECRET are required for http mode.')
   }
 
-  // MCP_AUTH_DISABLE=1 skips Bearer JWT verification — for deployments behind
-  // an external auth boundary (reverse proxy, API gateway like agentgateway).
-  // Caller is responsible for upstream auth + providing Notion token via a
-  // separate channel (e.g. NOTION_TOKEN env var resolved by tokenStore default).
-  const authDisabled = process.env.MCP_AUTH_DISABLE === '1'
-
   // CF deploy requirement (P3-03): CREDENTIAL_SECRET MUST be set in the
   // container env (wrangler secret put). When set, mcp-core's JWTIssuer derives
   // a deterministic Ed25519 (EdDSA) signing key via HKDF-SHA256 with no disk I/O.
@@ -123,7 +118,7 @@ export async function startHttp(): Promise<void> {
     serverName: SERVER_NAME,
     port,
     host,
-    authDisabled,
+
     delegatedOAuth: {
       flow: 'redirect',
       upstream: {
@@ -149,10 +144,8 @@ export async function startHttp(): Promise<void> {
         return sub
       }
     },
-    authScope: async (claims: { sub?: unknown; anonymous?: unknown }, next: () => Promise<void>) => {
-      // Anonymous caller (auth-disabled mode behind gateway): use 'default'
-      // bucket so a single deployment can serve one Notion token via env.
-      const sub = claims.anonymous === true ? 'default' : typeof claims.sub === 'string' ? claims.sub : 'default'
+    authScope: async (claims: { sub?: unknown }, next: () => Promise<void>) => {
+      const sub = typeof claims.sub === 'string' ? claims.sub : 'default'
       // Warm the per-sub cache from the durable store (KV) BEFORE the tool
       // dispatch reads it synchronously via the factory/resolver. After a
       // container delete+recreate the in-memory cache is empty; without this a

--- a/tests/wrangler-config.test.ts
+++ b/tests/wrangler-config.test.ts
@@ -43,8 +43,4 @@ describe('wrangler.jsonc', () => {
     expect(cfg.routes[0].pattern).toBe('notion.n24q02m.com')
     expect(cfg.routes[0].custom_domain).toBe(true)
   })
-
-  it('never enables MCP_AUTH_DISABLE in vars (anonymous-bucket-collapse guard)', () => {
-    expect(cfg.vars.MCP_AUTH_DISABLE).toBeUndefined()
-  })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,9 +35,6 @@
   // MCP_RELAY_PASSWORD (Gate A shared relay-password front door),
   // NOTION_OAUTH_CLIENT_ID, NOTION_OAUTH_CLIENT_SECRET.
   //
-  // MCP_AUTH_DISABLE is intentionally ABSENT: enabling it would collapse every
-  // JWT sub into the 'default' token bucket (http.ts) -> silent per-sub
-  // isolation loss. Never set auth-bypass on shared infra.
   "vars": {
     "MCP_TRANSPORT": "http",
     "PORT": "8080",


### PR DESCRIPTION
Removed the `MCP_AUTH_DISABLE` feature which allowed bypassing Bearer JWT verification in HTTP mode. This feature relied heavily on upstream environment security and introduced a significant risk of authentication bypass if misconfigured.

Changes:
- Removed `MCP_AUTH_DISABLE` check and `authDisabled` option in `src/transports/http.ts`.
- Simplified `authScope` to remove anonymous caller/bucket handling.
- Removed associated tests in `src/transports/http.test.ts`, `src/transports/http.cf.test.ts`, and `tests/wrangler-config.test.ts`.
- Updated documentation in `README.md` and `CLAUDE.md`.
- Cleaned up configuration templates in `wrangler.jsonc`.
- Restored missing operational success log for KV store readiness.

---
*PR created automatically by Jules for task [6075901436652525492](https://jules.google.com/task/6075901436652525492) started by @n24q02m*