### PR TITLE
[TEST] Missing tests for deriveSubject in http transport

### DIFF
--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -354,6 +354,21 @@ describe('deriveSubject', () => {
     }
     expect(deriveSubject(tokens)).toBe('bot-123')
   })
+
+  it('returns "default" if workspace_id is not a string', () => {
+    const tokens = { workspace_id: 123 }
+    expect(deriveSubject(tokens)).toBe('default')
+  })
+
+  it('returns "default" if bot_id is not a string', () => {
+    const tokens = { bot_id: 123 }
+    expect(deriveSubject(tokens)).toBe('default')
+  })
+
+  it('returns "default" if owner is present but user is missing', () => {
+    const tokens = { owner: {} }
+    expect(deriveSubject(tokens)).toBe('default')
+  })
 })
 
 describe('selectTokenStore', () => {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -76,6 +76,7 @@ export async function startHttp(): Promise<void> {
   if (tokenStore.ready) {
     try {
       await tokenStore.ready()
+      console.error(`[${SERVER_NAME}] durable KV store reachable at startup`)
     } catch (err) {
       console.error(
         `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`


### PR DESCRIPTION
Add unit tests for `deriveSubject` in `src/transports/http.ts` to cover edge cases:
- workspace_id not being a string
- bot_id not being a string
- owner present but user missing

Also fixed a failing test in `src/transports/http.test.ts` by adding a missing success log in `src/transports/http.ts` when the durable KV store is reachable at startup.

---
*PR created automatically by Jules for task [4097409465297152486](https://jules.google.com/task/4097409465297152486) started by @n24q02m*