### PR TITLE
[FIX] Restore missing success log in http transport and verify import usage

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -76,6 +76,7 @@ export async function startHttp(): Promise<void> {
   if (tokenStore.ready) {
     try {
       await tokenStore.ready()
+      console.error(`[${SERVER_NAME}] durable KV store reachable`)
     } catch (err) {
       console.error(
         `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`


### PR DESCRIPTION
While investigating the report of an unused import `NotionTokenStoreLike` in `src/transports/http.ts`, I verified that it is indeed required for type safety (specifically for accessing the optional `.ready()` method on the token store). 

However, I identified and fixed a regression in the same file: the `startHttp` function was missing a success log message ("durable KV store reachable") that was expected by the test suite. Restoring this log message fixed the failing test `logs success when tokenStore.ready() succeeds` in `src/transports/http.test.ts` and ensures proper observability of the KV storage backend reachability at startup.

---
*PR created automatically by Jules for task [2742724526906758200](https://jules.google.com/task/2742724526906758200) started by @n24q02m*