### PR TITLE
fix: add nodejs_compat flag for CF worker bundle

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,7 @@
   "name": "better-notion-mcp-worker",
   "main": "src/worker.ts",
   "compatibility_date": "2026-06-14",
+  "compatibility_flags": ["nodejs_compat"],
   "containers": [
     {
       "name": "better-notion-mcp-worker",


### PR DESCRIPTION
Worker bundle pulls file-uri-to-path (require('path')); without nodejs_compat the bundle fails + Windows libuv crash. Add nodejs_compat -> clean bundle -> deploy + canary PASS.