### PR TITLE
fix: add missing import os to cf_full_flow.py

### DIFF
--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -41,6 +41,7 @@ import argparse
 import base64
 import hashlib
 import json as _json
+import os
 import secrets
 import sys
 import urllib.parse


### PR DESCRIPTION
os.environ used at line 52 but os never imported -> NameError at module load (notion protocol test was unrunnable).