### PR TITLE
fix: green notion main — single-DO worker test + symmetric KV-ready log

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -76,6 +76,7 @@ export async function startHttp(): Promise<void> {
   if (tokenStore.ready) {
     try {
       await tokenStore.ready()
+      console.error(`[${SERVER_NAME}] durable KV store reachable at startup`)
     } catch (err) {
       console.error(
         `[${SERVER_NAME}] durable KV store UNREACHABLE at startup: ${err instanceof Error ? err.message : String(err)}`

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -137,14 +137,14 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     expect(calls).toEqual(['default'])
   })
 
-  it('Bearer token with sub -> routes to that sub DO (per-user isolation)', async () => {
+  it('Bearer token with sub -> still routes to the single "default" DO (single-DO collapse)', async () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
     await worker.fetch(
       new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
       env as never
     )
-    expect(calls).toEqual(['user-123'])
+    expect(calls).toEqual(['default'])
   })
 
   it('Bearer token with malformed base64 payload -> defaults to "default" DO', async () => {


### PR DESCRIPTION
Two pre-existing main failures fixed: (1) worker.test.ts single-DO routing assertion (sub -> 'default'), (2) add symmetric 'durable KV store reachable' success log so the tokenStore.ready success-path test asserts a real log. Verified locally: worker.test.ts + http.test.ts 42/42 pass.