### PR TITLE
⚡ Bolt: Cache inline regular expressions in hot paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-06-29 - Cache Regex in Hot Paths
 **Learning:** Instantiating new regex literals within functions on hot paths (e.g., `isValidBase64` processing file buffers) incurs a compilation penalty and GC overhead. Caching the regex object at the module level and using `.test()` proved significantly faster (~2.6ms vs 72ms per 10k iterations on large payloads).
 **Action:** Always declare static regexes at the module level rather than redefining them inside utility functions, especially for high-frequency operations.
+## 2026-06-30 - Precompute Inline Regex to avoid Regex Compilation Penalties
+**Learning:** In hot paths, like string matching using `.match()` in `src/tools/helpers/errors.ts`, `src/tools/helpers/markdown.ts`, and `src/tools/helpers/properties.ts`, re-compiling inline regexes can cause CPU allocations and garbage collection overheads.
+**Action:** Always precompute these regex as module-level constants (e.g. `SAFE_STRING_REGEX`) rather than recreating them during runtime to improve speed and performance.

--- a/src/tools/helpers/errors.ts
+++ b/src/tools/helpers/errors.ts
@@ -1,6 +1,8 @@
 /**
  * Custom error class for Notion MCP operations
  */
+const SAFE_STRING_REGEX = /^[a-zA-Z0-9.[\]_ /-]*/
+
 export class NotionMCPError extends Error {
   constructor(
     public message: string,
@@ -39,7 +41,7 @@ function sanitizeValidationBody(body: any): any {
         // Sanitize path: allow only alphanumeric, dots, brackets, underscores, hyphens, spaces, and slashes.
         // We truncate at the first "unsafe" character to avoid leaking potentially sensitive
         // values that might have been appended (e.g. by a proxy or if Notion includes values in paths).
-        const match = body[field].match(/^[a-zA-Z0-9.[\]_ /-]*/)
+        const match = body[field].match(SAFE_STRING_REGEX)
         safe[field] = match ? match[0] : ''
       } else {
         safe[field] = body[field]

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -66,6 +66,10 @@ const CHECKED_LIST_REGEX = /^\s*[-*+]\s\[([ xX])\](?:\s|$)/
 const BULLETED_LIST_REGEX = /^\s*[-*+]\s/
 const NUMBERED_LIST_REGEX = /^\s*\d+\.\s/
 const DIVIDER_REGEX = /^[-*]{3,}$/
+const MENTION_ID_REGEX = /([a-f0-9]{32})/
+const INLINE_SUMMARY_REGEX = /^<details>\s*<summary>(.*?)<\/summary>(.*?)(<\/details>)?$/
+const SUMMARY_REGEX = /<summary>(.*?)<\/summary>/
+const COLUMN_REGEX = /^:::column(?:\{width=([\d.]+)\})?$/
 
 /**
  * Convert markdown string to Notion blocks
@@ -505,7 +509,7 @@ class InlineParser {
           const mentionTarget = this.text.slice(closeBracket + 2, closeParen)
 
           // Extract 32-char hex page ID from Notion URL or use as-is
-          const idMatch = mentionTarget.match(/([a-f0-9]{32})/)
+          const idMatch = mentionTarget.match(MENTION_ID_REGEX)
           const pageId = idMatch ? idMatch[1] : mentionTarget
 
           this.richText.push(
@@ -822,7 +826,7 @@ function parseToggle(lines: string[], startIndex: number): ToggleParseResult {
   const detailsLine = lines[i].trim()
 
   // Try to extract <summary>...</summary> from the <details> line itself
-  const inlineSummaryMatch = detailsLine.match(/^<details>\s*<summary>(.*?)<\/summary>(.*?)(<\/details>)?$/)
+  const inlineSummaryMatch = detailsLine.match(INLINE_SUMMARY_REGEX)
 
   if (inlineSummaryMatch) {
     // All-on-one-line or inline summary: <details><summary>Title</summary>[Content][</details>]
@@ -851,7 +855,7 @@ function parseToggle(lines: string[], startIndex: number): ToggleParseResult {
 
     // Look for <summary>...</summary> on the next line
     if (i < lines.length) {
-      const summaryMatch = lines[i].match(/<summary>(.*?)<\/summary>/)
+      const summaryMatch = lines[i].match(SUMMARY_REGEX)
       if (summaryMatch) {
         title = summaryMatch[1]
         i++
@@ -915,7 +919,7 @@ function parseColumns(lines: string[], startIndex: number): ColumnParseResult {
       break
     }
 
-    const columnMatch = line.match(/^:::column(?:\{width=([\d.]+)\})?$/)
+    const columnMatch = line.match(COLUMN_REGEX)
     if (columnMatch) {
       // Flush previous column (even if empty)
       if (inColumn) {

--- a/src/tools/helpers/properties.ts
+++ b/src/tools/helpers/properties.ts
@@ -5,10 +5,12 @@
 
 import * as RichText from './richtext.js'
 
+const PAGE_ID_REGEX = /([a-f0-9]{32})/
+
 /** Extract a 32-char hex page ID from a Notion URL, or return the input as-is if it's already a raw ID */
 function extractPageId(value: any): string {
   if (typeof value !== 'string') return String(value)
-  const match = value.match(/([a-f0-9]{32})/)
+  const match = value.match(PAGE_ID_REGEX)
   if (match) return match[1]
   // Also accept hyphenated UUIDs as-is
   return value


### PR DESCRIPTION
💡 **What:** Extracted inline RegExp literals (e.g., `/([a-f0-9]{32})/`, `/^[a-zA-Z0-9.[\]_ /-]*/`) to module-level constants (e.g., `PAGE_ID_REGEX`, `SAFE_STRING_REGEX`, `MENTION_ID_REGEX`, `INLINE_SUMMARY_REGEX`, `SUMMARY_REGEX`, `COLUMN_REGEX`) across multiple helper files.
🎯 **Why:** To improve execution speed by eliminating the need for the JS engine to recompile these regular expressions on every function invocation, particularly in hot paths like markdown parsing and error formatting. This also reduces memory allocations and garbage collection overhead.
📊 **Impact:** Reduces CPU cycles and GC pauses spent on regex initialization in heavily used utility functions, yielding a small but measurable reduction in execution time for large payloads or complex error processing.
🔬 **Measurement:** Verify by running the full test suite (`bun run test`). All tests pass, demonstrating no change in functionality. Performance profiles will show fewer `RegExp` object allocations during parsing workloads.

---
*PR created automatically by Jules for task [12541562577753706678](https://jules.google.com/task/12541562577753706678) started by @n24q02m*