### PR TITLE
fix: correct AGENTS.md file organization to match current src layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,15 +100,14 @@ import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 
 ```
 src/
-  main.ts                     # Entry point — selects transport by TRANSPORT_MODE
-  init-server.ts              # Deprecated re-export of transports/stdio
+  init-server.ts              # Entry point — imports main.ts (startServer/getTransportMode)
+  main.ts                     # Transport selection; stdio (NOTION_TOKEN) handled directly
   create-server.ts            # Shared MCP Server factory
-  auth/                       # OAuth 2.1 + PKCE, DCR, session management
-    notion-oauth-provider.ts  # Notion OAuth callback relay + token storage
-    stateless-client-store.ts # Stateless HMAC-based DCR store
+  auth/                       # Per-JWT-sub Notion access token stores (http mode)
+    notion-token-store.ts     # In-memory per-sub token map + NotionTokenStoreLike iface
+    notion-token-store-kv.ts  # KV write-through token store (Cloudflare deploy)
   transports/
-    stdio.ts                  # Local mode (NOTION_TOKEN)
-    http.ts                   # Remote mode (Express + OAuth 2.1)
+    http.ts                   # Remote mode (Express + OAuth 2.1, multi-user)
   docs/                       # Markdown docs served as MCP resources
   tools/
     registry.ts               # Tool registration + routing


### PR DESCRIPTION
## Problem

`AGENTS.md` §"File Organization" described a `src/` layout that no longer matches the actual code — it listed three files that do not exist and mis-described the entry point.

## Verified against current `src/`

- `init-server.ts` is the real entry point importing `./main.js` (`startServer` / `getTransportMode`) — not "a deprecated re-export of transports/stdio".
- `auth/` contains only `notion-token-store.ts` + `notion-token-store-kv.ts`; the non-existent `notion-oauth-provider.ts` and `stateless-client-store.ts` were listed.
- `transports/` has only `http.ts`; the non-existent `transports/stdio.ts` was listed (stdio is handled directly in `main.ts` via `StdioServerTransport`).

## Change

Docs-only. Corrected the File Organization block to reflect the actual files, matching the (already-correct) layout in `CLAUDE.md`. No code touched.