### PR TITLE
fix: bump mcp-core to 1.18.0-beta.23 for durable delegated-OAuth session state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.18.0-beta.22",
+        "@n24q02m/mcp-core": "^1.18.0-beta.23",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3",
       },
@@ -127,7 +127,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.22", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-NOEYOXiW95lBVZEu/BUfa2WFrorfjy88dLQYXWmSxMl/ek6hE16tVKYZNJLDx60lG9bDU8p5PJH8sSn/3EWhrw=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.23", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-V9eNWJilVcaNnacNUtSMvZlwcd9jDv7n7I/Qeyku7/ZmrnsK8w8/iFXufTt7sRmT4sXXP17CYdHmI3kJsl/7Zw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.18.0-beta.22",
+    "@n24q02m/mcp-core": "^1.18.0-beta.23",
     "@notionhq/client": "^5.22.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
Picks up mcp-core 1.18.0-beta.23 which backs the delegated-OAuth handshake state (pendingSessions + authCodes) with the container's CF KV instead of an in-process map. Fixes the CF 'Invalid state' on /callback (the container cold-starts between /authorize and /callback under single-DO + sleepAfter, losing the in-memory state). No notion code change — mcp-core auto-detects the KV from MCP_STORAGE_BACKEND=cf-kv (already set on the notion CF deploy).