### PR TITLE
fix: wire durable KV-backed sessionKv for delegated OAuth on CF deploy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.18.0-beta.23",
+        "@n24q02m/mcp-core": "^1.18.0-beta.25",
         "@notionhq/client": "^5.22.0",
         "zod": "^4.4.3",
       },
@@ -127,7 +127,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.23", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-V9eNWJilVcaNnacNUtSMvZlwcd9jDv7n7I/Qeyku7/ZmrnsK8w8/iFXufTt7sRmT4sXXP17CYdHmI3kJsl/7Zw=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.18.0-beta.25", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-IBWwYfXsEqadHF7aoQr3Un9vbRQNRqepZ1tCkoSi0r6tonj/sfgfTJw3wJB/1YL56SasXWlVnFyS2r5F1GG8iw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.18.0-beta.23",
+    "@n24q02m/mcp-core": "^1.18.0-beta.25",
     "@notionhq/client": "^5.22.0",
     "zod": "^4.4.3"
   },

--- a/src/auth/notion-token-store-kv.ts
+++ b/src/auth/notion-token-store-kv.ts
@@ -15,7 +15,10 @@
 import { backendFromEnv, CfKvBackend, PerPluginStore } from '@n24q02m/mcp-core/storage'
 import type { NotionTokenStoreLike } from './notion-token-store.js'
 
-const PLUGIN_NAME = 'better-notion'
+// Exported so other CF-KV consumers (the delegated-OAuth session store) key
+// into the SAME Worker-enforced namespace -- the kv.internal outbound handler
+// (src/worker.ts) allowlists KV keys by this exact prefix.
+export const PLUGIN_NAME = 'better-notion'
 
 // Minimal structural shape of mcp-core's injectable Http (storage/backends.ts):
 // request(method, url, data?, headers?) -> { status, body }. Declared locally so

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -33,6 +33,29 @@ vi.mock('../auth/notion-token-store.js', () => {
   }
 })
 
+const mockKvTokenStoreInstance = {
+  get: vi.fn(),
+  getAsync: vi.fn().mockResolvedValue(undefined),
+  save: vi.fn(),
+  clear: vi.fn(),
+  // Resolves instantly (unlike the real KvNotionTokenStore.ready(), which does
+  // a live fetch to kv.internal) -- a real network call here would make
+  // startHttp()'s completion timing nondeterministic against tests' fixed
+  // setTimeout wait, flaking whichever assertion runs after it.
+  ready: vi.fn().mockResolvedValue(undefined)
+}
+
+vi.mock('../auth/notion-token-store-kv.js', () => {
+  return {
+    KvNotionTokenStore: class {
+      constructor() {
+        Object.assign(this, mockKvTokenStoreInstance)
+      }
+    },
+    PLUGIN_NAME: 'better-notion'
+  }
+})
+
 vi.mock('../create-server.js', () => ({
   createMCPServer: vi.fn()
 }))
@@ -49,7 +72,11 @@ vi.mock('@notionhq/client', () => ({
 }))
 
 describe('startHttp', () => {
-  const originalEnv = process.env
+  // A real copy, not a reference -- `process.env` is a live mutable object, so
+  // `const originalEnv = process.env` would alias it: a test setting
+  // `process.env.MCP_STORAGE_BACKEND` mutates this "original" too, leaking into
+  // every later test's `{...originalEnv, ...}` reset below.
+  const originalEnv = { ...process.env }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -61,6 +88,13 @@ describe('startHttp', () => {
       HOST: undefined,
       MCP_AUTH_DISABLE: undefined
     }
+    // `{KEY: undefined}` in the reassignment above does not reliably delete the
+    // key (process.env coerces undefined to the string "undefined" in some
+    // runtimes) -- delete explicitly so a leftover MCP_STORAGE_BACKEND=cf-kv
+    // from another test file's mutation of the shared process.env can never
+    // leak into these tests and silently switch sessionKvForDeploy's branch.
+    delete process.env.MCP_STORAGE_BACKEND
+    delete process.env.MCP_KV_BASE_URL
     // Prevent logs during tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
@@ -178,6 +212,58 @@ describe('startHttp', () => {
         authDisabled: true
       })
     )
+
+    if (handlers.SIGINT) await handlers.SIGINT()
+    await startPromise
+  })
+
+  it('wires a durable sessionKv into delegatedOAuth when MCP_STORAGE_BACKEND=cf-kv', async () => {
+    process.env.MCP_STORAGE_BACKEND = 'cf-kv'
+    process.env.MCP_KV_BASE_URL = 'http://kv.internal'
+
+    vi.mocked(mcpCore.runHttpServer).mockResolvedValue({
+      host: 'localhost',
+      port: 3000,
+      close: vi.fn().mockResolvedValue(undefined)
+    } as any)
+
+    const handlers: Record<string, (...args: any[]) => any> = {}
+    vi.spyOn(process, 'once').mockImplementation((event, handler) => {
+      handlers[event as string] = handler as (...args: any[]) => any
+      return process
+    })
+
+    const startPromise = startHttp()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const options = vi.mocked(mcpCore.runHttpServer).mock.calls[0][1] as any
+    // Must be the durable KV-backed store (not undefined -> in-memory fallback),
+    // so the OAuth handshake state survives a container cold-start between
+    // /authorize and /callback -- the exact regression this wiring fixes.
+    expect(options.delegatedOAuth?.sessionKv).toBeDefined()
+
+    if (handlers.SIGINT) await handlers.SIGINT()
+    await startPromise
+  })
+
+  it('leaves sessionKv undefined (in-memory fallback) when MCP_STORAGE_BACKEND is not cf-kv', async () => {
+    vi.mocked(mcpCore.runHttpServer).mockResolvedValue({
+      host: 'localhost',
+      port: 3000,
+      close: vi.fn().mockResolvedValue(undefined)
+    } as any)
+
+    const handlers: Record<string, (...args: any[]) => any> = {}
+    vi.spyOn(process, 'once').mockImplementation((event, handler) => {
+      handlers[event as string] = handler as (...args: any[]) => any
+      return process
+    })
+
+    const startPromise = startHttp()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const options = vi.mocked(mcpCore.runHttpServer).mock.calls[0][1] as any
+    expect(options.delegatedOAuth?.sessionKv).toBeUndefined()
 
     if (handlers.SIGINT) await handlers.SIGINT()
     await startPromise

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -14,14 +14,31 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { runHttpServer } from '@n24q02m/mcp-core'
+import { type SessionKv, wrapKvBackendAsSessionKv } from '@n24q02m/mcp-core/auth'
+import { backendFromEnv } from '@n24q02m/mcp-core/storage'
 import { Client } from '@notionhq/client'
 import { NotionTokenStore, type NotionTokenStoreLike } from '../auth/notion-token-store.js'
-import { KvNotionTokenStore } from '../auth/notion-token-store-kv.js'
+import { KvNotionTokenStore, PLUGIN_NAME } from '../auth/notion-token-store-kv.js'
 import { createMCPServer } from '../create-server.js'
 import { resolveCredentialState, setState, setSubjectTokenResolver } from '../credential-state.js'
 import { NotionMCPError } from '../tools/helpers/errors.js'
 
 const SERVER_NAME = 'better-notion-mcp'
+
+/**
+ * Durable KV for the delegated-OAuth handshake state (pending sessions +
+ * issued auth codes), so it survives a container cold-start/restart between
+ * /authorize and /callback. Keyed under the SAME `better-notion/` namespace
+ * as the token store (`PLUGIN_NAME`) -- the Worker's kv.internal outbound
+ * handler allowlists keys by that exact prefix (src/worker.ts); any other
+ * prefix is rejected with 403. undefined outside the cf-kv deploy (stdio /
+ * local single-process) -- the session store then falls back to an
+ * in-process map, correct for that single-request-context case.
+ */
+function sessionKvForDeploy(): SessionKv | undefined {
+  if ((process.env.MCP_STORAGE_BACKEND ?? '').toLowerCase() !== 'cf-kv') return undefined
+  return wrapKvBackendAsSessionKv(backendFromEnv(), `${PLUGIN_NAME}/delegated-oauth:`)
+}
 
 export const subjectContext = new AsyncLocalStorage<{ sub: string }>()
 
@@ -127,6 +144,7 @@ export async function startHttp(): Promise<void> {
     authDisabled,
     delegatedOAuth: {
       flow: 'redirect',
+      sessionKv: sessionKvForDeploy(),
       upstream: {
         authorizeUrl: 'https://api.notion.com/v1/oauth/authorize',
         tokenUrl: 'https://api.notion.com/v1/oauth/token',


### PR DESCRIPTION
## Summary
- Bumps `@n24q02m/mcp-core` to `1.18.0-beta.25` (adds a caller-scoped KV key-prefix option to the delegated-OAuth session store, per n24q02m/mcp-core#601/#602).
- Wires `sessionKv` explicitly in `startHttp()` via `wrapKvBackendAsSessionKv(backendFromEnv(), 'better-notion/delegated-oauth:')`, matching the SAME `better-notion/` KV namespace the Worker's `kv.internal` outbound handler already allowlists for the token store (`PLUGIN_NAME`, now exported from `notion-token-store-kv.ts`).
- Root cause: the mcp-core beta.23 fix (durable OAuth session state) auto-built a KV store with a global, unscoped key prefix; this Worker's `kv.internal` handler rejects any key outside `better-notion/*` with 403, which the router's bare `catch` turned into an opaque 500 on `/authorize` -- regressing the exact OAuth flow that fix was meant to repair.

## Test plan
- [x] New tests in `http.test.ts`: `sessionKv` is wired when `MCP_STORAGE_BACKEND=cf-kv`, left `undefined` (in-memory fallback) otherwise -- RED before the wiring, GREEN after.
- [x] Fixed two bugs surfaced while adding this coverage: an aliased (not copied) `process.env` snapshot causing cross-test leakage, and an unmocked `KvNotionTokenStore.ready()` making a real network fetch that raced the tests' fixed wait.
- [x] `bun run test` full suite: 954/954, run 4x clean (no flakiness)
- [x] `bun run check` (Biome + tsc --noEmit) exit 0
- [x] `bun run build` succeeds