### PR TITLE
feat: deploy CF Worker+Container on release from cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -294,3 +294,46 @@ jobs:
             -f event_type=plugin-sync \
             -f 'client_payload[repo]=better-notion-mcp' \
             -f 'client_payload[tag]=${{ needs.release.outputs.tag }}'
+
+  deploy-cf:
+    name: Deploy Cloudflare Worker+Container
+    # Builds the http-slim image on a GitHub Linux runner and deploys it to
+    # Cloudflare so any release == CF live on that version — a beta dispatch redeploys
+    # the beta, a stable dispatch is maintainer-gated (replaces the
+    # manual local deploy_cf.py step + its Windows Docker OOM). Only needs the
+    # `release` job (deploy_cf.py builds its OWN image, so merge-docker is not a
+    # dependency). Dispatch-only workflow (no fork PRs) => secrets are safe.
+    # NOTE: in CI the template renders the image at the NEW tag, so deploy_cf.py's
+    # auto-rollback (prev_ref != new) is inert here; a failed canary still fails
+    # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
+    # rollback is a tracked follow-up.
+    needs: [release]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout the released tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+      - name: Setup Bun (bunx wrangler)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install worker deps (wrangler bundles worker.ts, needs @cloudflare/containers)
+        run: bun install --frozen-lockfile
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Deploy to Cloudflare (build http-slim + push + deploy + canary)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_KV_ID: ${{ secrets.CF_KV_ID }}
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          IMAGE_TAG: ${{ needs.release.outputs.version }}
+        run: python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -64,6 +65,28 @@ for _stream in (sys.stdout, sys.stderr):
         _stream.reconfigure(encoding="utf-8", errors="replace")
 
 DEPLOY_CONFIG = "wrangler.deploy.jsonc"
+TEMPLATE_CONFIG = "wrangler.deploy.template.jsonc"
+
+
+def render_template(path: str) -> str:
+    """Substitute ``${VAR}`` tokens in the committed deploy template from the
+    environment.
+
+    CI runs ``deploy_cf.py --from-template`` to reconstruct the gitignored
+    ``wrangler.deploy.jsonc`` from the committed placeholder template plus the
+    real IDs, which arrive as env vars (GitHub Actions secrets synced from
+    skret). Fails loudly if a referenced var is missing so a half-substituted
+    config never reaches ``wrangler deploy``.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+
+    def _sub(m: re.Match[str]) -> str:
+        val = os.environ.get(m.group(1))
+        if val is None:
+            raise SystemExit(f"template var ${{{m.group(1)}}} not set in environment")
+        return val
+
+    return re.sub(r"\$\{([A-Z0-9_]+)\}", _sub, text)
 
 
 def _strip_jsonc(text: str) -> str:
@@ -315,6 +338,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--dry-run", action="store_true", help="print the plan, run nothing")
     p.add_argument(
+        "--from-template",
+        action="store_true",
+        help="reconstruct wrangler.deploy.jsonc from the committed template + env (CI)",
+    )
+    p.add_argument(
         "--no-canary",
         action="store_true",
         help="skip the post-deploy canary gate (and its auto-rollback)",
@@ -322,6 +350,11 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
 
     repo = Path(__file__).resolve().parent.parent
+    if args.from_template:
+        (repo / DEPLOY_CONFIG).write_text(
+            render_template(str(repo / TEMPLATE_CONFIG)), encoding="utf-8"
+        )
+        print(f"Rendered {DEPLOY_CONFIG} from {TEMPLATE_CONFIG} (CI mode).")
     cfg = _load_deploy_config(repo)
     worker = cfg["name"]
     base, _account, name = _image_parts(cfg)
@@ -334,7 +367,17 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_build:
         print("[1/4] docker build --target http")
         _run(
-            ["docker", "build", "--target", "http", "-t", local, "."],
+            [
+                "docker",
+                "build",
+                "--target",
+                "http",
+                "--build-arg",
+                "SLIM=1",
+                "-t",
+                local,
+                ".",
+            ],
             dry=args.dry_run,
             cwd=repo,
         )

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -1,0 +1,39 @@
+// wrangler.deploy.template.jsonc - COMMITTED placeholder template for CI CF deploy.
+// scripts/deploy_cf.py --from-template renders this into the gitignored
+// wrangler.deploy.jsonc by substituting the placeholder tokens below from the
+// environment (CI provides them from GitHub Actions secrets synced from skret).
+// Real account/KV IDs never live in git; they are placeholders here.
+// notion is KV-only: no D1 (no docs DB) and no Vectorize (no embeddings) blocks,
+// unlike the wet template this is copied from.
+// NO routes block (notion.n24q02m.com already attached; the deploy token can't
+// reconcile routes). workers_dev:false keeps the worker off *.workers.dev.
+{
+  "name": "better-notion-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": false,
+  "containers": [
+    {
+      "name": "better-notion-mcp-worker",
+      "class_name": "NotionContainer",
+      "image": "registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/better-notion-mcp:${IMAGE_TAG}",
+      "instance_type": "basic",
+      "max_instances": 1
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "NOTION", "class_name": "NotionContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["NotionContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
+  "vars": {
+    "MCP_TRANSPORT": "http",
+    "PORT": "8080",
+    "HOST": "0.0.0.0",
+    "PUBLIC_URL": "${PUBLIC_URL}",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal"
+  },
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
Mirrors the wet-mcp deploy-cf-in-cd pilot (TS repo variant: no Python test). Part of the 6-CF-server rollout.

- Overwrote scripts/deploy_cf.py with wet-mcp's proven generic version (adds render_template() + --from-template to rebuild the gitignored wrangler.deploy.jsonc from a committed placeholder template).
- Added wrangler.deploy.template.jsonc: placeholder template mirroring this repo's real deploy config (KV-only; no D1/Vectorize). Placeholders: ${CLOUDFLARE_ACCOUNT_ID}, ${IMAGE_TAG}, ${CF_KV_ID}, ${PUBLIC_URL}.
- Added deploy-cf job to cd.yml (dispatch-only, if: needs.release.outputs.released == 'true'): builds the http image on a GitHub runner + bun install + python scripts/deploy_cf.py --from-template. CF_D1_ID/CF_VECTORIZE_ID env lines dropped (repo lacks those bindings).

Verified: render_template() reproduces the real wrangler.deploy.jsonc body byte-for-byte with 0 leftover placeholders; cd.yml YAML parses (7 jobs); biome check clean on the template; all pre-commit hooks passed.