### PR TITLE
fix: use placeholders for PUBLIC_URL and routes in wrangler.jsonc (BYO-generic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ docker run -p 8080:8080 \
 
 Run your own multi-user better-notion-mcp serverless on Cloudflare (Worker + Container + KV).
 
-**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+**Prerequisites:** a Cloudflare account on the **Workers Paid plan** — required for Containers (the Cloudflare free tier does not include Containers) — and the `wrangler` CLI.
 
 1. `git clone https://github.com/n24q02m/better-notion-mcp && cd better-notion-mcp`
 2. `wrangler login`

--- a/scripts/cf-deploy.mjs
+++ b/scripts/cf-deploy.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 // cf-deploy.mjs - config-only `wrangler deploy` for the live CF Worker+Container.
 //
-// The committed wrangler.jsonc keeps two deploy-time placeholders out of git so
-// no live resource IDs are checked in:
+// The committed wrangler.jsonc keeps three deploy-time placeholders out of git so
+// no live resource IDs (or an env-specific public URL) are checked in:
 //   - <YOUR_ACCOUNT_ID>              in the container image ref
 //   - <better-notion-kv-namespace-id> in the KV binding
-// This script substitutes both into a throwaway, gitignored wrangler.deploy.jsonc
+//   - <YOUR_PUBLIC_URL>              in vars.PUBLIC_URL (worker base URL)
+// This script substitutes all three into a throwaway, gitignored wrangler.deploy.jsonc
 // (deleted after the run) and runs `wrangler deploy` against it, so the committed
 // wrangler.jsonc stays clean.
 //
@@ -17,6 +18,7 @@
 // Required env:
 //   CLOUDFLARE_API_TOKEN   - CF API token (any secret manager works)
 //   CLOUDFLARE_ACCOUNT_ID  - substituted for <YOUR_ACCOUNT_ID>
+//   PUBLIC_URL             - substituted for <YOUR_PUBLIC_URL> (worker base URL)
 // Optional env:
 //   CF_KV_NAMESPACE_ID     - substituted for <better-notion-kv-namespace-id>
 //                            (defaults to the live "KV" namespace below)
@@ -60,13 +62,21 @@ if (!dryRun && !process.env.CLOUDFLARE_API_TOKEN) {
   console.error('CLOUDFLARE_API_TOKEN is required (wrangler auth).')
   process.exit(1)
 }
+const publicUrl = process.env.PUBLIC_URL
+if (!publicUrl) {
+  console.error('PUBLIC_URL is required (substituted for <YOUR_PUBLIC_URL>).')
+  process.exit(1)
+}
 const kvNamespaceId = process.env.CF_KV_NAMESPACE_ID || DEFAULT_KV_NAMESPACE_ID
 
 const src = readFileSync('wrangler.jsonc', 'utf8')
 const resolved = src
   .replaceAll('<YOUR_ACCOUNT_ID>', accountId)
   .replaceAll('<better-notion-kv-namespace-id>', kvNamespaceId)
-  // Drop the single-line `"routes": [...],` block (custom domain already attached).
+  .replaceAll('<YOUR_PUBLIC_URL>', publicUrl)
+  // Drop the single-line `"routes": [...],` block: the custom domain is already
+  // attached, and this also strips the <YOUR_WORKER_DOMAIN> placeholder so it
+  // never reaches wrangler.
   .replace(/^\s*"routes":\s*\[[^\]]*\],?\s*$/m, '')
   // Serve ONLY the custom domain. Without these, wrangler enables a public
   // workers.dev URL + preview URLs by default -> an unintended public surface.
@@ -74,7 +84,15 @@ const resolved = src
 
 if (dryRun) {
   console.log(`cf:dryrun -> would write ${DEPLOY_CONFIG} and run: bunx wrangler deploy --config ${DEPLOY_CONFIG}`)
-  console.log('--- resolved wrangler config suppressed (contains live resource IDs) ---')
+  console.log(`cf:dryrun -> PUBLIC_URL resolved to ${publicUrl}`)
+  // Fail loudly if any placeholder survived substitution: an unsubstituted
+  // <...> token would otherwise ship literally into the deployed config.
+  const leftover = [...new Set(resolved.match(/<[A-Za-z0-9_-]+>/g) ?? [])]
+  if (leftover.length > 0) {
+    console.error(`cf:dryrun -> unsubstituted placeholder(s) would reach wrangler: ${leftover.join(', ')}`)
+    process.exit(1)
+  }
+  console.log('cf:dryrun -> no unsubstituted placeholders remain (live resource IDs suppressed).')
   process.exit(0)
 }
 

--- a/scripts/cf-deploy.mjs
+++ b/scripts/cf-deploy.mjs
@@ -62,18 +62,23 @@ if (!dryRun && !process.env.CLOUDFLARE_API_TOKEN) {
   console.error('CLOUDFLARE_API_TOKEN is required (wrangler auth).')
   process.exit(1)
 }
-const publicUrl = process.env.PUBLIC_URL
-if (!publicUrl) {
-  console.error('PUBLIC_URL is required (substituted for <YOUR_PUBLIC_URL>).')
-  process.exit(1)
-}
 const kvNamespaceId = process.env.CF_KV_NAMESPACE_ID || DEFAULT_KV_NAMESPACE_ID
 
 const src = readFileSync('wrangler.jsonc', 'utf8')
+
+// PUBLIC_URL is required only while the committed config still carries the
+// <YOUR_PUBLIC_URL> placeholder; a BYO fork that hardcodes vars.PUBLIC_URL
+// needs no env.
+const publicUrl = process.env.PUBLIC_URL
+if (src.includes('<YOUR_PUBLIC_URL>') && !publicUrl) {
+  console.error('PUBLIC_URL is not set (base wrangler.jsonc uses <YOUR_PUBLIC_URL>).')
+  process.exit(1)
+}
+
 const resolved = src
   .replaceAll('<YOUR_ACCOUNT_ID>', accountId)
   .replaceAll('<better-notion-kv-namespace-id>', kvNamespaceId)
-  .replaceAll('<YOUR_PUBLIC_URL>', publicUrl)
+  .replaceAll('<YOUR_PUBLIC_URL>', publicUrl ?? '')
   // Drop the single-line `"routes": [...],` block: the custom domain is already
   // attached, and this also strips the <YOUR_WORKER_DOMAIN> placeholder so it
   // never reaches wrangler.
@@ -84,7 +89,7 @@ const resolved = src
 
 if (dryRun) {
   console.log(`cf:dryrun -> would write ${DEPLOY_CONFIG} and run: bunx wrangler deploy --config ${DEPLOY_CONFIG}`)
-  console.log(`cf:dryrun -> PUBLIC_URL resolved to ${publicUrl}`)
+  if (publicUrl) console.log(`cf:dryrun -> PUBLIC_URL resolved to ${publicUrl}`)
   // Fail loudly if any placeholder survived substitution: an unsubstituted
   // <...> token would otherwise ship literally into the deployed config.
   const leftover = [...new Set(resolved.match(/<[A-Za-z0-9_-]+>/g) ?? [])]

--- a/tests/wrangler-config.test.ts
+++ b/tests/wrangler-config.test.ts
@@ -39,8 +39,8 @@ describe('wrangler.jsonc', () => {
     expect(cfg.containers[0].image).not.toContain('ghcr.io')
   })
 
-  it('routes the production custom domain', () => {
-    expect(cfg.routes[0].pattern).toBe('notion.n24q02m.com')
+  it('keeps the route as a BYO placeholder (never hardcodes a real custom domain)', () => {
+    expect(cfg.routes[0].pattern).toBe('<YOUR_WORKER_DOMAIN>')
     expect(cfg.routes[0].custom_domain).toBe(true)
   })
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -46,10 +46,10 @@
     // reachable when the http server binds 0.0.0.0:8080 (same as the OCI VM
     // compose). Without HOST the container "is not listening on 10.0.0.1:8080".
     "HOST": "0.0.0.0",
-    "PUBLIC_URL": "https://notion.n24q02m.com",
+    "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal"
   },
-  "routes": [{ "pattern": "notion.n24q02m.com", "custom_domain": true }],
+  "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
Base wrangler.jsonc now fully BYO: PUBLIC_URL + routes use placeholders like account/KV. deploy_cf.py uses gitignored wrangler.deploy.jsonc; maintainer CD unaffected.