### PR TITLE
⚡ Bolt: Replace spread operator with for loop in autoPaginate

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2026-06-30 - Precompute Inline Regex to avoid Regex Compilation Penalties
 **Learning:** In hot paths, like string matching using `.match()` in `src/tools/helpers/errors.ts`, `src/tools/helpers/markdown.ts`, and `src/tools/helpers/properties.ts`, re-compiling inline regexes can cause CPU allocations and garbage collection overheads.
 **Action:** Always precompute these regex as module-level constants (e.g. `SAFE_STRING_REGEX`) rather than recreating them during runtime to improve speed and performance.
+## 2024-07-04 - Avoid spread operator for array appends on large data
+**Learning:** In V8 environments, using the spread operator (`...`) inside `Array.prototype.push()` (e.g., `arr.push(...largeArray)`) places the elements onto the call stack. For very large paginated datasets, this can cause "Maximum call stack size exceeded" errors and introduces intermediate array allocation and garbage collection penalties.
+**Action:** Always replace `arr.push(...largeArray)` with a traditional `for` loop (e.g., `for (let i = 0; i < largeArray.length; i++) arr.push(largeArray[i]);`) in paths handling potentially large or unbounded sets of data to ensure safety and improve performance.

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -45,7 +45,11 @@ export async function autoPaginate<T>(
     }
 
     const response = await fetchFn(cursor || undefined, currentPageSize)
-    allResults.push(...response.results)
+    // BOLT OPTIMIZATION: Avoid maximum call stack exceeded errors and array allocation penalties
+    // associated with the spread operator on large paginated datasets.
+    for (let i = 0; i < response.results.length; i++) {
+      allResults.push(response.results[i])
+    }
     cursor = response.next_cursor
     pageCount++
 


### PR DESCRIPTION
💡 What: Replaced the spread operator (`...`) used inside `allResults.push()` with a traditional `for` loop in `src/tools/helpers/pagination.ts`.
🎯 Why: In JavaScript, spreading a large array inside a function call places each element on the call stack, which can lead to "Maximum call stack size exceeded" errors for large datasets. A `for` loop is safer and avoids the intermediate array allocation and garbage collection overhead.
📊 Impact: Completely eliminates the risk of call stack errors during pagination of very large datasets and provides a small reduction in memory allocation overhead.
🔬 Measurement: Verified functionality by running the full test suite (`bun run test`) which passes with 100% success.

---
*PR created automatically by Jules for task [5665312111345768877](https://jules.google.com/task/5665312111345768877) started by @n24q02m*