### PR TITLE
⚡ Bolt: Optimize markdown parser array allocations and regex compilation

### DIFF
--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -70,6 +70,7 @@ const MENTION_ID_REGEX = /([a-f0-9]{32})/
 const INLINE_SUMMARY_REGEX = /^<details>\s*<summary>(.*?)<\/summary>(.*?)(<\/details>)?$/
 const SUMMARY_REGEX = /<summary>(.*?)<\/summary>/
 const COLUMN_REGEX = /^:::column(?:\{width=([\d.]+)\})?$/
+const TABLE_SEPARATOR_REGEX = /^[-:]+$/
 
 /**
  * Convert markdown string to Notion blocks
@@ -91,7 +92,9 @@ class MarkdownParser {
 
     // Flush remaining list
     if (this.currentList.length > 0) {
-      this.blocks.push(...this.currentList)
+      for (let j = 0; j < this.currentList.length; j++) {
+        this.blocks.push(this.currentList[j])
+      }
     }
 
     return this.blocks
@@ -102,7 +105,9 @@ class MarkdownParser {
 
     // Flush list if we're not in a list anymore
     if (this.currentListType && !isListItem(line)) {
-      this.blocks.push(...this.currentList)
+      for (let j = 0; j < this.currentList.length; j++) {
+        this.blocks.push(this.currentList[j])
+      }
       this.currentList = []
       this.currentListType = null
     }
@@ -786,15 +791,19 @@ function parseTable(lines: string[], startIndex: number): TableParseResult | nul
 
   if (parsedRows.length >= 2) {
     const possibleSeparator = parsedRows[1]
-    const isSeparator = possibleSeparator.every((cell: string) => /^[-:]+$/.test(cell.trim()))
+    const isSeparator = possibleSeparator.every((cell: string) => TABLE_SEPARATOR_REGEX.test(cell.trim()))
 
     if (isSeparator) {
       hasHeader = true
       headerRow = parsedRows[0]
-      dataRows.push(...parsedRows.slice(2))
+      for (let j = 2; j < parsedRows.length; j++) {
+        dataRows.push(parsedRows[j])
+      }
     } else {
       headerRow = parsedRows[0]
-      dataRows.push(...parsedRows.slice(1))
+      for (let j = 1; j < parsedRows.length; j++) {
+        dataRows.push(parsedRows[j])
+      }
     }
   } else {
     headerRow = parsedRows[0]


### PR DESCRIPTION
💡 What: Replaced array spread operations (`.push(...array)` and `.push(...array.slice())`) with manual `for` loops in the markdown parser. Extracted inline regular expression `/^[-:]+$/` to a module-level constant (`TABLE_SEPARATOR_REGEX`).
🎯 Why: Array spread operations allocate intermediate arrays and can throw "Maximum call stack size exceeded" errors on very large arrays. Inline regular expressions inside hot loops (like `.every()` in `parseTable`) incur compilation penalties.
📊 Impact: Eliminates V8 stack overflow crashes for extremely large lists/tables in markdown parsing, and reduces GC pressure and compilation overhead by precomputing the table separator regex and preventing intermediate array allocations.
🔬 Measurement: Verified with `bun run test` (all 954 tests pass) and `bun run check:fix` indicating no regressions or Biome violations.

---
*PR created automatically by Jules for task [5987470595464188585](https://jules.google.com/task/5987470595464188585) started by @n24q02m*