### PR TITLE
fix: point NotionContainer pingEndpoint at /health

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -175,9 +175,10 @@ export class NotionContainer extends Container<Env> {
   sleepAfter = '5m'
   // CF container readiness-probe override. Default 'ping' (URL http://ping/) does
   // not resolve, so the health-check fetch throws and the container is marked
-  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. 'localhost/'
-  // resolves to the container itself; the default route returns 200.
-  pingEndpoint = 'localhost/'
+  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. core-ts's
+  // local-server.ts serves 200 at /health (liveness route); '/' 302-redirects to
+  // the OAuth/relay app, so the probe must target /health specifically.
+  pingEndpoint = 'localhost/health'
   // The container reaches api.notion.com over the public internet; kv.internal
   // stays intercepted (see outboundByHost).
   enableInternet = true


### PR DESCRIPTION
## Summary
- `NotionContainer.pingEndpoint` was `'localhost/'`, which mcp-core's `local-server.ts` (core-ts) 302-redirects to the OAuth/relay app instead of returning 2xx.
- CF marks the container unhealthy on every probe, so it never sleeps (runs 24/7 instead of respecting `sleepAfter`).
- core-ts serves a dedicated liveness route at `/health` (200 JSON). Point the probe there instead.
- Note: the currently-deployed container image predates this source change and is reportedly healthy on the old build; this fix matters for the next rebuild/redeploy.

## Change
- `src/worker.ts`: `pingEndpoint = 'localhost/'` -> `pingEndpoint = 'localhost/health'` + updated adjacent comment. No other lines touched (the unrelated `CONTAINER_PING_ENDPOINT` export used only by a regression test is untouched — see PR discussion for context).

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] `bunx vitest run tests/worker.test.ts` — 19/19 passed
- [ ] CI green