### PR TITLE
fix: reject unauthenticated /mcp at the Worker edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -133,6 +133,19 @@ export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
   'kv.internal': kvOutbound
 }
 
+// Bearer credential presence check. Structural only -- validity is the container's job.
+const BEARER = /^Bearer\s+\S/i
+
+function unauthenticated(request: Request): Response {
+  const { origin } = new URL(request.url)
+  return new Response(null, {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`
+    }
+  })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // Public entrypoint: ONLY routes inbound requests to the per-user container
@@ -143,6 +156,19 @@ export default {
     // @cloudflare/containers' ContainerProxy + the NotionContainer.outboundByHost
     // registry below; unit tests call the handlers directly via the
     // OUTBOUND_BY_HOST export.
+    // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before this
+    // gate every anonymous /mcp request started the container and reset its 5m idle
+    // timer -- an unauthenticated caller could pin it awake and bill GiB-s around the
+    // clock. Verified 2026-07-09: a python-httpx client POSTed /mcp with no
+    // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it rejects
+    // requests carrying no bearer credential at all and reproduces the container's own
+    // 401 (empty body + RFC 9728 WWW-Authenticate). Token VALIDITY is never judged
+    // here -- the container remains the sole authority, so no mcp-core auth logic is
+    // duplicated at the edge.
+    const url = new URL(request.url)
+    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+      if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
+    }
     if (env.NOTION) {
       const userId = await extractUserId()
       const stub = env.NOTION.get(env.NOTION.idFromName(userId))
@@ -173,11 +199,12 @@ async function extractUserId(): Promise<string> {
 export class NotionContainer extends Container<Env> {
   defaultPort = 8080
   sleepAfter = '5m'
-  // CF container readiness-probe override. Default 'ping' (URL http://ping/) does
-  // not resolve, so the health-check fetch throws and the container is marked
-  // unhealthy -> CF keeps it running 24/7 instead of sleeping on idle. core-ts's
-  // local-server.ts serves 200 at /health (liveness route); '/' 302-redirects to
-  // the OAuth/relay app, so the probe must target /health specifically.
+  // Port-readiness probe used by @cloudflare/containers' waitForPort(): it does
+  // tcpPort.fetch('http://' + pingEndpoint) against the container's bound port, so the
+  // host segment is only a Host header (no DNS) and ANY HTTP response marks the port
+  // ready. We point it at /health because core-ts serves a cheap 200 there while '/'
+  // 302-redirects into the OAuth app. This does NOT drive the platform's `healthy`
+  // metric -- see the edge auth gate above for the real cause of containers never sleeping.
   pingEndpoint = 'localhost/health'
   // The container reaches api.notion.com over the public internet; kv.internal
   // stays intercepted (see outboundByHost).

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -67,14 +67,6 @@ export const CONTAINER_ENV_KEYS = [
   'NOTION_OAUTH_CLIENT_SECRET'
 ] as const
 
-// CF Containers readiness-probe target (NotionContainer.pingEndpoint). The
-// default 'ping' (URL http://ping/) does not resolve, so the health-check fetch
-// throws and the container is marked unhealthy -> CF keeps it running 24/7
-// instead of sleeping on idle. 'localhost/' resolves to the container itself;
-// the default route returns 200. Exported so the regression test pins it away
-// from the default.
-export const CONTAINER_PING_ENDPOINT = 'localhost/'
-
 function pickContainerEnv(env: Env): Record<string, string> {
   const out: Record<string, string> = {}
   for (const k of CONTAINER_ENV_KEYS) {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -17,6 +17,24 @@ function fakeEnv() {
 // public `fetch` entrypoint, so tests exercise them through the exported registry).
 const kvH = OUTBOUND_BY_HOST['kv.internal']!
 
+// Spies on a NOTION binding's idFromName, shared by the edge-auth-gate and
+// single-user-DO-contract describe blocks below.
+function envWithDoSpy() {
+  const calls: string[] = []
+  return {
+    calls,
+    env: {
+      NOTION: {
+        idFromName: (n: string) => {
+          calls.push(n)
+          return { name: n }
+        },
+        get: (_id: unknown) => ({ fetch: async () => new Response('do-hit', { status: 200 }) })
+      }
+    }
+  }
+}
+
 describe('outbound registry (KV-only)', () => {
   it('registers a kv.internal outbound handler', () => {
     expect(NotionContainer.outboundByHost['kv.internal']).toBeDefined()
@@ -103,26 +121,51 @@ describe('public fetch entrypoint does NOT expose outbound handlers (security)',
   })
 })
 
-describe('single-user DO contract + per-sub routing (E.2)', () => {
-  function envWithDoSpy() {
-    const calls: string[] = []
-    return {
-      calls,
-      env: {
-        NOTION: {
-          idFromName: (n: string) => {
-            calls.push(n)
-            return { name: n }
-          },
-          get: (_id: unknown) => ({ fetch: async () => new Response('do-hit', { status: 200 }) })
-        }
-      }
-    }
-  }
-
-  it('no Bearer token -> routes to the "default" DO', async () => {
+describe('edge auth gate (cost bug: anonymous /mcp must never reach the DO)', () => {
+  it('POST /mcp with no Authorization -> 401, DO never touched', async () => {
     const { calls, env } = envWithDoSpy()
-    const res = await worker.fetch(new Request('https://notion.n24q02m.com/mcp'), env as never)
+    const res = await worker.fetch(new Request('https://notion.n24q02m.com/mcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('')
+    expect(res.headers.get('WWW-Authenticate')).toMatch(
+      /^Bearer resource_metadata="https:\/\/[^"]+\/\.well-known\/oauth-protected-resource"$/
+    )
+    expect(calls).toEqual([])
+  })
+
+  it('OPTIONS /mcp with no Authorization -> 401, DO never touched', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://notion.n24q02m.com/mcp', { method: 'OPTIONS' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls).toEqual([])
+  })
+
+  it('POST /mcp with Authorization: Bearer anything -> DO is called (validity not judged)', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://notion.n24q02m.com/mcp', {
+        method: 'POST',
+        headers: { authorization: 'Bearer anything' }
+      }),
+      env as never
+    )
+    expect(res.status).toBe(200)
+    expect(calls).toEqual(['default'])
+  })
+
+  it('GET /authorize?foo=1 with no Authorization -> non-/mcp paths still reach the DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    await worker.fetch(new Request('https://notion.n24q02m.com/authorize?foo=1'), env as never)
+    expect(calls).toEqual(['default'])
+  })
+})
+
+describe('single-user DO contract + per-sub routing (E.2)', () => {
+  it('no Bearer token on a non-/mcp path -> routes to the "default" DO', async () => {
+    // /mcp itself is gated by the edge auth check below when there's no Bearer;
+    // /authorize is not, so it still exercises extractUserId()'s "default" fallback.
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://notion.n24q02m.com/authorize'), env as never)
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('do-hit')
     expect(calls).toEqual(['default'])

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import worker, { CONTAINER_ENV_KEYS, CONTAINER_PING_ENDPOINT, NotionContainer, OUTBOUND_BY_HOST } from '../src/worker'
+import worker, { CONTAINER_ENV_KEYS, NotionContainer, OUTBOUND_BY_HOST } from '../src/worker'
 
 function fakeEnv() {
   const kv = new Map<string, ArrayBuffer>()
@@ -100,13 +101,13 @@ describe('CF container readiness (TS-on-CF regressions)', () => {
     expect(CONTAINER_ENV_KEYS).toContain('MCP_RELAY_PASSWORD')
   })
 
-  // The default Container ping ('ping' -> URL http://ping/) does not resolve, so
-  // the health-check fetch throws and the container is marked unhealthy -> CF
-  // keeps it running 24/7 instead of sleeping on idle. 'localhost/' resolves to
-  // the container itself and the default route returns 200.
-  it('pings localhost/ (resolves to the container itself), not the unresolvable "ping"', () => {
-    expect(CONTAINER_PING_ENDPOINT).toBe('localhost/')
-    expect(CONTAINER_PING_ENDPOINT).not.toBe('ping')
+  // NotionContainer's real constructor (from @cloudflare/containers) requires a
+  // live Durable Object ctx (ctx.container/.storage/.sql), so it cannot be
+  // `new`'d in a plain-node unit test -- assert against the source text instead,
+  // same technique as the sleepAfter check in transports/http.cf.test.ts.
+  it('pingEndpoint targets /health, the actual field the container class reads', () => {
+    const src = readFileSync('src/worker.ts', 'utf-8')
+    expect(src).toContain("pingEndpoint = 'localhost/health'")
   })
 })
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,21 @@
-import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// @cloudflare/containers imports `cloudflare:workers`, which only exists in the
+// Workers runtime, so it cannot load under Node/vitest. Mock it: Container as a
+// plain base class (real field initializers like `pingEndpoint = '...'` still run
+// against it, so NotionContainer can be constructed and its real fields read) +
+// a ContainerProxy stub for the entrypoint re-export. Same technique as the
+// sibling better-email-mcp's tests/worker.test.ts.
+vi.mock('@cloudflare/containers', () => ({
+  Container: class {
+    env: unknown
+    constructor(_ctx?: unknown, env?: unknown) {
+      this.env = env ?? {}
+    }
+  },
+  ContainerProxy: class {}
+}))
+
 import worker, { CONTAINER_ENV_KEYS, NotionContainer, OUTBOUND_BY_HOST } from '../src/worker'
 
 function fakeEnv() {
@@ -101,13 +117,9 @@ describe('CF container readiness (TS-on-CF regressions)', () => {
     expect(CONTAINER_ENV_KEYS).toContain('MCP_RELAY_PASSWORD')
   })
 
-  // NotionContainer's real constructor (from @cloudflare/containers) requires a
-  // live Durable Object ctx (ctx.container/.storage/.sql), so it cannot be
-  // `new`'d in a plain-node unit test -- assert against the source text instead,
-  // same technique as the sleepAfter check in transports/http.cf.test.ts.
-  it('pingEndpoint targets /health, the actual field the container class reads', () => {
-    const src = readFileSync('src/worker.ts', 'utf-8')
-    expect(src).toContain("pingEndpoint = 'localhost/health'")
+  it('pingEndpoint targets /health, not the default unresolvable "ping"', () => {
+    const c = new NotionContainer(undefined as never, {} as never)
+    expect(c.pingEndpoint).toBe('localhost/health')
   })
 })
 


### PR DESCRIPTION
## The cost bug

mcp-core's OAuth Authorization Server runs INSIDE the container Durable Object, not at the
Worker edge. The Worker's `fetch` unconditionally routed every inbound request (including
anonymous ones) straight to the container, which starts the Durable Object and resets its
5-minute idle timer before it even gets a chance to answer 401 itself.

Measured live on the sibling `better-email-mcp` deployment (2026-07-09/10, identical worker
shape): an unauthenticated `python-httpx/0.28.1` client POSTed `/mcp` with NO `Authorization`
header roughly every 20 seconds for 12+ hours, pinning that container awake around the clock
-- 1282 x HTTP 401 in a single 6-hour window. `better-notion-mcp` has the identical exposure
(same worker pattern, same OAuth-in-container design), so it gets the same fix. Cloudflare
bills container memory (GiB-s) for the whole time a container is awake, so this is a live,
unbounded cost leak driven entirely by anonymous traffic.

## The fix

`src/worker.ts` now gates `/mcp` (and any path under it) at the edge, before the Durable
Object is touched: if there is no `Bearer <token>` in the `Authorization` header, the Worker
answers 401 itself and never calls `env.NOTION.get(...)`. The 401 is byte-compatible with what
the container returns today (empty body, `WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`).

The check is purely structural: it only asks "is there a bearer credential at all", never
"is this token valid". mcp-core's OAuth logic inside the container remains the sole authority
on token validity -- nothing is duplicated at the edge. Any request carrying `Bearer <anything>`
still reaches the container unchanged, same as `/authorize`, `/token`, `/register`, `/login`,
`/.well-known/*`, and `/health`.

## Second fix in the same file: a misleading comment

The `NotionContainer.pingEndpoint` comment claimed the default `'ping'` readiness probe "does
not resolve, so the health-check fetch throws and the container is marked unhealthy -> CF
keeps it running 24/7" -- that's not what happens and it already misled two debugging
sessions. `@cloudflare/containers`' `waitForPort()` does `tcpPort.fetch('http://' + pingEndpoint)`
against the container's already-bound TCP port; the host segment is only a `Host` header
(no DNS lookup happens), and the library's own docs say the user doesn't need to implement
this route at all -- any HTTP response resolves it. The comment is corrected to describe the
actual mechanism and points at the edge gate above as the real fix for the always-awake
behavior. The `pingEndpoint` value itself is unchanged.

## Tests

Extended `tests/worker.test.ts` (did not rewrite). Hoisted the existing `envWithDoSpy()`
helper (previously local to one `describe` block) to module scope so it can be shared by the
new edge-auth-gate tests:

- `POST /mcp` with no `Authorization` -> 401, `WWW-Authenticate` matches the RFC 9728 shape,
  empty body, Durable Object stub never called.
- `OPTIONS /mcp` with no `Authorization` -> 401, stub never called.
- `POST /mcp` with `Authorization: Bearer anything` -> stub called exactly once (validity is
  not judged at the edge).
- Non-`/mcp` path (`/authorize`) with no `Authorization` -> still reaches the stub.
- Adjusted the one pre-existing test that asserted `/mcp` + no `Authorization` reaches the DO
  (it now legitimately hits the new 401 first): moved it to `/authorize` (an ungated path) to
  keep testing `extractUserId()`'s "default" fallback, which was its actual intent.

## Verification

- `bun run type-check` (both `tsconfig.json` and `tsconfig.worker.json`) -- clean
- `bunx vitest run tests/worker.test.ts` -- 23/23 passed
- `bun run test` (full suite) -- 958 passed, 0 failed
- `bun run check` (biome + tsc) -- **fails on a clean, unmodified `main` too** (verified via
  `git stash`): the working tree has pre-existing untracked debris
  (`scripts/notion-verify-*.json(.pkce)`, leftover JWTs from a prior E2E session) that biome
  can't parse, plus one pre-existing unused import (`JWTIssuer` in `worker.ts`, not touched by
  this diff) and one pre-existing lint suggestion in `credential-state.ts` (unrelated file).
  Running `biome check` scoped to just the two files this PR touches
  (`bunx biome check src/worker.ts tests/worker.test.ts`) shows only that one pre-existing
  unused-import warning -- nothing introduced by this change.
- `bun run cf:dryrun` -- fails locally because it requires `CLOUDFLARE_ACCOUNT_ID`/
  `CLOUDFLARE_API_TOKEN`, not available in this environment (reported honestly, not faked). A
  direct `wrangler deploy --dry-run --config wrangler.jsonc` against the template config
  succeeded (`Total Upload: 59.81 KiB / gzip: 14.93 KiB`, `--dry-run: exiting now.`),
  confirming the Worker still bundles with these changes.

Not merging -- leaving open per request.