### PR TITLE
fix: fail the release when the computed version already exists on npm

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,68 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
+      # Dry-run PSR (no_operation_mode => --noop: no commit/tag/push/release) purely to
+      # learn the version it WOULD publish, so the npm-collision guard below can fire
+      # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and
+      # same prerelease inputs as the real step, run against the same untouched checkout,
+      # so the computed version is identical.
+      - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10
+        id: dryrun
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          config_file: semantic-release.toml
+          prerelease: ${{ inputs.release_type == 'beta' }}
+          prerelease_token: beta
+          no_operation_mode: true
+
+      # Fail early and loudly if the version PSR intends to publish already exists on
+      # npm. npm never allows reusing a version number, so a hit here means the git
+      # history has diverged from the registry (this repo published 3.0.0, 3.0.1-beta,
+      # 3.0.1-beta.1 and 3.1.0-beta.1 in Feb 2026, then rewrote history onto the 2.x
+      # line). Catching it here converts two nasty failure modes -- PSR silently setting
+      # released=false on a matching tag (every publish job skipped) and an opaque npm
+      # 409 deep inside `npm publish` -- into one explicit, actionable error, before any
+      # tag or Release is created.
+      - name: Guard against re-publishing an already-published npm version
+        if: steps.dryrun.outputs.released == 'true'
+        env:
+          COMPUTED_VERSION: ${{ steps.dryrun.outputs.version }}
+        run: |
+          set -uo pipefail
+          PKG='@n24q02m/better-notion-mcp'
+          echo "Checking npm for ${PKG}@${COMPUTED_VERSION} before semantic-release tags anything..."
+
+          # npm view against the live registry (behaviour verified unauthenticated):
+          #   version exists        -> exit 0, prints the version on stdout  => COLLISION
+          #   version/package 404   -> exit non-zero, output contains 'E404' => FREE
+          #   network/registry error-> exit non-zero, output has NO 'E404'   => UNKNOWN
+          # A transient error must NEVER be read as "free": that could let a real
+          # collision slip through, which is worse than the bug this guard prevents.
+          if output="$(npm view "${PKG}@${COMPUTED_VERSION}" version 2>&1)"; then
+            status=0
+          else
+            status=$?
+          fi
+
+          # COLLISION: registry returned a concrete version -> already published.
+          if [ "${status}" -eq 0 ] && [ -n "${output}" ]; then
+            echo "::error::Computed release version ${COMPUTED_VERSION} already exists on npm as ${PKG}@${COMPUTED_VERSION}. npm NEVER allows re-publishing a version number, even one later unpublished or deprecated. This almost always means the git history diverged from what was published to npm -- tags/commits were rewritten while the registry kept the original releases. Do NOT retry the same version: bump PAST the already-published range (higher than any version ever published) and dispatch the release again."
+            exit 1
+          fi
+
+          # FREE: an E404 (missing version, or missing package) means this exact
+          # coordinate is not on the registry -> safe to publish.
+          if printf '%s\n' "${output}" | grep -q 'E404'; then
+            echo "OK: ${PKG}@${COMPUTED_VERSION} is not on npm (E404) -- safe to publish."
+            exit 0
+          fi
+
+          # UNKNOWN: npm view failed without an E404 (network/registry outage, rate
+          # limit, auth). Refuse to proceed so a genuine collision cannot be mistaken
+          # for "free".
+          echo "::error::Could not verify whether ${PKG}@${COMPUTED_VERSION} exists on npm: 'npm view' failed without an E404 (likely a transient registry/network error, rate limit, or outage). Refusing to proceed so a genuine collision cannot slip through as a false 'free'. Re-run the release once the registry is reachable. npm output: ${output}"
+          exit 1
+
       - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10
         id: release
         with:


### PR DESCRIPTION
## Problem

In February 2026 this package published `3.0.0`, `3.0.1-beta`, `3.0.1-beta.1` and `3.1.0-beta.1` to npm. The git history was later rewritten and `main` now lives on the 2.x lineage (`git describe --tags origin/main` = `v2.37.0-beta.1`). **npm never allows reusing a version number** -- even a deleted one -- so those four versions remain claimed on the registry forever. The 3.x tags/Releases survive on `archive/v3-lineage`.

If python-semantic-release ever computes one of those versions (reachable only via a future major bump into the 3.x range), the release fails in one of two bad ways:

- **Silent freeze:** if a matching git tag exists, PSR reports "vX has already been released", sets its `released` output to `false`, and every downstream publish job is **skipped**. Nobody notices.
- **Opaque 409:** if no tag exists, `npm publish` dies with a 409 deep inside the pipeline -- after PSR has already created a git tag and GitHub Release, leaving a messy half-done state.

Neither is acceptable. We want a loud, early, actionable failure.

## Change (`.github/workflows/cd.yml` only)

Placed the guard in the `release` job **before** the real semantic-release step, so it fires before any tag or Release is created -- the earliest point at which the version is known. This is the preferred placement from the task; it is feasible here because PSR's action exposes a no-operation mode.

1. **Dry-run step** (`id: dryrun`) -- reuses the exact same pinned PSR action (`350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0`) with `no_operation_mode: true` (`--noop`: no commit/tag/push/release) and the same `prerelease`/`prerelease_token` inputs as the real step. The action still reports `version`/`released`/`is_prerelease` in noop mode, so the computed version is identical to what the real step will produce (same untouched checkout, nothing mutated between them). No new action or dependency is introduced.
2. **Guard step** -- gated on `steps.dryrun.outputs.released == 'true'` (mirrors the existing `needs.release.outputs.released == 'true'` gate on the publish jobs, so it only fires when a publish will actually happen; without this gate, a "no releasable commits" dispatch would report the current already-published version and false-fail). It queries `npm view "@n24q02m/better-notion-mcp@<version>" version` and classifies three outcomes:

   | npm view result | meaning | action |
   |---|---|---|
   | exit 0, prints a version | **COLLISION** | `::error::` (npm never permits reuse; history diverged; bump past the published range, do not retry) + `exit 1` |
   | non-zero, output contains `E404` | **FREE** (version or package absent) | proceed |
   | non-zero, no `E404` (network/registry outage, rate limit, auth) | **UNKNOWN** | `::error::` + `exit 1` -- never treated as "free" |

   Treating a transient error as "free" would be worse than the bug being fixed, so the default on any non-E404 failure is to refuse to publish.

The `release` job's outputs (`released`/`tag`/`version`/`is_prerelease`) still come from the real `id: release` step and are unchanged, so `publish-npm`, `build-docker`, `merge-docker`, `publish-mcp-registry`, `sync-marketplace` and `deploy-cf` consume them exactly as before. The new action reference is pinned by the same commit SHA already used in the file. No PSR config, tags, Releases or `package.json` were touched.

## Verification

**YAML / workflow validation** (both run locally, real output):

```
$ bunx --yes @action-validator/cli .github/workflows/cd.yml
validator_exit=0            # no output == valid

$ python -c "import yaml; yaml.safe_load(open('.github/workflows/cd.yml'))"
YAML OK: parsed successfully
```

Applicable pre-commit hooks pass (`gitleaks`, `check-yaml`, trailing-whitespace, end-of-file-fixer); the `types: [ts]` hooks correctly skip a YAML-only change.

**Three-way classification against the live registry** (unauthenticated `npm view`), using the exact shell logic from the guard:

```
CASE 1  npm view "@n24q02m/better-notion-mcp@3.0.0"      -> exit 0, prints "3.0.0"
        => CLASSIFICATION: COLLISION (fail, exit 1)

CASE 2  npm view "@n24q02m/better-notion-mcp@99.99.99"   -> exit 1, "npm error code E404"
        => CLASSIFICATION: FREE (proceed, exit 0)

CASE 3  npm view "@n24q02m/definitely-not-a-package@1.0.0" -> exit 1, "npm error code E404"
        => CLASSIFICATION: FREE (proceed, exit 0)
        (a whole-package 404 is still an E404: the exact coordinate is not published,
         so it is correctly "free". Our real package always exists, so in practice only
         the per-version E404 path is hit here.)

CASE 4  npm view against an unreachable registry (simulated ECONNREFUSED, no E404)
        => CLASSIFICATION: UNKNOWN (fail loudly, exit 1)
```

Do not merge.