### PR TITLE
fix: decline standing GET /mcp SSE stream at the edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -161,6 +161,17 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
+    // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
+    // scale-to-zero container this is pure idle cost: @cloudflare/containers
+    // counts an open stream as an in-flight request forever (inflight > 0 =>
+    // activity never expires), so a single idle client pins the container
+    // awake 24/7. None of this stack's servers send server-initiated
+    // messages; request-scoped notifications ride the POST's own SSE
+    // response. The spec allows declining the stream: both official SDKs
+    // treat 405 as the optional-feature path and continue POST-only.
+    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
+    }
     if (env.NOTION) {
       const userId = await extractUserId()
       const stub = env.NOTION.get(env.NOTION.idFromName(userId))

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -153,6 +153,13 @@ describe('edge auth gate (cost bug: anonymous /mcp must never reach the DO)', ()
     expect(calls).toEqual([])
   })
 
+  it('GET /mcp with no Authorization -> still 401 (bearer gate runs before the 405 gate), DO never touched', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://notion.n24q02m.com/mcp', { method: 'GET' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls).toEqual([])
+  })
+
   it('POST /mcp with Authorization: Bearer anything -> DO is called (validity not judged)', async () => {
     const { calls, env } = envWithDoSpy()
     const res = await worker.fetch(
@@ -173,6 +180,29 @@ describe('edge auth gate (cost bug: anonymous /mcp must never reach the DO)', ()
   })
 })
 
+describe('standing GET /mcp SSE decline (cost bug: an open stream pins the container awake 24/7)', () => {
+  it('GET /mcp with a valid Bearer -> 405, Allow: POST, DELETE, DO never touched', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://notion.n24q02m.com/mcp', { method: 'GET', headers: { authorization: 'Bearer x' } }),
+      env as never
+    )
+    expect(res.status).toBe(405)
+    expect(res.headers.get('allow')).toBe('POST, DELETE')
+    expect(calls).toEqual([])
+  })
+
+  it('GET /mcp/sub with a valid Bearer -> 405 (sub-path also declines the stream)', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://notion.n24q02m.com/mcp/sub', { method: 'GET', headers: { authorization: 'Bearer x' } }),
+      env as never
+    )
+    expect(res.status).toBe(405)
+    expect(calls).toEqual([])
+  })
+})
+
 describe('single-user DO contract + per-sub routing (E.2)', () => {
   it('no Bearer token on a non-/mcp path -> routes to the "default" DO', async () => {
     // /mcp itself is gated by the edge auth check below when there's no Bearer;
@@ -187,8 +217,11 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
   it('Bearer token without sub -> routes to the "default" DO', async () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
+    // POST: GET /mcp is declined with 405 (standing SSE stream) before reaching
+    // the DO, so sub-extraction is exercised via the same method a real client
+    // uses to send a JSON-RPC message.
     await worker.fetch(
-      new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://notion.n24q02m.com/mcp', { method: 'POST', headers: { authorization: `Bearer ${jwt}` } }),
       env as never
     )
     expect(calls).toEqual(['default'])
@@ -198,7 +231,7 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
     await worker.fetch(
-      new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://notion.n24q02m.com/mcp', { method: 'POST', headers: { authorization: `Bearer ${jwt}` } }),
       env as never
     )
     expect(calls).toEqual(['default'])
@@ -210,7 +243,7 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     // Actually, atob() in Node/Bun is quite permissive but we can provide something that definitely fails or results in garbage.
     // In many JS environments atob("!!!") throws.
     await worker.fetch(
-      new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: 'Bearer h.!!!.s' } }),
+      new Request('https://notion.n24q02m.com/mcp', { method: 'POST', headers: { authorization: 'Bearer h.!!!.s' } }),
       env as never
     )
     expect(calls).toEqual(['default'])
@@ -220,7 +253,10 @@ describe('single-user DO contract + per-sub routing (E.2)', () => {
     const { calls, env } = envWithDoSpy()
     const malformedJsonB64 = btoa('{"sub": "missing-quote')
     await worker.fetch(
-      new Request('https://notion.n24q02m.com/mcp', { headers: { authorization: `Bearer h.${malformedJsonB64}.s` } }),
+      new Request('https://notion.n24q02m.com/mcp', {
+        method: 'POST',
+        headers: { authorization: `Bearer h.${malformedJsonB64}.s` }
+      }),
       env as never
     )
     expect(calls).toEqual(['default'])


### PR DESCRIPTION
## Summary
- `@cloudflare/containers` treats an open proxied stream as an in-flight request forever (inflight > 0 => activity never expires), so a standing GET /mcp SSE stream from any MCP client pins the scale-to-zero container awake and billing 24/7.
- None of this stack's servers send server-initiated push messages; request-scoped notifications already ride the POST's own SSE response, so nothing is lost by declining the GET stream.
- The streamable-HTTP spec allows a server to decline the optional GET stream with 405. Both official SDKs handle it as the expected/optional-feature path and continue POST-only (TS client: `client/streamableHttp.js:100-104`; Python client retries a couple of times then gives up quietly).
- Adds a 405 (`Allow: POST, DELETE`) for `GET /mcp` and `GET /mcp/*` in the edge worker, after the existing bearer-gate check.

## Test plan
- [x] `bunx vitest run tests/worker.test.ts` -- 26/26 passing, including 3 new cases: authenticated GET /mcp -> 405 with `Allow: POST, DELETE`, authenticated GET /mcp/sub -> 405, unauthenticated GET /mcp -> still 401 (bearer gate runs first).
- [x] Fixed 4 pre-existing sub-routing tests that implicitly relied on GET reaching the DO (no explicit `method`) -- switched them to POST, matching how a real client sends JSON-RPC messages.
- [x] `bunx tsc --noEmit` clean.
- [x] `bunx biome check` clean (pre-existing unused-import warning on `JWTIssuer`, unrelated to this change).
- [x] Full suite (`bunx vitest run`) green: 961/961.