### PR TITLE
feat: add smithery.yaml for stdio deployment

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,12 @@
+# Smithery configuration -- https://smithery.ai/docs/build/project-config
+# Runs the server over stdio (its default transport). No config is required to
+# start; configure credentials at runtime via the server's own config flow
+# (see README).
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties: {}
+    additionalProperties: false
+  commandFunction: |-
+    (config) => ({ command: 'npx', args: ['-y', '@n24q02m/better-notion-mcp'] })


### PR DESCRIPTION
Adds a Smithery deploy config so the server can be listed and connected on smithery.ai.

- `startCommand.type: stdio` runs the server over stdio (its default transport).
- `commandFunction` invokes the published package, matching the canonical runtime hint in `server.json`.
- Empty `configSchema`: no config is required to start; credentials are configured at runtime via the server's own config flow.

Registry: Smithery.ai (E3).