### PR TITLE
feat: document CLI, smithery, and self-host endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ mcp-name: io.github.n24q02m/better-notion-mcp
 
 - [Features](#features)
 - [Install](#install)
+- [CLI](#cli)
+- [Hosted endpoint](#hosted-endpoint)
+- [Smithery](#smithery)
 - [Status](#status)
 - [Documentation](#documentation)
 - [Tools](#tools)
@@ -96,6 +99,47 @@ docker run --rm -i -e NOTION_TOKEN=ntn_your_token_here n24q02m/better-notion-mcp
 ```
 
 See the [Documentation](#documentation) section for per-client setup (Claude Code, Codex, Gemini CLI, Cursor, Windsurf) and HTTP/OAuth mode.
+
+## CLI
+
+Installing the package exposes a `better-notion-mcp` binary (run it with `npx` or after a global install). It has **no subcommands** -- running it starts the MCP server and speaks the protocol over stdin/stdout, so it is normally launched by an MCP client rather than by hand.
+
+```bash
+# Start the stdio server (default transport; requires NOTION_TOKEN)
+NOTION_TOKEN=ntn_your_token_here npx --yes @n24q02m/better-notion-mcp@latest
+
+# Start the remote HTTP server (OAuth 2.1) instead of stdio
+npx --yes @n24q02m/better-notion-mcp@latest --http
+```
+
+| Argument / env | Effect |
+|:---------------|:-------|
+| _(none)_ | stdio transport (default); requires `NOTION_TOKEN` |
+| `--http` | HTTP transport with OAuth 2.1 (equivalent to `TRANSPORT_MODE=http` / `MCP_TRANSPORT=http`) |
+
+See [Configuration](#configuration) for the full environment-variable reference.
+
+## Hosted endpoint
+
+A ready-to-use remote instance is hosted at **`https://notion.n24q02m.com/mcp`** (HTTP transport, OAuth 2.1 -- no integration token to paste). Point an MCP client that supports remote HTTP servers at it:
+
+```jsonc
+// MCP client config -- remote HTTP (OAuth 2.1)
+{
+  "mcpServers": {
+    "better-notion-mcp": {
+      "type": "http",
+      "url": "https://notion.n24q02m.com/mcp"
+    }
+  }
+}
+```
+
+On first connect the client opens Notion's OAuth consent screen; per-user access tokens are held in-process only (see [Trust Model](#trust-model)). To run your own remote instance instead, see [Self-Hosting (Remote Mode)](#self-hosting-remote-mode) and [Deploy to Cloudflare](#deploy-to-cloudflare).
+
+## Smithery
+
+The repo ships a [`smithery.yaml`](smithery.yaml) config for [Smithery](https://smithery.ai). Smithery launches the server over stdio (`npx -y @n24q02m/better-notion-mcp`) and requires no install-time config -- provide your Notion credentials at runtime through the server's own setup flow (`NOTION_TOKEN` env, or the relay form; see [Configuration](#configuration)).
 
 ## Status
 


### PR DESCRIPTION
## Summary

Refresh `README.md` to document three previously-undocumented surfaces, all verified against source / live infra:

- **`## CLI`** -- the `better-notion-mcp` binary (`bin/cli.mjs`, bundled from `src/main.ts`). It has **no subcommands**; the only argument is the `--http` flag (verified in `src/main.ts:60` `getTransportMode` -- `argv.includes('--http')`). Documents stdio (default, needs `NOTION_TOKEN`) vs `--http` (OAuth 2.1) invocation.
- **`## Hosted endpoint`** -- the n24q02m-hosted remote instance at `https://notion.n24q02m.com/mcp` (HTTP + OAuth 2.1). Verified live: `POST` returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://notion.n24q02m.com/.well-known/oauth-protected-resource"`.
- **`## Smithery`** -- describes the shipped `smithery.yaml` (stdio via `npx -y @n24q02m/better-notion-mcp`, no install-time config).

Table of contents updated to match. Change is README-only and surgical.

## Verification

- Pre-commit run on `README.md`: gitleaks, trailing-whitespace, merge-conflict, end-of-file-fixer all pass.
- Hosted endpoint OAuth gating confirmed via `curl` (401 + `WWW-Authenticate: Bearer`).
- No secrets / model IDs / personal email / private paths added (public-safe).