### PR TITLE
feat: wire core buildCli for doctor/config/relay/--version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@n24q02m/mcp-core": "^1.19.0",
+        "@n24q02m/mcp-core": "1.20.0-beta.2",
         "@notionhq/client": "^5.23.0",
         "zod": "^4.4.3",
       },
@@ -127,7 +127,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.19.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-SWhhZMcgqt0SEbZVb/NudgFrvrbB+YudHMZiNUF21LnecjQseuQKP3KVLqDHIdMTM35FrOz/zii7uQ1NRrS1Tg=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.20.0-beta.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "better-sqlite3": "^12.11.1", "env-paths": "^4.0.0", "jose": "^6.2.3" } }, "sha512-i8dizV+LgAu+jFlEJbg0bd5ahPgmGbPw7mpWOb3M6ukxKsaT6dtxM48nvvdPIkKM4WUfjyr1NIa67BJl9e5qWQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@n24q02m/mcp-core": "^1.19.0",
+    "@n24q02m/mcp-core": "1.20.0-beta.2",
     "@notionhq/client": "^5.23.0",
     "zod": "^4.4.3"
   },

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -438,4 +438,85 @@ describe('main.ts', () => {
       delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED
     })
   })
+
+  describe('CLI wiring (buildCli)', () => {
+    const currentDir = dirname(fileURLToPath(import.meta.url))
+    const mainPath = join(currentDir, 'main.ts')
+
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'production')
+      process.argv[1] = mainPath
+      vi.mocked(fs.realpathSync).mockReturnValue(mainPath)
+    })
+
+    afterEach(() => {
+      delete process.env.BETTER_NOTION_MCP_BOOTSTRAPPED
+    })
+
+    it('prints version and exits 0 without starting the server', async () => {
+      process.argv = [process.argv[0], mainPath, '--version']
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ version: '9.9.9' }))
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      vi.resetModules()
+      await import(`${pathToFileURL(mainPath).href}?test=${Date.now()}`)
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+
+      expect(logSpy).toHaveBeenCalledWith('better-notion-mcp 9.9.9')
+      expect(exitSpy).toHaveBeenCalledWith(0)
+      expect(stdioConnectMock).not.toHaveBeenCalled()
+      logSpy.mockRestore()
+    })
+
+    it('routes config status to the built-in handler without starting the server', async () => {
+      process.argv = [process.argv[0], mainPath, 'config', 'status']
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      vi.resetModules()
+      await import(`${pathToFileURL(mainPath).href}?test=${Date.now()}`)
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('better-notion-mcp:'))
+      expect(stdioConnectMock).not.toHaveBeenCalled()
+      logSpy.mockRestore()
+    })
+
+    it('does not exit right after the stdio transport connects (stays alive until shutdown)', async () => {
+      // Regression guard: Server.connect() resolves once the transport
+      // starts listening, not once the session ends. If `serve()` returned
+      // right there, buildCli's `.then((code) => process.exit(code))` would
+      // kill the process immediately after startup instead of keeping the
+      // server running.
+      process.argv = [process.argv[0], mainPath]
+      process.env.NOTION_TOKEN = 'ntn_test_token'
+
+      vi.resetModules()
+      await import(`${pathToFileURL(mainPath).href}?test=${Date.now()}`)
+      await vi.waitFor(() => expect(stdioConnectMock).toHaveBeenCalled())
+
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(exitSpy).not.toHaveBeenCalled()
+    })
+
+    it('exits 0 once SIGINT fires after the transport connects', async () => {
+      process.argv = [process.argv[0], mainPath]
+      process.env.NOTION_TOKEN = 'ntn_test_token'
+      let sigintHandler: (() => void) | undefined
+      const onceSpy = vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+        if (event === 'SIGINT') sigintHandler = listener as () => void
+        return process
+      })
+
+      vi.resetModules()
+      await import(`${pathToFileURL(mainPath).href}?test=${Date.now()}`)
+      await vi.waitFor(() => expect(sigintHandler).toBeDefined())
+      expect(exitSpy).not.toHaveBeenCalled()
+
+      sigintHandler?.()
+      await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+      expect(exitSpy).toHaveBeenCalledWith(0)
+
+      onceSpy.mockRestore()
+    })
+  })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { buildCli } from '@n24q02m/mcp-core'
 import { Client } from '@notionhq/client'
 import { getNotionToken, resolveCredentialState } from './credential-state.js'
 import { registerTools } from './tools/registry.js'
@@ -139,7 +140,36 @@ export async function bootstrap(selectedMode: string = mode) {
 }
 // Rebuild target: mcp-core 1.11.5 (P0 fork-bomb fix)
 
-// Only execute bootstrap if we're the main module and not in a test environment.
+/**
+ * `serve` entry point for `buildCli` (config/relay/doctor/--version/-h
+ * built-ins; bare/flag argv routes here).
+ *
+ * `bootstrap()` already resolves as soon as the transport is ready -- for
+ * http mode that means `startHttp()` has already blocked until its own
+ * SIGINT/SIGTERM shutdown completes (see transports/http.ts), but for stdio
+ * mode `server.connect(transport)` resolves the instant the stdin listener
+ * attaches, not when the session ends. If this function returned right
+ * there, buildCli's `.then((code) => process.exit(code))` would kill the
+ * process immediately after startup. So stdio keeps this promise pending
+ * until SIGINT/SIGTERM, mirroring the shutdown-wait pattern http already
+ * uses.
+ */
+async function serve(): Promise<void> {
+  await bootstrap()
+  if (mode === 'http') return
+  await new Promise<void>((resolve) => {
+    const shutdown = () => {
+      console.error(`[${SERVER_NAME}] shutting down`)
+      resolve()
+    }
+    process.once('SIGINT', shutdown)
+    process.once('SIGTERM', shutdown)
+  })
+}
+
+// Only execute the CLI if we're the main module and not in a test environment.
 if (isMain(import.meta.url) && process.env.NODE_ENV !== 'test') {
-  bootstrap()
+  buildCli(SERVER_NAME, { serve, version: getPackageVersion() })(process.argv.slice(2)).then((code) =>
+    process.exit(code)
+  )
 }


### PR DESCRIPTION
## Summary
- Wire mcp-core's `buildCli` into `src/main.ts`, giving `better-notion-mcp` the same `doctor`/`config status|delete`/`relay status|open|reset`/`--version`/`-h` CLI built-ins the Python servers (wet/mnemo/telegram/crg) already have (Task W5.1). `pluginName` uses the default `serverName.replace(/-mcp$/, '')` = `better-notion`, matching the existing `PerPluginStore("better-notion")` slug used by the HTTP multi-user token store, so `config status`/`doctor` read the same storage the server already writes to.
- Bump `@n24q02m/mcp-core` to the exact `1.20.0-beta.2` prerelease (a `^` range never resolves to a prerelease build; verified `bun install` resolves `1.20.0-beta.2`).
- Fix a premature-exit hazard found while wiring: `Server.connect()` for stdio resolves as soon as the transport starts listening (attaches a `stdin` `'data'` listener), not once the session ends. buildCli's documented usage is `buildCli(...)(argv).then((code) => process.exit(code))`, so without a fix the process would call `process.exit(0)` immediately after startup instead of staying alive to serve requests. The stdio path in `serve()` now waits on `SIGINT`/`SIGTERM` before resolving; `http` mode is unaffected (`transports/http.ts` already blocks until its own shutdown handler resolves).

## Test plan
- [x] `bun run test` — 971/971 pass (3 new CLI-wiring tests: `--version` output, `config status` routing, stdio does-not-exit-early regression guard, SIGINT-triggers-exit(0)).
- [x] `bun run check` (biome + tsc) — clean.
- [x] `bun run build` + real binary: `node bin/cli.mjs --version` -> `better-notion-mcp 2.37.0`; `-h` -> usage + `subcommands: config, doctor, relay`; `config status` / `doctor` against an isolated HOME -> correct "not configured" / `[warn]` output, store dir `.better-notion-mcp` (matches the multi-user slug).
- [x] Spawned the built binary with an open stdin pipe (real client-connection shape, not a backgrounded shell job whose stdin EOFs immediately) and `NOTION_TOKEN` set: process stays alive past 2s (regression guard), then a simulated `SIGINT` resolves the wait and exits 0.

Note: real OS-level `SIGINT` delivery via `child_process.kill('SIGINT')` isn't reliably testable on Windows (Node/Windows terminates the child directly rather than routing through the JS handler); the shutdown-handler logic itself is covered by a unit test that captures and manually invokes the registered handler. CI runs on `ubuntu-latest` where real signal delivery works as documented.

https://claude.ai/code/session_014BDQppEphd9i2hfu1x35Ns