### PR TITLE
feat: setup_status config action + BYO OAuth client CLI flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ mise run fix                # bun run check:fix
 ## Env vars
 
 - **stdio mode** (default): `NOTION_TOKEN` (bat buoc; stdio fails fast if unset, see `main.ts:76`)
-- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET` (bat buoc, validated `transports/http.ts:51-53`), `PUBLIC_URL` (OAuth redirect URLs), `MCP_AUTH_DISABLE=1` (optional, skip Bearer JWT verification behind external gateway)
+- **http mode** (opt-in via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`): `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET` (bat buoc, validated `transports/http.ts`; BYO OAuth client cung ho tro `--oauth-client-id=<id>` / `--oauth-client-secret=<secret>` CLI flag -- flag override env var, xem `argFlag()` trong `transports/http.ts`), `PUBLIC_URL` (OAuth redirect URLs), `MCP_AUTH_DISABLE=1` (optional, skip Bearer JWT verification behind external gateway)
 - `PORT` (default `0` = OS-assigned random port), `HOST` (optional bind address)
 - Secrets: skret SSM namespace `/better-notion-mcp/prod` (region `ap-southeast-1`)
 
@@ -93,6 +93,8 @@ Two transports, selected in `init-server.ts:14-15` (delegated to `main.ts`). The
 
 - **stdio (default)**: MCP SDK `StdioServerTransport` directly. Single-user; requires `NOTION_TOKEN`. Fails fast with a stderr message if the token is unset (`main.ts:76-91`). No local relay spawn.
 - **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Always delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access token stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. Deploy at `https://notion.n24q02m.com` (Cloudflare Worker + Container; legacy OCI VM at `https://better-notion-mcp.n24q02m.com`).
+
+**CLI `auth`/`logout` subcommand -- N/A by domain (verified 2026-07-17)**: unlike wet/mnemo (`auth google`) or telegram (`auth`/`login`/`logout`), notion has no interactive CLI-triggered credential flow to standardize. stdio mode reads `NOTION_TOKEN` straight from the env (no local relay, no on-disk session to log out of); http mode is always a delegated browser OAuth redirect served at `/authorize` (no CLI-drivable step). Cross-server auth-naming parity (`auth [<provider>]` + `logout`) is therefore not applicable here.
 
 ## Config storage path
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Eight composite Notion tools (39 actions) plus three infrastructure tools (`conf
 | `comments` | `list`, `get`, `create` | Page comments and discussion replies |
 | `content_convert` | `markdown-to-blocks`, `blocks-to-markdown` | Convert between Markdown and Notion blocks (uses a `direction` parameter) |
 | `file_uploads` | `create`, `send`, `complete`, `retrieve`, `list` | Upload files to Notion (single or multi-part) |
-| `config` | `status`, `setup_start`, `setup_reset`, `setup_complete`, `set`, `cache_clear` | Inspect and manage credential state and configuration lifecycle |
+| `config` | `status`, `setup_status`, `setup_start`, `setup_reset`, `setup_complete`, `set`, `cache_clear` | Inspect and manage credential state and configuration lifecycle |
 | `config__open_relay` | - | Open the relay configuration form in the browser and return the relay URL + credential state |
 | `help` | - | Get full documentation for any composite tool (`tool_name` parameter) |
 
@@ -211,8 +211,8 @@ Eight composite Notion tools (39 actions) plus three infrastructure tools (`conf
 | `NOTION_TOKEN` | Yes (stdio) | - | Notion integration token |
 | `TRANSPORT_MODE` / `MCP_TRANSPORT` | No | `stdio` | Set either to `http` for remote mode (or pass `--http`) |
 | `PUBLIC_URL` | No (http) | - | Server's public URL for OAuth redirect links |
-| `NOTION_OAUTH_CLIENT_ID` | Yes (http) | - | Notion Public Integration client ID |
-| `NOTION_OAUTH_CLIENT_SECRET` | Yes (http) | - | Notion Public Integration client secret |
+| `NOTION_OAUTH_CLIENT_ID` | Yes (http) | - | Notion Public Integration client ID (or `--oauth-client-id=<id>` CLI flag, which overrides the env var) |
+| `NOTION_OAUTH_CLIENT_SECRET` | Yes (http) | - | Notion Public Integration client secret (or `--oauth-client-secret=<secret>` CLI flag, which overrides the env var) |
 | `MCP_AUTH_DISABLE` | No (http) | - | Set to `1` to skip Bearer JWT verification when behind an external auth gateway |
 | `PORT` | No | `0` (OS-assigned) | Server port; set explicitly (e.g. `8080`) to bind a fixed port |
 | `HOST` | No | - | Bind address (http mode) |

--- a/src/tools/composite/config.test.ts
+++ b/src/tools/composite/config.test.ts
@@ -85,6 +85,43 @@ describe('config', () => {
     })
   })
 
+  describe('setup_status action', () => {
+    it('should return the same credential fields as status, tagged setup_status', async () => {
+      const result = await config({ action: 'setup_status' })
+
+      expect(result.action).toBe('setup_status')
+      expect(result.state).toBe('awaiting_setup')
+      expect(result.has_token).toBe(false)
+      expect(result.setup_url).toBeNull()
+      expect(result.token_source).toBeNull()
+    })
+
+    it('should reflect configured state with relay token', async () => {
+      vi.mocked(getState).mockReturnValue('configured')
+      vi.mocked(getNotionToken).mockReturnValue('ntn_test123')
+      vi.mocked(getSubjectToken).mockReturnValue('ntn_test123')
+
+      const result = await config({ action: 'setup_status' })
+
+      expect(result.state).toBe('configured')
+      expect(result.has_token).toBe(true)
+      expect(result.token_source).toBe('relay')
+    })
+
+    it('should not include unrelated status fields (identical shape to status minus the action tag)', async () => {
+      vi.mocked(getState).mockReturnValue('configured')
+      vi.mocked(getSubjectToken).mockReturnValue('ntn_oauth_token')
+      process.env.PUBLIC_URL = 'https://better-notion-mcp.example.com'
+
+      const statusResult = await config({ action: 'status' })
+      const setupStatusResult = await config({ action: 'setup_status' })
+
+      const { action: _a, ...statusFields } = statusResult
+      const { action: _b, ...setupStatusFields } = setupStatusResult
+      expect(setupStatusFields).toEqual(statusFields)
+    })
+  })
+
   describe('setup_start action', () => {
     it('should return PUBLIC_URL/authorize when in HTTP mode', async () => {
       process.env.PUBLIC_URL = 'https://better-notion-mcp.example.com'

--- a/src/tools/composite/config.ts
+++ b/src/tools/composite/config.ts
@@ -8,10 +8,29 @@ import { getState, getSubjectToken, resetState, resolveCredentialState } from '.
 import { NotionMCPError, withErrorHandling } from '../helpers/errors.js'
 
 export interface ConfigInput {
-  action: 'status' | 'setup_start' | 'setup_reset' | 'setup_complete' | 'set' | 'cache_clear'
+  action: 'status' | 'setup_status' | 'setup_start' | 'setup_reset' | 'setup_complete' | 'set' | 'cache_clear'
   force?: boolean
   key?: string
   value?: string
+}
+
+/**
+ * Credential/setup-focused fields shared by `status` (kept for backward
+ * compatibility -- it has always returned exactly this shape) and the
+ * dedicated `setup_status` action (parity with the credential-state-only
+ * action every other server in the stack exposes, e.g. wet/mnemo/telegram
+ * `config(action="setup_status")`).
+ */
+function buildSetupStatusInfo() {
+  const state = getState()
+  const token = getSubjectToken()
+  const publicUrl = process.env.PUBLIC_URL ?? null
+  return {
+    state,
+    has_token: token !== null,
+    setup_url: publicUrl ? `${publicUrl}/authorize` : null,
+    token_source: token ? (process.env.NOTION_TOKEN ? 'environment' : publicUrl ? 'oauth' : 'relay') : null
+  }
 }
 
 /**
@@ -21,16 +40,11 @@ export async function config(input: ConfigInput): Promise<any> {
   return withErrorHandling(async () => {
     switch (input.action) {
       case 'status': {
-        const state = getState()
-        const token = getSubjectToken()
-        const publicUrl = process.env.PUBLIC_URL ?? null
-        return {
-          action: 'status',
-          state,
-          has_token: token !== null,
-          setup_url: publicUrl ? `${publicUrl}/authorize` : null,
-          token_source: token ? (process.env.NOTION_TOKEN ? 'environment' : publicUrl ? 'oauth' : 'relay') : null
-        }
+        return { action: 'status', ...buildSetupStatusInfo() }
+      }
+
+      case 'setup_status': {
+        return { action: 'setup_status', ...buildSetupStatusInfo() }
       }
 
       case 'setup_start': {
@@ -100,7 +114,7 @@ export async function config(input: ConfigInput): Promise<any> {
         throw new NotionMCPError(
           `Unsupported action: ${(input as any).action}`,
           'VALIDATION_ERROR',
-          'Valid actions: status, setup_start, setup_reset, setup_complete, set, cache_clear'
+          'Valid actions: status, setup_status, setup_start, setup_reset, setup_complete, set, cache_clear'
         )
     }
   })()

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -409,7 +409,7 @@ const TOOLS = [
   {
     name: 'config',
     description:
-      'Manage server configuration and credential state.\n\nActions:\n- status: current credential state, token source, setup URL\n- setup_start (-> force): trigger relay setup to configure Notion token via browser\n- setup_reset: clear credentials and config, return to awaiting_setup\n- setup_complete: re-check credentials after external config changes\n- set: update a runtime setting (notion has no mutable settings; returns info)\n- cache_clear: clear any cached state (no-op for notion)',
+      'Manage server configuration and credential state.\n\nActions:\n- status: current credential state, token source, setup URL\n- setup_status: credential/setup state only (alias-equivalent to status for notion; kept for cross-server parity)\n- setup_start (-> force): trigger relay setup to configure Notion token via browser\n- setup_reset: clear credentials and config, return to awaiting_setup\n- setup_complete: re-check credentials after external config changes\n- set: update a runtime setting (notion has no mutable settings; returns info)\n- cache_clear: clear any cached state (no-op for notion)',
     annotations: {
       title: 'Config',
       readOnlyHint: false,
@@ -422,7 +422,7 @@ const TOOLS = [
       properties: {
         action: {
           type: 'string',
-          enum: ['status', 'setup_start', 'setup_reset', 'setup_complete', 'set', 'cache_clear'],
+          enum: ['status', 'setup_status', 'setup_start', 'setup_reset', 'setup_complete', 'set', 'cache_clear'],
           description: 'Action to perform'
         },
         force: {

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -109,6 +109,67 @@ describe('startHttp', () => {
     await expect(startHttp()).rejects.toThrow('NOTION_OAUTH_CLIENT_ID and NOTION_OAUTH_CLIENT_SECRET are required')
   })
 
+  describe('BYO OAuth client CLI flags', () => {
+    const originalArgv = process.argv
+
+    afterEach(() => {
+      process.argv = originalArgv
+    })
+
+    it('accepts --oauth-client-id/--oauth-client-secret when env vars are absent', async () => {
+      delete process.env.NOTION_OAUTH_CLIENT_ID
+      delete process.env.NOTION_OAUTH_CLIENT_SECRET
+      process.argv = [...originalArgv, '--http', '--oauth-client-id=flag-id', '--oauth-client-secret=flag-secret']
+
+      vi.mocked(mcpCore.runHttpServer).mockResolvedValue({
+        host: 'localhost',
+        port: 3000,
+        close: vi.fn().mockResolvedValue(undefined)
+      } as any)
+      const handlers: Record<string, (...args: any[]) => any> = {}
+      vi.spyOn(process, 'once').mockImplementation((event, handler) => {
+        handlers[event as string] = handler as (...args: any[]) => any
+        return process
+      })
+
+      const startPromise = startHttp()
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const options = vi.mocked(mcpCore.runHttpServer).mock.calls[0][1] as any
+      expect(options.delegatedOAuth?.upstream?.clientId).toBe('flag-id')
+      expect(options.delegatedOAuth?.upstream?.clientSecret).toBe('flag-secret')
+
+      if (handlers.SIGINT) await handlers.SIGINT()
+      await startPromise
+    })
+
+    it('flag overrides env var when both are present', async () => {
+      // env vars from beforeEach ('id' / 'secret') are already set.
+      process.argv = [...originalArgv, '--http', '--oauth-client-id=flag-id', '--oauth-client-secret=flag-secret']
+
+      vi.mocked(mcpCore.runHttpServer).mockResolvedValue({
+        host: 'localhost',
+        port: 3000,
+        close: vi.fn().mockResolvedValue(undefined)
+      } as any)
+      const handlers: Record<string, (...args: any[]) => any> = {}
+      vi.spyOn(process, 'once').mockImplementation((event, handler) => {
+        handlers[event as string] = handler as (...args: any[]) => any
+        return process
+      })
+
+      const startPromise = startHttp()
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const options = vi.mocked(mcpCore.runHttpServer).mock.calls[0][1] as any
+      expect(options.delegatedOAuth?.upstream?.clientId).toBe('flag-id')
+      expect(options.delegatedOAuth?.upstream?.clientSecret).toBe('flag-secret')
+
+      if (handlers.SIGINT) await handlers.SIGINT()
+      await startPromise
+    })
+  })
+
   it('starts the server and handles shutdown via SIGINT', async () => {
     const closeMock = vi.fn().mockResolvedValue(undefined)
     vi.mocked(mcpCore.runHttpServer).mockResolvedValue({

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -26,6 +26,19 @@ import { NotionMCPError } from '../tools/helpers/errors.js'
 const SERVER_NAME = 'better-notion-mcp'
 
 /**
+ * Parse a `--flag=value` argv entry. Used for the BYO OAuth client CLI flags
+ * below -- notion's `--http` serve path has no interactive subcommand to
+ * attach flags to (unlike wet/mnemo's `auth --client-id`), so the flags ride
+ * on the same leading-dash argv that `--http` itself uses (buildCli passes
+ * it through to `serve` untouched). Returns null if the flag is absent.
+ */
+function argFlag(name: string): string | null {
+  const prefix = `--${name}=`
+  const found = process.argv.find((a) => a.startsWith(prefix))
+  return found ? found.slice(prefix.length) : null
+}
+
+/**
  * Durable KV for the delegated-OAuth handshake state (pending sessions +
  * issued auth codes), so it survives a container cold-start/restart between
  * /authorize and /callback. Keyed under the SAME `better-notion/` namespace
@@ -117,10 +130,15 @@ export async function startHttp(): Promise<void> {
   const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 0
   const host = process.env.HOST
 
-  const clientId = process.env.NOTION_OAUTH_CLIENT_ID
-  const clientSecret = process.env.NOTION_OAUTH_CLIENT_SECRET
+  // BYO OAuth client: CLI flag overrides env var (parity with wet/mnemo's
+  // `auth --client-id`/`--client-secret`; see argFlag doc comment above).
+  const clientId = argFlag('oauth-client-id') || process.env.NOTION_OAUTH_CLIENT_ID
+  const clientSecret = argFlag('oauth-client-secret') || process.env.NOTION_OAUTH_CLIENT_SECRET
   if (!clientId || !clientSecret) {
-    throw new Error('NOTION_OAUTH_CLIENT_ID and NOTION_OAUTH_CLIENT_SECRET are required for http mode.')
+    throw new Error(
+      'NOTION_OAUTH_CLIENT_ID and NOTION_OAUTH_CLIENT_SECRET are required for http mode ' +
+        '(or pass --oauth-client-id=<id> --oauth-client-secret=<secret>).'
+    )
   }
 
   // MCP_AUTH_DISABLE=1 skips Bearer JWT verification — for deployments behind


### PR DESCRIPTION
## Summary

Part of S16 UX/asymmetry hardening (WS6 Task W6.3 + WS5 Task W5.3), verified against `origin/main` in an isolated worktree.

- **W6.3 (setup_status)**: `config(action="status")` conflated credential/setup state with what would be domain status (it currently returns nothing but setup fields for notion, since there's no other domain status). Added a dedicated `setup_status` action returning the same credential fields, for cross-server tool-surface parity with wet/mnemo/telegram's `config(action="setup_status")`. `status` is unchanged (backward-compatible) -- both now share one internal helper (`buildSetupStatusInfo`) to avoid duplicating the read.
- **W5.3 (BYOK)**: `NOTION_OAUTH_CLIENT_ID`/`NOTION_OAUTH_CLIENT_SECRET` were env-var-only. Added `--oauth-client-id=<id>` / `--oauth-client-secret=<secret>` CLI flags on the `--http` serve path (flag overrides env), matching the "env AND CLI flag" contract already shipped for wet/mnemo's `auth --client-id/--client-secret`.
- **W5.2 (auth naming) -- verified N/A for this repo**: notion has no interactive CLI-triggered credential flow to standardize (`auth [<provider>]` + `logout`). stdio mode reads `NOTION_TOKEN` straight from env (no on-disk session), http mode is always a delegated browser OAuth redirect at `/authorize`. No `auth`/`login`/`logout` subcommand exists to rename or alias. Documented the finding in `CLAUDE.md` rather than adding a no-op command.

Registry tool schema (`config` action enum + description) and docs (`README.md`, `CLAUDE.md`) updated to match.

## Test plan

- [x] `bun run type-check` -- clean
- [x] `bun run lint` -- clean (biome)
- [x] `bun run test` -- 976/976 passing (35 files), including new `setup_status` action tests and new BYO-flag override tests in `transports/http.test.ts`
- [x] Existing `status` action tests unchanged/passing (backward compat verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `setup_status` action to the configuration tool for checking credential and setup state.
  * Added command-line options for OAuth client ID and secret configuration.

* **Documentation**
  * Documented `setup_status`, OAuth command-line overrides, and authentication behavior.
  * Clarified that command-line OAuth options take precedence over environment variables.

* **Bug Fixes**
  * Improved HTTP OAuth credential validation when values are supplied through command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->