### PR TITLE
⚡ Bolt: Use pre-allocated arrays in markdown rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2024-07-04 - Multiline String Prefixing Performance in V8/Bun
 **Learning:** Using regex `.replace(/^/gm, 'prefix')` for multiline string operations (like indenting or adding blockquote markers in markdown rendering) incurs measurable overhead due to RegExp state machine execution. In V8/Bun, using template literals combined with native string search via `.replaceAll('\n', '\nprefix')` (e.g., \`prefix${str.replaceAll('\n', '\nprefix')}\`) is significantly faster.
 **Action:** When applying static prefixes to every line of a string on a hot path, prefer string concatenation and `.replaceAll('\n', '\nprefix')` over global regex start-of-line replacements.
+
+## 2024-07-17 - Avoid .map() and intermediate array allocations in Hot Paths
+**Learning:** In heavily used loops or rendering pipelines (e.g., parsing markdown tables and columns), using array methods like `.map()` and `.push()` can cause unnecessary garbage collection overhead and closure allocations. Specifically, large `.map()` chains or dynamic `.push()` calls create many intermediate arrays that penalize V8 performance.
+**Action:** Replace `.map()` and dynamic `.push()` with manual `for` loops over pre-allocated arrays (e.g., `new Array(length)`) to reduce garbage collection pressure and improve CPU efficiency in highly recursive or hot code paths.

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -1178,28 +1178,34 @@ function createEquation(expression: string): NotionBlock {
 
 function createTable(headers: string[], rows: string[][], hasHeader: boolean): NotionBlock {
   const tableWidth = headers.length
-  const allRows: NotionBlock[] = []
+  const allRows: NotionBlock[] = new Array(rows.length + 1)
 
   // Header row
-  allRows.push({
+  const headerCells = new Array(tableWidth)
+  for (let c = 0; c < tableWidth; c++) {
+    headerCells[c] = parseRichText(headers[c])
+  }
+
+  allRows[0] = {
     object: 'block',
     type: 'table_row',
     table_row: {
-      cells: headers.map((h) => parseRichText(h))
+      cells: headerCells
     }
-  })
+  }
 
   // Data rows
-  for (const row of rows) {
-    const cells = []
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r]
+    const cells = new Array(tableWidth)
     for (let c = 0; c < tableWidth; c++) {
-      cells.push(parseRichText(row[c] || ''))
+      cells[c] = parseRichText(row[c] || '')
     }
-    allRows.push({
+    allRows[r + 1] = {
       object: 'block',
       type: 'table_row',
       table_row: { cells }
-    })
+    }
   }
 
   return {
@@ -1215,18 +1221,20 @@ function createTable(headers: string[], rows: string[][], hasHeader: boolean): N
 }
 
 function createColumnList(columns: NotionBlock[][], widthRatios?: (number | undefined)[]): NotionBlock {
-  const columnBlocks = columns.map((children, i) => {
+  const columnBlocks = new Array(columns.length)
+  for (let i = 0; i < columns.length; i++) {
+    const children = columns[i]
     const col: any = { children }
     const ratio = widthRatios?.[i]
     if (ratio !== undefined) {
       col.format = { column_ratio: ratio }
     }
-    return {
+    columnBlocks[i] = {
       object: 'block' as const,
       type: 'column',
       column: col
     }
-  })
+  }
 
   return {
     object: 'block',


### PR DESCRIPTION
Refactors `createTable` and `createColumnList` in `src/tools/helpers/markdown.ts` to replace chained `.map()` and `.push()` operations with manual `for` loops and pre-allocated arrays (`new Array(length)`).

💡 What: Replaced `.map()` and `.push()` in table and column markdown block rendering with manual loops over pre-allocated arrays.
🎯 Why: To avoid intermediate array allocations, closure creation, and garbage collection overhead in hot markdown parsing paths.
📊 Impact: Reduces memory allocations and GC pressure when processing large markdown files containing tables and columns.
🔬 Measurement: Verified with `bun run test` (all 976 tests pass) and `bun run check:fix` for formatting.

---
*PR created automatically by Jules for task [17383407141008793241](https://jules.google.com/task/17383407141008793241) started by @n24q02m*