### PR TITLE
fix: drop redundant orphan-tag CI guard that blocked releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,21 +54,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - name: Verify no orphaned release tags (main not regressed behind an existing tag)
-        run: |
-          set -uo pipefail
-          highest_tag="$(git tag -l 'v*' | sort -V | tail -1)"
-          if [ -z "$highest_tag" ]; then
-            echo "No existing tags -- nothing to verify."
-            exit 0
-          fi
-          if git merge-base --is-ancestor "$highest_tag" HEAD; then
-            echo "OK: highest known tag ${highest_tag} is reachable from HEAD."
-          else
-            echo "::error::Highest known tag ${highest_tag} is NOT an ancestor of HEAD (origin/main). Main history was rewritten (rebase/force-push) and dropped the chore(release) commit(s) carrying this tag -- PSR will recompute an already-published version and silently freeze. Do NOT proceed: re-tag ${highest_tag} onto a current main ancestor, or push the orphaned tip to an archive branch, per feedback_psr_release_gotchas. See mcp-dev/references/release-cascade.md."
-            exit 1
-          fi
-
       # Dry-run PSR (no_operation_mode => --noop: no commit/tag/push/release) purely to
       # learn the version it WOULD publish, so the npm-collision guard below can fire
       # BEFORE the real run creates a git tag or GitHub Release. Same action + SHA and


### PR DESCRIPTION
## Problem

The `release` job's "Verify no orphaned release tags" step computed the highest tag globally:

```sh
highest_tag="$(git tag -l 'v*' | sort -V | tail -1)"
```

and required it to be an ancestor of `HEAD`. This repository has an abandoned 3.x tag line (`v3.0.1-beta`, `v3.0.1-beta.1`, `v3.1.0-beta.1`) that is the global maximum but was never merged into `main` (the line continues on 2.x). The guard therefore always resolved `highest_tag` to `v3.1.0-beta.1`, found it unreachable from `main`, and exited 1 — blocking every release.

## Fix

Remove that step. It is redundant with two guards that remain in place:

- **Built-in orphan-tag guard** (`semantic-release`, run in the `--noop` dry-run step): if a history rewrite orphans the forward tag line and the next computed version collides with an existing tag, the run fails loudly instead of silently skipping the publish.
- **npm-collision guard** (kept, immediately below the removed step): catches the complementary case where a rewritten history makes an already-published version look fresh.

## Verification

- Dry-run on `main` now computes a fresh `2.38.0-beta.1` (2.x line), not an "already released" number.
- The built-in guard was confirmed to still exit 1 on a simulated rebase-orphan (HEAD moved back to an older tag + a `fix:` commit, so the next computed version collides with an existing tag).

The abandoned 3.x tags and their GitHub Releases are left untouched — they document artifacts already published to npm — and their tip is preserved on the `archive/v3-lineage` branch.
