### PR TITLE
⚡ Bolt: Optimize markdown table parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2024-07-17 - Avoid .map() and intermediate array allocations in Hot Paths
 **Learning:** In heavily used loops or rendering pipelines (e.g., parsing markdown tables and columns), using array methods like `.map()` and `.push()` can cause unnecessary garbage collection overhead and closure allocations. Specifically, large `.map()` chains or dynamic `.push()` calls create many intermediate arrays that penalize V8 performance.
 **Action:** Replace `.map()` and dynamic `.push()` with manual `for` loops over pre-allocated arrays (e.g., `new Array(length)`) to reduce garbage collection pressure and improve CPU efficiency in highly recursive or hot code paths.
+## 2026-07-20 - Avoid Redundant String Scans
+**Learning:** Checking `.includes(char)` on a string when `.startsWith(char)` is already being verified is entirely redundant and forces V8 to scan the entire string. Additionally, replacing `.trim().startsWith()` with `.trimStart().startsWith()` avoids parsing whitespaces at the end of long strings in hot loops.
+**Action:** Remove redundant `.includes()` checks when string prefixes are already matched, and use targeted trimming like `.trimStart()` when only the leading characters matter.

--- a/src/tools/helpers/markdown.ts
+++ b/src/tools/helpers/markdown.ts
@@ -191,7 +191,7 @@ class MarkdownParser {
     }
 
     // Table (pipe-delimited)
-    if (line.includes('|') && trimmedLine.startsWith('|')) {
+    if (trimmedLine.startsWith('|')) {
       const tableData = parseTable(this.lines, i)
       if (tableData) {
         this.blocks.push(createTable(tableData.headers, tableData.rows, tableData.hasHeader))
@@ -765,8 +765,10 @@ function parseTable(lines: string[], startIndex: number): TableParseResult | nul
   let i = startIndex
 
   // Collect all consecutive pipe-delimited lines
-  while (i < lines.length && lines[i].trim().startsWith('|') && lines[i].includes('|')) {
-    tableLines.push(lines[i])
+  while (i < lines.length) {
+    const line = lines[i]
+    if (!line.trimStart().startsWith('|')) break
+    tableLines.push(line)
     i++
   }
 


### PR DESCRIPTION
💡 **What:** Optimized `processLine` and `parseTable` in `src/tools/helpers/markdown.ts` by removing a redundant `.includes('|')` check where `.startsWith('|')` is already matched, and refactored the `while` loop to cache the array access and use `.trimStart()` instead of `.trim()`.

🎯 **Why:** In hot paths like parsing markdown tables, checking `.includes()` across large strings is an O(N) operation that causes unnecessary CPU overhead. Furthermore, `.trim()` unnecessarily trims the trailing edge of a string when we only care about the prefix. Using `.trimStart()` and caching string variables reduces redundant allocations and parsing overhead.

📊 **Impact:** Reduces redundant V8 string scans for every single line of a parsed markdown table, speeding up rendering pipelines for heavily tabulated documents.

🔬 **Measurement:** Parsing of markdown tables in benchmark profiles will show reduced CPU time spent in string scanning and garbage collection. Test suites pass with no regressions.

---
*PR created automatically by Jules for task [9205345010302260322](https://jules.google.com/task/9205345010302260322) started by @n24q02m*