### PR TITLE
fix: drop rangeStrategy from update-type package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,8 +33,7 @@
       "groupSlug": "non-major-dev",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days",
-      "rangeStrategy": "pin"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Auto-merge patch updates after cooldown",
@@ -43,8 +42,7 @@
       "groupSlug": "all-patch",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days",
-      "rangeStrategy": "pin"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Auto-merge GitHub Actions digest updates after cooldown",


### PR DESCRIPTION
## Problem

Renovate rejects any `packageRules` entry that combines `matchUpdateTypes` with `rangeStrategy: "pin"` — the range strategy is resolved before the update type is known, so it cannot be applied conditionally on it (renovatebot/renovate#10165). This repo's config had exactly this combination on 2 rules, which silently stopped every dependency-update PR since 2026-07-17.

## Fix

Drop the invalid `rangeStrategy: "pin"` from the two `matchUpdateTypes`-scoped rules (dev-scope minor auto-merge, patch auto-merge). Top-level `"rangeStrategy": "bump"` is preserved — this repo is publish/library-style and should keep bumping ranges rather than pinning them.

## Verification

```python
d = json.load(open('renovate.json'))
bad = [i for i, x in enumerate(d['packageRules']) if 'matchUpdateTypes' in x and x.get('rangeStrategy') == 'pin']
assert bad == []
assert d['rangeStrategy'] == 'bump'
```

Closes #1133