### PR TITLE
feat: govern duplicate bot pull requests

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -1,0 +1,115 @@
+name: Bot PR Governance
+
+on:
+  pull_request:
+    types:
+      - opened
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional PR number to audit; omit for an inventory-only run
+        required: false
+        type: string
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: bot-governance-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  governance:
+    name: Bot PR Rate Limit & Exact Duplicate Check
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      ACTOR: ${{ github.actor }}
+    steps:
+      - name: Audit or govern bot PR
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          is_bot_branch() {
+            case "$1" in
+              bolt/*|bolt-*|palette/*|palette-*|sentinel/*|sentinel-*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "Inventory-only run: listing open bot PRs."
+            gh pr list --repo "$REPO" --state open --limit 1000 \
+              --json number,title,headRefName,author \
+              --jq '[.[] | select(.headRefName | test("^(bolt[-/]|palette[-/]|sentinel[-/])"))]'
+            exit 0
+          fi
+
+          if ! is_bot_branch "$BRANCH"; then
+            echo "Not a governed bot branch: $BRANCH"
+            exit 0
+          fi
+
+          echo "Governed bot PR #$PR_NUMBER on $BRANCH"
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "bot-generated" || true
+
+          since=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          bot_count=$(gh pr list --repo "$REPO" --state open --limit 1000 \
+            --json createdAt,headRefName,author |
+            jq --arg actor "$ACTOR" --arg since "$since" \
+              '[.[] | select(.author.login == $actor) | select(.createdAt > $since) | select(.headRefName | test("^(bolt[-/]|palette[-/]|sentinel[-/])"))] | length')
+
+          echo "Open governed PRs by $ACTOR in the last 24 hours: $bot_count"
+          if (( bot_count > 5 )); then
+            gh pr close "$PR_NUMBER" --repo "$REPO" \
+              --comment "**Bot rate limit exceeded**: $bot_count governed PRs from this actor were open in the last 24 hours (limit: 5). Consolidate related proposals before reopening."
+            exit 0
+          fi
+
+          current_diff=$(mktemp)
+          trap 'rm -f "$current_diff"' EXIT
+          if ! gh pr diff "$PR_NUMBER" --repo "$REPO" --patch > "$current_diff"; then
+            echo "Could not read the current patch; leaving the PR open for human review."
+            exit 0
+          fi
+
+          normalized_current=$(mktemp)
+          trap 'rm -f "$current_diff" "$normalized_current"' EXIT
+          sed -n '/^diff --git /,$p' "$current_diff" > "$normalized_current"
+          if [[ ! -s "$normalized_current" ]]; then
+            echo "The PR has no comparable text patch; leaving it open."
+            exit 0
+          fi
+          current_hash=$(sha256sum "$normalized_current" | awk '{print $1}')
+
+          while IFS=$'\t' read -r candidate branch; do
+            [[ "$candidate" == "$PR_NUMBER" ]] && continue
+            is_bot_branch "$branch" || continue
+
+            candidate_diff=$(mktemp)
+            candidate_normalized=$(mktemp)
+            if gh pr diff "$candidate" --repo "$REPO" --patch > "$candidate_diff" 2>/dev/null; then
+              sed -n '/^diff --git /,$p' "$candidate_diff" > "$candidate_normalized"
+              if [[ -s "$candidate_normalized" ]] && [[ "$current_hash" == "$(sha256sum "$candidate_normalized" | awk '{print $1}')" ]]; then
+                gh pr close "$PR_NUMBER" --repo "$REPO" \
+                  --comment "**Exact duplicate**: this PR has the same normalized patch as open bot PR #$candidate. Keep the older proposal for review instead of running duplicate CI."
+                rm -f "$candidate_diff" "$candidate_normalized"
+                exit 0
+              fi
+            fi
+            rm -f "$candidate_diff" "$candidate_normalized"
+          done < <(
+            gh pr list --repo "$REPO" --state open --limit 1000 \
+              --json number,headRefName \
+              --jq '.[] | [.number, .headRefName] | @tsv'
+          )
+
+          echo "No exact duplicate found; leaving the governed PR open for normal review."


### PR DESCRIPTION
## Summary\n- add internal bot PR governance for Bolt, Palette, and Sentinel branch families\n- enforce a 5-open-PRs-per-actor/24h rate limit\n- close only exact normalized patch duplicates; leave different proposals for human review\n- add workflow_dispatch inventory mode for safe verification when no bot PR is open\n\n## Verification\n- actionlint .github/workflows/bot-governance.yml\n- git diff --check\n- full repository pre-commit hooks passed\n\nThis intentionally does not govern fork PRs or Renovate dependency PRs.