### PR TITLE
fix: align live Cloudflare validation

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -29,12 +29,29 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-      PR_TITLE: ${{ github.event.pull_request.title }}
-      BRANCH: ${{ github.event.pull_request.head.ref }}
-      ACTOR: ${{ github.actor }}
     steps:
+      - name: Resolve target pull request
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${PR_NUMBER}" ]]; then
+            printf 'branch=\nactor=\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          read -r branch actor < <(
+            gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json headRefName,author \
+              --jq '[.headRefName, .author.login] | @tsv'
+          )
+          printf 'branch=%s\nactor=%s\n' "$branch" "$actor" >> "$GITHUB_OUTPUT"
+
       - name: Audit or govern bot PR
         shell: bash
+        env:
+          BRANCH: ${{ steps.target.outputs.branch }}
+          ACTOR: ${{ steps.target.outputs.actor }}
         run: |
           set -euo pipefail
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,10 @@ mise run fix                # bun run check:fix
 ## Release & Deploy
 
 - Conventional Commits. Tag format: `v{version}` (config: `semantic-release.toml`)
-- CD: workflow_dispatch, chon beta/stable
-- Pipeline: PSR v10 -> npm publish (`@n24q02m/better-notion-mcp`) -> Docker multi-arch (amd64 + arm64) -> DockerHub + GHCR -> MCP Registry
+- CD: workflow_dispatch, chọn beta/stable; versioning qua `n24q02m/better-semantic-release` và publish-action
+- Pipeline: semantic release -> npm publish (`@n24q02m/better-notion-mcp`) -> Docker multi-arch (amd64 + arm64) -> DockerHub + GHCR -> MCP Registry
 - OCI VM deploy: Docker Compose + Watchtower. Prod `:latest` 0.125G, Staging `:beta` 0.0625G
-- Cloudflare deploy (canonical, manual via wrangler): `notion.n24q02m.com` (Worker + Container + KV). Legacy OCI VM: `better-notion-mcp.n24q02m.com` (prod) / `better-notion-mcp-staging.n24q02m.com` (staging) — fallback until decommission.
+- Cloudflare deploy canonical: CD job `deploy-cf` checks out the released tag, runs `scripts/deploy_cf.py`, waits for rollout, and runs Gate A/B/JWKS canary. Do not deploy the n24q02m instance manually from a laptop. Public host: `https://notion.n24q02m.com` (Worker + Container + KV); the legacy OCI host is not canonical.
 
 ## Pre-commit hooks
 
@@ -92,7 +92,7 @@ mise run fix                # bun run check:fix
 Two transports, selected in `init-server.ts:14-15` (delegated to `main.ts`). There is no `MCP_MODE` env var; the old `local-relay` / `remote-oauth` distinction was removed (see `transports/http.ts:4-9`).
 
 - **stdio (default)**: MCP SDK `StdioServerTransport` directly. Single-user; requires `NOTION_TOKEN`. Fails fast with a stderr message if the token is unset (`main.ts:76-91`). No local relay spawn.
-- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Always delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access token stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. Deploy at `https://notion.n24q02m.com` (Cloudflare Worker + Container; legacy OCI VM at `https://better-notion-mcp.n24q02m.com`).
+- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Always delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access token stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. The n24q02m deployment is `https://notion.n24q02m.com` through the Cloudflare CD job.
 
 **CLI `auth`/`logout` subcommand -- N/A by domain (verified 2026-07-17)**: unlike wet/mnemo (`auth google`) or telegram (`auth`/`login`/`logout`), notion has no interactive CLI-triggered credential flow to standardize. stdio mode reads `NOTION_TOKEN` straight from the env (no local relay, no on-disk session to log out of); http mode is always a delegated browser OAuth redirect served at `/authorize` (no CLI-drivable step). Cross-server auth-naming parity (`auth [<provider>]` + `logout`) is therefore not applicable here.
 

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -179,33 +179,38 @@ def _run_session(
     import anyio
 
     async def _go() -> None:
+        import httpx2
         from mcp import ClientSession
-        from mcp.client.streamable_http import streamablehttp_client
+        from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
 
-        async with (
-            streamablehttp_client(
-                f"{endpoint}/mcp", headers={"Authorization": f"Bearer {jwt}"}
-            ) as (r, w, _),
-            ClientSession(r, w) as s,
-        ):
-            await s.initialize()
-            tools = await s.list_tools()
-            print("TOOLS:", [t.name for t in tools.tools])
-            st = await s.call_tool("config", {"action": "status"})
-            st_txt = "".join(getattr(b, "text", "") for b in st.content)
-            print("CONFIG_STATUS:", st_txt[:300].replace("\n", " "))
-            if expect_has_token:
-                assert '"has_token": true' in st_txt or '"has_token":true' in st_txt, (
-                    f"has_token is NOT true -- token did not survive / not saved: {st_txt[:300]}"
-                )
-                print("ASSERT OK: has_token=true.")
-            if probe_me:
-                me = await s.call_tool("users", {"action": "me"})
-                me_txt = "".join(getattr(b, "text", "") for b in me.content)
-                print("USERS_ME:", me_txt[:300].replace("\n", " "))
-                assert "error" not in me_txt.lower() or "bot" in me_txt.lower(), (
-                    f"users(me) failed -- Notion token not usable: {me_txt[:300]}"
-                )
+        class BearerAuth(httpx2.Auth):
+            def auth_flow(self, request: httpx2.Request):
+                request.headers["Authorization"] = f"Bearer {jwt}"
+                yield request
+
+        async with create_mcp_http_client(auth=BearerAuth()) as http_client:
+            async with streamable_http_client(
+                f"{endpoint}/mcp", http_client=http_client
+            ) as (r, w):
+                async with ClientSession(r, w) as s:
+                    await s.initialize()
+                    tools = await s.list_tools()
+                    print("TOOLS:", [t.name for t in tools.tools])
+                    st = await s.call_tool("config", {"action": "status"})
+                    st_txt = "".join(getattr(b, "text", "") for b in st.content)
+                    print("CONFIG_STATUS:", st_txt[:300].replace("\n", " "))
+                    if expect_has_token:
+                        assert '"has_token": true' in st_txt or '"has_token":true' in st_txt, (
+                            f"has_token is NOT true -- token did not survive / not saved: {st_txt[:300]}"
+                        )
+                        print("ASSERT OK: has_token=true.")
+                    if probe_me:
+                        me = await s.call_tool("users", {"action": "me"})
+                        me_txt = "".join(getattr(b, "text", "") for b in me.content)
+                        print("USERS_ME:", me_txt[:300].replace("\n", " "))
+                        assert "error" not in me_txt.lower() or "bot" in me_txt.lower(), (
+                            f"users(me) failed -- Notion token not usable: {me_txt[:300]}"
+                        )
 
     anyio.run(_go)
 

--- a/tests/test-oauth-mcp.mjs
+++ b/tests/test-oauth-mcp.mjs
@@ -20,7 +20,7 @@ import { execFile } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
 import { createServer } from 'node:http'
 
-const MCP_URL = process.env.MCP_URL || 'https://better-notion-mcp.n24q02m.com'
+const MCP_URL = process.env.MCP_URL || 'https://notion.n24q02m.com'
 const CALLBACK_PORT = 9876
 const CALLBACK_URI = `http://127.0.0.1:${CALLBACK_PORT}/callback`
 


### PR DESCRIPTION
## Summary
- update the live OAuth full-flow harness for MCP SDK v2 streamable HTTP
- point OAuth smoke-test defaults and deployment docs at the canonical Cloudflare host
- make manually dispatched bot governance resolve the target PR branch and author

## Verification
- bun run check
- bun x vitest run src/init-server.test.ts
- bun run test (984/984)
- actionlint
- node --check tests/test-oauth-mcp.mjs
- git diff --check

## Live validation
- unauthenticated CF health/OAuth/JWKS probes pass
- existing local JWT is expired; fresh Notion consent is required before exchange/recreate verification