### PR TITLE
fix: update Cloudflare worker types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.7",
-        "@cloudflare/workers-types": "^5.20260718.1",
+        "@cloudflare/workers-types": "^5.20260804.1",
         "@types/node": "^26.1.2",
         "@vitest/coverage-v8": "^4.1.10",
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",
-    "@cloudflare/workers-types": "^5.20260718.1",
+    "@cloudflare/workers-types": "^5.20260804.1",
     "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "^4.1.10",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
## Summary
- update @cloudflare/workers-types from ^5.20260718.1 to ^5.20260804.1
- carry the exact dependency change from Renovate PR #1204 after its branch conflicted with merged PR #1203

## Verification
- bun install --frozen-lockfile
- CI=true bun run check
- CI=true bun run test (35 files, 984 tests)
- pre-commit hooks pass

Supersedes #1204.