### PR TITLE
fix: reject Unicode URL obfuscation characters

### DIFF
--- a/src/tools/helpers/security.test.ts
+++ b/src/tools/helpers/security.test.ts
@@ -67,6 +67,12 @@ describe('Security Utilities', () => {
       // Byte Order Mark
       expect(isSafeUrl('java\uFEFFscript:alert(1)')).toBe(false)
     })
+    it('should reject invisible operators and Unicode noncharacters in both URL validators', () => {
+      for (const char of ['\u2060', '\u206F', '\uFFFE', '\uFFFF']) {
+        expect(isSafeUrl(`java${char}script:alert(1)`)).toBe(false)
+        expect(isSafeWebUrl(`https://example.com/${char}path`)).toBe(false)
+      }
+    })
 
     it('should allow valid relative or absolute URLs that fail parsing but are not dangerous', () => {
       // These fail new URL() parsing but don't match the dangerous protocol checks

--- a/src/tools/helpers/security.ts
+++ b/src/tools/helpers/security.ts
@@ -27,7 +27,7 @@ const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:'])
 const SAFE_WEB_PROTOCOLS = new Set(['http:', 'https:'])
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for security sanitization
-const CONTROL_CHARS_REGEX = /[\s\x00-\x1F\x7F-\x9F\xAD\u200B-\u200F\u202A-\u202E\uFEFF]/
+const CONTROL_CHARS_REGEX = /[\s\x00-\x1F\x7F-\x9F\xAD\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF\uFFFE-\uFFFF]/
 
 // Name of the envelope tag that marks untrusted content, and the token it is
 // rewritten to when it appears inside a payload. See wrapToolResult.


### PR DESCRIPTION
## Summary
- reject invisible operators U+2060–U+206F and Unicode noncharacters U+FFFE–U+FFFF in the shared URL guard
- cover both `isSafeUrl` and stricter `isSafeWebUrl` behavior
- keep the change limited to source/tests; no `.jules` ledger mutation

## Verification
- targeted Vitest: 38 passed
- full Vitest with explicit non-secret CI OAuth placeholders: 985 passed
- Biome check passed

This clean replacement supersedes security PRs #1207 and #1227.