### PR TITLE
fix: propagate Notion pagination limits

### DIFF
--- a/src/tools/composite/databases.test.ts
+++ b/src/tools/composite/databases.test.ts
@@ -392,6 +392,7 @@ describe('databases', () => {
 
       expect(result.total).toBe(2)
       expect(result.results).toHaveLength(2)
+      expect(mockNotion.dataSources.query).toHaveBeenCalledWith(expect.objectContaining({ page_size: 2 }))
     })
 
     it('should format various property types in results', async () => {

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -486,23 +486,25 @@ async function queryDatabase(notion: Client, input: DatabasesInput): Promise<Que
   if (input.sorts) queryParams.sorts = input.sorts
 
   // Fetch with pagination
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).dataSources.query({
-      ...queryParams,
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  // Limit results if specified
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  const allResults = await autoPaginate(
+    async (cursor, pageSize) => {
+      const response: any = await (notion as any).dataSources.query({
+        ...queryParams,
+        start_cursor: cursor,
+        page_size: pageSize
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   // Format results
+  const results = allResults
+
   const formattedResults = formatDatabaseResults(results)
 
   return {

--- a/src/tools/composite/file-uploads.test.ts
+++ b/src/tools/composite/file-uploads.test.ts
@@ -314,6 +314,10 @@ describe('fileUploads', () => {
       expect(result.file_uploads).toHaveLength(2)
       expect(result.file_uploads[0].file_upload_id).toBe('f1')
       expect(result.file_uploads[1].file_upload_id).toBe('f2')
+      expect(mockNotion.fileUploads.list).toHaveBeenCalledWith({
+        start_cursor: undefined,
+        page_size: 2
+      })
     })
   })
 

--- a/src/tools/composite/file-uploads.ts
+++ b/src/tools/composite/file-uploads.ts
@@ -235,19 +235,22 @@ async function retrieveFileUpload(notion: Client, input: FileUploadsInput): Prom
  * Maps to: GET /v1/file_uploads
  */
 async function listFileUploads(notion: Client, input: FileUploadsInput): Promise<any> {
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).fileUploads.list({
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
+  const allResults = await autoPaginate(
+    async (cursor, pageSize) => {
+      const response: any = await (notion as any).fileUploads.list({
+        start_cursor: cursor,
+        page_size: pageSize
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  const results = allResults
 
   return {
     action: 'list',

--- a/src/tools/helpers/pagination.test.ts
+++ b/src/tools/helpers/pagination.test.ts
@@ -94,6 +94,27 @@ describe('autoPaginate', () => {
 
     expect(fetchFn).toHaveBeenCalledWith(undefined, 50)
   })
+  it('uses the remaining limit for page size and stops without an extra request', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: [1, 2],
+        next_cursor: 'cursor-1',
+        has_more: true
+      })
+      .mockResolvedValueOnce({
+        results: [3, 4],
+        next_cursor: 'cursor-2',
+        has_more: true
+      })
+
+    const results = await autoPaginate(fetchFn, { limit: 3 })
+
+    expect(results).toEqual([1, 2, 3])
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(fetchFn).toHaveBeenNthCalledWith(1, undefined, 3)
+    expect(fetchFn).toHaveBeenNthCalledWith(2, 'cursor-1', 1)
+  })
 })
 
 describe('fetchChildrenRecursive', () => {


### PR DESCRIPTION
## Summary
- pass `pageSize` and `limit` through database and file-upload pagination callers
- let the helper request only the remaining items and stop without an extra API call
- preserve default page size and add helper/caller request-shape regression tests

## Verification
- pagination/database/file-upload tests: 104 passed
- full Vitest with explicit non-secret CI OAuth placeholders: 985 passed
- Biome check passed

This clean source/test replacement supersedes Bolt PRs #1208, #1212, #1214, #1217, #1219, #1222, #1224, and #1226.