### PR TITLE
fix: ⚡ Bolt: Optimize autoPaginate allocation and early exit

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@ Proposals that were reviewed and declined. A closing comment lives on the PR, wh
 - **Dropping the redundant `.includes('|')` and using `.trimStart()` in `markdown.ts` table parsing** (PRs #1142, #1143, #1144 — one cluster, three PRs). The redundancy is real and the rewrite is behaviour-preserving, but `parseTable` runs once per table during page conversion and the removed check scans a single line. Unmeasured, so closed. `#1142` is the cleanest diff if this is ever revisited.
 - **Writing `// ⚡ Bolt: ...` narration into source files** (PR #1143, `markdown.ts:193`). This is a public repository; attribution markers of that form do not belong in shipped code. Keep the rationale in this ledger and in the commit message.
 - **Deleting existing entries from this file** (PR #1143 removed 22 lines). This ledger is append-only memory. Removing entries is how settled proposals return.
+
+## 2026-08-23 - In-place Array Truncation and Early Pagination Exit
+**Learning:** In V8/Bun environments, using `.slice(0, limit)` to truncate large arrays (like paginated API results) creates unnecessary garbage collection overhead due to intermediate array allocations. Furthermore, slicing after fetching all results causes excessive network I/O.
+**Action:** Use in-place array truncation (`arr.length = limit`) instead of `.slice()`. When paginating API requests, use `autoPaginate`'s built-in `limit` option to exit the pagination loop early and pass the dynamically calculated `pageSize` directly to the API network call to avoid fetching excess data.

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -485,25 +485,27 @@ async function queryDatabase(notion: Client, input: DatabasesInput): Promise<Que
   if (filter) queryParams.filter = filter
   if (input.sorts) queryParams.sorts = input.sorts
 
-  // Fetch with pagination
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).dataSources.query({
-      ...queryParams,
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  // Limit results if specified
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  // Pass the pageSize provided by autoPaginate directly to the .query API call
+  // and pass { limit: input.limit } to autoPaginate to stop API network calls early.
+  // This significantly reduces network I/O and prevents post-fetch array slicing overhead.
+  const allResults = await autoPaginate(
+    async (cursor, pageSize) => {
+      const response: any = await (notion as any).dataSources.query({
+        ...queryParams,
+        start_cursor: cursor,
+        page_size: pageSize
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   // Format results
-  const formattedResults = formatDatabaseResults(results)
+  const formattedResults = formatDatabaseResults(allResults)
 
   return {
     action: 'query',

--- a/src/tools/composite/file-uploads.ts
+++ b/src/tools/composite/file-uploads.ts
@@ -235,24 +235,28 @@ async function retrieveFileUpload(notion: Client, input: FileUploadsInput): Prom
  * Maps to: GET /v1/file_uploads
  */
 async function listFileUploads(notion: Client, input: FileUploadsInput): Promise<any> {
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).fileUploads.list({
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  // Pass the pageSize provided by autoPaginate directly to the .list API call
+  // and pass { limit: input.limit } to autoPaginate to stop API network calls early.
+  // This significantly reduces network I/O and prevents post-fetch array slicing overhead.
+  const allResults = await autoPaginate(
+    async (cursor, pageSize) => {
+      const response: any = await (notion as any).fileUploads.list({
+        start_cursor: cursor,
+        page_size: pageSize
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   return {
     action: 'list',
-    total: results.length,
-    file_uploads: results.map((f: any) => ({
+    total: allResults.length,
+    file_uploads: allResults.map((f: any) => ({
       file_upload_id: f.id,
       filename: f.filename,
       content_type: f.content_type,

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -45,7 +45,7 @@ export async function autoPaginate<T>(
     }
 
     const response = await fetchFn(cursor || undefined, currentPageSize)
-    // BOLT OPTIMIZATION: Use manual push loop instead of spread operator to avoid
+    // Use manual push loop instead of spread operator to avoid
     // Maximum Call Stack Size Exceeded errors on very large page arrays and improve performance
     // on large datasets by avoiding intermediate array allocations from spread
     const results = response.results
@@ -67,7 +67,13 @@ export async function autoPaginate<T>(
     }
   } while (cursor !== null)
 
-  return limit > 0 ? allResults.slice(0, limit) : allResults
+  // Use in-place array truncation to avoid GC overhead
+  // from intermediate array allocations caused by .slice()
+  if (limit > 0 && allResults.length > limit) {
+    allResults.length = limit
+  }
+
+  return allResults
 }
 
 /** Block types that need children fetched for proper markdown rendering */


### PR DESCRIPTION
💡 What: Optimized pagination array handling by introducing in-place truncation and exposed `limit` + `pageSize` directly to the `autoPaginate` network callback in `databases.ts` and `file-uploads.ts`.
🎯 Why: Creating intermediate arrays using `.slice()` on extremely large payloads causes GC pauses. Fetching data beyond the requested `limit` solely to `.slice()` it afterward is inefficient and causes unnecessary Network I/O.
📊 Impact: Considerably reduces API calls for endpoints configured with strict limits, directly avoiding Network I/O costs, and alleviates GC pressure.
🔬 Measurement: Verify by executing pagination endpoints using a `limit` smaller than the dataset.

---
*PR created automatically by Jules for task [2120475213987473944](https://jules.google.com/task/2120475213987473944) started by @n24q02m*