### PR TITLE
feat: dehost managed Cloudflare runtime

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -392,7 +392,7 @@ jobs:
     # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
     # rollback is a tracked follow-up.
     needs: [release]
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && vars.CF_HOSTED_ENABLED != 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ mise run fix                # bun run check:fix
 - CD: workflow_dispatch, chọn beta/stable; versioning qua `n24q02m/better-semantic-release` và publish-action
 - Pipeline: semantic release -> npm publish (`@n24q02m/better-notion-mcp`) -> Docker multi-arch (amd64 + arm64) -> DockerHub + GHCR -> MCP Registry
 - OCI VM deploy: Docker Compose + Watchtower. Prod `:latest` 0.125G, Staging `:beta` 0.0625G
-- Cloudflare deploy canonical: CD job `deploy-cf` checks out the released tag, runs `scripts/deploy_cf.py`, waits for rollout, and runs Gate A/B/JWKS canary. Do not deploy the n24q02m instance manually from a laptop. Public host: `https://notion.n24q02m.com` (Worker + Container + KV); the legacy OCI host is not canonical.
+- The n24q02m Cloudflare Worker/Container host is dehosted. `deploy-cf` is guarded by the repository variable `CF_HOSTED_ENABLED=false`; package, OCI, local stdio and self-host maintenance continue. Do not manually recreate the personal host.
 
 ## Pre-commit hooks
 
@@ -92,7 +92,7 @@ mise run fix                # bun run check:fix
 Two transports, selected in `init-server.ts:14-15` (delegated to `main.ts`). There is no `MCP_MODE` env var; the old `local-relay` / `remote-oauth` distinction was removed (see `transports/http.ts:4-9`).
 
 - **stdio (default)**: MCP SDK `StdioServerTransport` directly. Single-user; requires `NOTION_TOKEN`. Fails fast with a stderr message if the token is unset (`main.ts:76-91`). No local relay spawn.
-- **http (opt-in)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Always delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access token stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. The n24q02m deployment is `https://notion.n24q02m.com` through the Cloudflare CD job.
+- **http (opt-in, self-hosted)**: enabled via `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. Uses delegated OAuth 2.1 redirect flow to Notion at `https://api.notion.com/v1/oauth/authorize`. Requires `NOTION_OAUTH_CLIENT_ID` + `NOTION_OAUTH_CLIENT_SECRET`. Per-user access tokens are stored in-process keyed by JWT `sub` (`auth/notion-token-store.ts`, in-memory `Map`). Multi-user. The project no longer operates a public n24q02m HTTP deployment.
 
 **CLI `auth`/`logout` subcommand -- N/A by domain (verified 2026-07-17)**: unlike wet/mnemo (`auth google`) or telegram (`auth`/`login`/`logout`), notion has no interactive CLI-triggered credential flow to standardize. stdio mode reads `NOTION_TOKEN` straight from the env (no local relay, no on-disk session to log out of); http mode is always a delegated browser OAuth redirect served at `/authorize` (no CLI-drivable step). Cross-server auth-naming parity (`auth [<provider>]` + `logout`) is therefore not applicable here.
 
@@ -110,7 +110,7 @@ cd ../mcp-core && uv run --project scripts/e2e python -m e2e.driver <config-id>
 
 Configs for this repo: `notion-paste-token`.
 
-Note: ``notion-oauth`` reclassified out of T2 matrix 2026-04-27 — verify post-deploy via manual smoke against ``notion.n24q02m.com`` (Cloudflare) only.
+Note: `notion-oauth` remains outside the removed T2 matrix. Validate HTTP mode against an operator-owned self-hosted deployment; there is no n24q02m hosted endpoint.
 
 Tier policy:
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,19 +1,19 @@
 # Privacy Policy — Better Notion MCP
 
-**Last updated:** 2026-06-16
+**Last updated:** 2026-08-24
 
 ## Data Collection
 
 Better Notion MCP acts as a proxy between MCP clients (Claude, Cursor, etc.) and the Notion API. It does **not** collect, store, or transmit any user data beyond what is necessary for the current request.
 
-## OAuth Mode (Remote Server)
+## HTTP Mode (Self-Hosted)
 
-When using the remote server at `notion.n24q02m.com`:
+The project does not operate a public hosted Notion MCP service. If you run HTTP mode on infrastructure you control:
 
-- **Authentication**: Uses Notion OAuth 2.0.
-- **Token storage**: Your Notion access token is encrypted (AES-GCM) and stored in Cloudflare KV, scoped to your authenticated session (keyed by your OAuth identity) so that no other user can read it and so you do not have to re-authorize after a server restart. It is used only to call the Notion API on your behalf and is never logged.
-- **No content database**: Beyond the encrypted access token above, no Notion page content or session history is persisted between requests.
-- **Logging**: Only anonymous request metadata (timestamps, status codes) is logged for operational monitoring. No Notion content is logged.
+- **Authentication**: Uses the Notion OAuth 2.0 credentials you configure.
+- **Token storage**: Access-token storage and retention are controlled by your deployment configuration.
+- **No content database by default**: The server does not require a Notion content database.
+- **Logging**: Logging and monitoring are controlled by the operator of the self-hosted deployment.
 
 ## Stdio Mode (Local)
 
@@ -25,7 +25,7 @@ When running locally via npm or Docker:
 ## Third-Party Services
 
 - **Notion API** (`api.notion.com`): Your data is subject to [Notion's Privacy Policy](https://www.notion.so/Privacy-Policy-3468d120cf614d4c9014c09f6aab3571).
-- **Cloudflare**: The remote server runs on Cloudflare (Workers + Containers + KV), which also provides DNS proxy and DDoS protection. See [Cloudflare Privacy](https://www.cloudflare.com/privacypolicy/).
+- **Self-hosting provider**: If you deploy HTTP mode, data processing by your chosen infrastructure provider is governed by that provider's terms and your configuration.
 
 ## Contact
 

--- a/server.json
+++ b/server.json
@@ -41,11 +41,5 @@
         }
       ]
     }
-  ],
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://notion.n24q02m.com/mcp"
-    }
   ]
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -47,6 +47,9 @@ export interface Env {
   MCP_RELAY_PASSWORD: string
   NOTION_OAUTH_CLIENT_ID: string
   NOTION_OAUTH_CLIENT_SECRET: string
+  // Dehost / tombstone drill flag (W4)
+  DEHOSTED?: string
+  TOMBSTONE?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
@@ -137,8 +140,30 @@ function unauthenticated(request: Request): Response {
   })
 }
 
+function tombstoneResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      message:
+        'The hosted Cloudflare endpoint for better-notion-mcp has been retired. The package remains active via local stdio (npx @n24q02m/better-notion-mcp / docker run -i n24q02m/better-notion-mcp) and self-hosted HTTP. See https://mcp.n24q02m.com/servers/better-notion-mcp/ for instructions.',
+      successor: 'https://mcp.n24q02m.com/servers/better-notion-mcp/'
+    }),
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Dehosted-Successor': 'https://mcp.n24q02m.com/servers/better-notion-mcp/'
+      }
+    }
+  )
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (env.DEHOSTED === 'true' || env.TOMBSTONE === 'true') {
+      return tombstoneResponse()
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -290,3 +290,52 @@ describe('KV security (Sentinel)', () => {
     expect(res.status).toBe(403)
   })
 })
+
+describe('tombstone contract (W4 dehost preparation & drill)', () => {
+  it('returns 410 Gone with non-sensitive successor message and headers before edge auth when DEHOSTED is true', async () => {
+    const { calls, env } = envWithDoSpy()
+    const dehostedEnv = { ...env, DEHOSTED: 'true' }
+
+    const res = await worker.fetch(
+      new Request('https://notion.n24q02m.com/mcp', {
+        method: 'POST'
+      }),
+      dehostedEnv as never
+    )
+
+    expect(res.status).toBe(410)
+    expect(res.headers.get('Content-Type')).toBe('application/json')
+    expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/better-notion-mcp/')
+
+    const body = await res.json()
+    expect(body).toMatchObject({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      successor: 'https://mcp.n24q02m.com/servers/better-notion-mcp/'
+    })
+    expect(body.message).toContain('retired')
+    expect(body.message).toContain('stdio')
+
+    // CRITICAL: 0 requests reach the Container DO
+    expect(calls).toEqual([])
+  })
+
+  it('returns 410 Gone on all routes before auth/DO for DEHOSTED and the existing TOMBSTONE drill alias', async () => {
+    const { calls, env } = envWithDoSpy()
+
+    for (const flag of ['DEHOSTED', 'TOMBSTONE'] as const) {
+      const flaggedEnv = { ...env, [flag]: 'true' }
+      for (const path of ['/authorize', '/health', '/.well-known/jwks.json', '/mcp/v1']) {
+        const res = await worker.fetch(
+          new Request(`https://notion.n24q02m.com${path}`, { method: 'GET' }),
+          flaggedEnv as never
+        )
+        expect(res.status).toBe(410)
+        expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/better-notion-mcp/')
+      }
+    }
+
+    // CRITICAL: 0 requests reach the Container DO
+    expect(calls).toEqual([])
+  })
+})

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -28,6 +28,7 @@
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["NotionContainer"] }],
   "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
   "vars": {
+    "DEHOSTED": "true",
     "MCP_TRANSPORT": "http",
     "PORT": "8080",
     "HOST": "0.0.0.0",


### PR DESCRIPTION
## Summary
- gate future Cloudflare host deployment with `CF_HOSTED_ENABLED=false`
- keep a deterministic HTTP 410 sentinel if an operator explicitly re-enables the template
- remove the retired hosted remote from `server.json`
- update repository and privacy docs for local/self-host operation
- keep npm, OCI, CI, security, release, and repository maintenance active

## Live dehost state
- `better-notion-mcp-worker` Worker script and Container application were deleted on 2026-08-24
- `notion.n24q02m.com` no longer resolves and cannot start an MCP/OAuth session
- repository variable `CF_HOSTED_ENABLED=false` is set
- KV namespace, rollback image `2.39.0`, skret secrets, encrypted backup, and isolated restore proof are retained

## Verification
- Worker Vitest suite: 28 passed
- `server.json` parses and contains package/OCI entries only
- repository remains public, active, and unarchived

Normal protected-branch review remains required; do not bypass it.