### PR TITLE
fix: ⚡ Bolt: Use in-place array truncation in autoPaginate

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@ Proposals that were reviewed and declined. A closing comment lives on the PR, wh
 - **Dropping the redundant `.includes('|')` and using `.trimStart()` in `markdown.ts` table parsing** (PRs #1142, #1143, #1144 — one cluster, three PRs). The redundancy is real and the rewrite is behaviour-preserving, but `parseTable` runs once per table during page conversion and the removed check scans a single line. Unmeasured, so closed. `#1142` is the cleanest diff if this is ever revisited.
 - **Writing `// ⚡ Bolt: ...` narration into source files** (PR #1143, `markdown.ts:193`). This is a public repository; attribution markers of that form do not belong in shipped code. Keep the rationale in this ledger and in the commit message.
 - **Deleting existing entries from this file** (PR #1143 removed 22 lines). This ledger is append-only memory. Removing entries is how settled proposals return.
+
+## 2024-08-24 - In-place Array Truncation
+**Learning:** Using `.slice(0, limit)` to truncate large arrays creates intermediate array allocations, adding GC overhead. Setting `array.length = limit` performs in-place truncation which avoids allocations and is faster on V8/Bun engines.
+**Action:** Always prefer `array.length = limit` when truncating an existing array if the original reference can be safely mutated.

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -67,7 +67,13 @@ export async function autoPaginate<T>(
     }
   } while (cursor !== null)
 
-  return limit > 0 ? allResults.slice(0, limit) : allResults
+  // Use in-place truncation to avoid intermediate array allocation GC
+  // overhead from .slice(0, limit) on very large result sets
+  if (limit > 0 && allResults.length > limit) {
+    allResults.length = limit
+  }
+
+  return allResults
 }
 
 /** Block types that need children fetched for proper markdown rendering */


### PR DESCRIPTION
💡 What: Replaces `.slice(0, limit)` with in-place array truncation (`allResults.length = limit`) in `src/tools/helpers/pagination.ts`'s `autoPaginate` function.
🎯 Why: Using `.slice()` allocates a brand new array under the hood. On very large paginated result sets (potentially thousands of items), this creates unnecessary intermediate array allocation and Garbage Collection (GC) overhead in V8/Bun, especially when it runs repeatedly per request. Since `autoPaginate` owns the `allResults` array locally, it's perfectly safe to mutate it.
📊 Impact: Eliminates the O(n) memory allocation overhead required for creating the shallow copy when enforcing a limit, reducing GC pressure during large paginated fetches.
🔬 Measurement: A micro-benchmark confirms array length mutation is generally instant, whereas `.slice()` costs time proportional to the elements sliced. Code verified with `bun run test` passing fully.

---
*PR created automatically by Jules for task [10471990203312427159](https://jules.google.com/task/10471990203312427159) started by @n24q02m*