### PR TITLE
fix: ⚡ Bolt: Pass limit to autoPaginate to save network I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,6 @@ Proposals that were reviewed and declined. A closing comment lives on the PR, wh
 - **Dropping the redundant `.includes('|')` and using `.trimStart()` in `markdown.ts` table parsing** (PRs #1142, #1143, #1144 — one cluster, three PRs). The redundancy is real and the rewrite is behaviour-preserving, but `parseTable` runs once per table during page conversion and the removed check scans a single line. Unmeasured, so closed. `#1142` is the cleanest diff if this is ever revisited.
 - **Writing `// ⚡ Bolt: ...` narration into source files** (PR #1143, `markdown.ts:193`). This is a public repository; attribution markers of that form do not belong in shipped code. Keep the rationale in this ledger and in the commit message.
 - **Deleting existing entries from this file** (PR #1143 removed 22 lines). This ledger is append-only memory. Removing entries is how settled proposals return.
+## 2024-07-28 - Optimize Pagination Network I/O
+**Learning:** In paginated functions (like `autoPaginate` handling Notion API `list` requests), waiting for all pages to fetch and then slicing the array in memory incurs severe performance and network I/O penalties.
+**Action:** Always pass limits directly into pagination functions or utility options (e.g., `{ limit: input.limit }`) to allow the loop to break early and prevent unnecessary network requests.

--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -486,21 +486,21 @@ async function queryDatabase(notion: Client, input: DatabasesInput): Promise<Que
   if (input.sorts) queryParams.sorts = input.sorts
 
   // Fetch with pagination
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).dataSources.query({
-      ...queryParams,
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  // Limit results if specified
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  const results = await autoPaginate(
+    async (cursor) => {
+      const response: any = await (notion as any).dataSources.query({
+        ...queryParams,
+        start_cursor: cursor,
+        page_size: 100
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   // Format results
   const formattedResults = formatDatabaseResults(results)

--- a/src/tools/composite/file-uploads.ts
+++ b/src/tools/composite/file-uploads.ts
@@ -235,19 +235,20 @@ async function retrieveFileUpload(notion: Client, input: FileUploadsInput): Prom
  * Maps to: GET /v1/file_uploads
  */
 async function listFileUploads(notion: Client, input: FileUploadsInput): Promise<any> {
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).fileUploads.list({
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  const results = await autoPaginate(
+    async (cursor) => {
+      const response: any = await (notion as any).fileUploads.list({
+        start_cursor: cursor,
+        page_size: 100
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   return {
     action: 'list',

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -58,16 +58,25 @@ export async function autoPaginate<T>(
 
     // Stop if limit reached
     if (limit > 0 && allResults.length >= limit) {
+      // In-place truncation to avoid intermediate GC allocations from .slice() on large arrays
+      allResults.length = limit
       break
     }
 
     // Stop if max pages reached (user-specified or safety limit)
     if (pageCount >= effectiveMax) {
+      if (limit > 0 && allResults.length > limit) {
+        allResults.length = limit
+      }
       break
     }
   } while (cursor !== null)
 
-  return limit > 0 ? allResults.slice(0, limit) : allResults
+  if (limit > 0 && allResults.length > limit) {
+    allResults.length = limit
+  }
+
+  return allResults
 }
 
 /** Block types that need children fetched for proper markdown rendering */

--- a/src/tools/helpers/pagination.ts
+++ b/src/tools/helpers/pagination.ts
@@ -58,25 +58,16 @@ export async function autoPaginate<T>(
 
     // Stop if limit reached
     if (limit > 0 && allResults.length >= limit) {
-      // In-place truncation to avoid intermediate GC allocations from .slice() on large arrays
-      allResults.length = limit
       break
     }
 
     // Stop if max pages reached (user-specified or safety limit)
     if (pageCount >= effectiveMax) {
-      if (limit > 0 && allResults.length > limit) {
-        allResults.length = limit
-      }
       break
     }
   } while (cursor !== null)
 
-  if (limit > 0 && allResults.length > limit) {
-    allResults.length = limit
-  }
-
-  return allResults
+  return limit > 0 ? allResults.slice(0, limit) : allResults
 }
 
 /** Block types that need children fetched for proper markdown rendering */


### PR DESCRIPTION
💡 What: Updated `listFileUploads` and `queryDatabase` to pass the `limit` explicitly to the `autoPaginate` options.
🎯 Why: Previously, `autoPaginate` fetched all possible pages from the Notion API and the resulting array was `.slice()`'d after the fact. By passing the limit explicitly, the loop breaks early, saving substantial network I/O and memory overhead.
📊 Impact: Faster API responses and significantly reduced server memory when querying datasets with a limit.
🔬 Measurement: Verify changes in `src/tools/composite/file-uploads.ts` and `src/tools/composite/databases.ts`, where `.slice()` has been removed and `{ limit: input.limit }` is passed into `autoPaginate`.

---
*PR created automatically by Jules for task [6744039899148185886](https://jules.google.com/task/6744039899148185886) started by @n24q02m*