### PR TITLE
fix: ⚡ Bolt: Optimize Notion pagination network I/O by passing limit to autoPaginate

### DIFF
--- a/src/tools/composite/databases.ts
+++ b/src/tools/composite/databases.ts
@@ -486,21 +486,21 @@ async function queryDatabase(notion: Client, input: DatabasesInput): Promise<Que
   if (input.sorts) queryParams.sorts = input.sorts
 
   // Fetch with pagination
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).dataSources.query({
-      ...queryParams,
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  // Limit results if specified
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  const results = await autoPaginate(
+    async (cursor, pageSize) => {
+      const response: any = await (notion as any).dataSources.query({
+        ...queryParams,
+        start_cursor: cursor,
+        page_size: pageSize
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   // Format results
   const formattedResults = formatDatabaseResults(results)

--- a/src/tools/composite/file-uploads.ts
+++ b/src/tools/composite/file-uploads.ts
@@ -235,19 +235,20 @@ async function retrieveFileUpload(notion: Client, input: FileUploadsInput): Prom
  * Maps to: GET /v1/file_uploads
  */
 async function listFileUploads(notion: Client, input: FileUploadsInput): Promise<any> {
-  const allResults = await autoPaginate(async (cursor) => {
-    const response: any = await (notion as any).fileUploads.list({
-      start_cursor: cursor,
-      page_size: 100
-    })
-    return {
-      results: response.results,
-      next_cursor: response.next_cursor,
-      has_more: response.has_more
-    }
-  })
-
-  const results = input.limit ? allResults.slice(0, input.limit) : allResults
+  const results = await autoPaginate(
+    async (cursor, pageSize) => {
+      const response: any = await (notion as any).fileUploads.list({
+        start_cursor: cursor,
+        page_size: pageSize
+      })
+      return {
+        results: response.results,
+        next_cursor: response.next_cursor,
+        has_more: response.has_more
+      }
+    },
+    { limit: input.limit }
+  )
 
   return {
     action: 'list',


### PR DESCRIPTION
💡 What: Updated `listFileUploads` (in `file-uploads.ts`) and `queryDatabase` (in `databases.ts`) to use the `pageSize` callback parameter provided by `autoPaginate` and passing the `limit` configuration, replacing the post-fetch `.slice()` pattern.
🎯 Why: To avoid fetching extra pages from the Notion API and discarding them later when a `limit` is set, significantly improving network I/O efficiency.
📊 Impact: Decreases latency, network requests, and memory usage when paginated endpoints are bounded by a limit.
🔬 Measurement: Verify changes in `src/tools/composite/databases.ts` and `src/tools/composite/file-uploads.ts`, and run `bun run test`.

---
*PR created automatically by Jules for task [14462172651826865706](https://jules.google.com/task/14462172651826865706) started by @n24q02m*