### PR TITLE
fix: align Bun toolchain with lockfile v2

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -5,7 +5,7 @@
 
 [tools]
 node = "24"
-bun = "latest"
+bun = "1.4.0"
 uv = "latest"
 python = "3.13"
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "version": "2.39.0",
   "license": "Apache-2.0",
   "type": "module",
-  "packageManager": "bun@1.2.21",
+  "packageManager": "bun@1.4.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- Pin `package.json` `packageManager` to `bun@1.4.0`.
- Pin `.mise.toml` Bun to `1.4.0`.

This addresses [#1211](https://github.com/n24q02m/better-notion-mcp/issues/1211) (run `33185837444`), whose three OS jobs used Bun `1.2.21` and rejected `lockfileVersion: 2`.

`bun.lock` bytes remain unchanged.

No local tests, builds, formatters, or linters were run per the H2a assignment; the parent session will run the requested Bun 1.4.0 verification commands.