### PR TITLE
fix(deps): bump mcp-core to 1.23.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@n24q02m/mcp-core": "1.23.0",
+        "@n24q02m/mcp-core": "1.23.1",
         "@notionhq/client": "^5.26.0",
         "zod": "^4.5.4",
       },
@@ -121,7 +121,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
-    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.23.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.2", "env-paths": "^4.0.0", "jose": "^6.2.6" } }, "sha512-YXKnTe7N8fZSg1bXYmXtxk+SFTn7KSr9MDoxpZBaL2DzItMMHBg3M8N8jAPNvQVHb4iQ+MY+tuJZXDlolb1cKw=="],
+    "@n24q02m/mcp-core": ["@n24q02m/mcp-core@1.23.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "better-sqlite3": "^13.0.3", "env-paths": "^4.0.0", "jose": "^6.2.10" } }, "sha512-hAH+NbM/29mvW9aqOA89m2r/E8dKlMqNR1XhajRXB8wqwpVBEutOF+qiYObhPSA92lKFszFAkceWbQoyN4H8QQ=="],
 
     "@notionhq/client": ["@notionhq/client@5.26.0", "", {}, "sha512-Oc3438nQ5YmZkVO7YJG8fcTYl0V46CirdCvO33azZ9f7ZfD2rsHE4fUVANJiBB9Xf1sqpCs82nd8oKPxeXLmMg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@n24q02m/mcp-core": "1.23.0",
+    "@n24q02m/mcp-core": "1.23.1",
     "@notionhq/client": "^5.26.0",
     "zod": "^4.5.4"
   },


### PR DESCRIPTION
## Summary
- pin `@n24q02m/mcp-core` 1.23.1
- refresh Bun lockfile

## Verification
- `bun install --frozen-lockfile`
- `bun run check`
- `bun run test -- --run` (988 passed)
- `bun run build`

Closes #1244