### PR TITLE
fix: isolate init-server transport mock

### DIFF
--- a/src/init-server.test.ts
+++ b/src/init-server.test.ts
@@ -2,13 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const startServerMock = vi.fn()
 
-vi.mock('./main.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./main.js')>()
-  return {
-    ...actual,
-    startServer: startServerMock
-  }
-})
+vi.mock('./main.js', () => ({
+  startServer: startServerMock,
+  getTransportMode: () =>
+    process.argv.includes('--http') || process.env.MCP_TRANSPORT === 'http' || process.env.TRANSPORT_MODE === 'http'
+      ? 'http'
+      : 'stdio'
+}))
+
 describe('initServer', () => {
   const originalEnv = process.env
   const originalArgv = process.argv


### PR DESCRIPTION
## Problem

The canonical T0 coverage run intermittently timed out in `src/init-server.test.ts`. Its partial `./main.js` mock called `importOriginal`, loading the complete server graph just to obtain `getTransportMode`; under aggregate T0 load the first 5-second test timed out, after which the next case escaped to the real HTTP startup path.

## Change

Keep the unit boundary local: mock both `startServer` and the lightweight transport selector used by `initServer`. `main.test.ts` remains the source test for the real exported selector.

## Verification

- RED: aggregate coverage run failed 2/6 init-server cases (one timeout, one real HTTP credential error)
- isolated test before the change passed but took 2.61s due to importing the server graph
- isolated test after the change: 6/6 passed in 414ms
- full coverage: 35 files, 988 tests passed; 97.76% statements
- Biome, TypeScript type-check, build, gitleaks and changed-file pre-commit gates passed
- local review graph and parent delta review found no issue

Review provider circuit remains `REVIEW-DEGRADED-PROVIDER-QUOTA`; no subagent approval is claimed.