### PR TITLE
fix: add bounded Notion provider acceptance

### DIFF
--- a/scripts/provider-readonly-acceptance.ts
+++ b/scripts/provider-readonly-acceptance.ts
@@ -1,0 +1,270 @@
+import { pathToFileURL } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { z } from 'zod'
+
+const SEARCH_QUERY = 'provider-acceptance'
+const SEARCH_LIMIT = 3
+
+export interface AcceptanceClient {
+  callTool(request: {
+    name: string
+    arguments?: Record<string, unknown>
+  }): Promise<unknown>
+}
+
+interface ToolCall {
+  name: string
+  arguments: Record<string, unknown>
+}
+
+interface OperationSummary {
+  operation: string
+  contentBlocks: number
+  resultCount?: number
+}
+
+export interface ReadOnlyAcceptanceSummary {
+  status: 'VERIFIED'
+  operations: OperationSummary[]
+}
+
+const READ_ONLY_CALLS: ReadonlyArray<{ operation: string; request: ToolCall }> = [
+  {
+    operation: 'workspace.info',
+    request: { name: 'workspace', arguments: { action: 'info' } }
+  },
+  {
+    operation: 'users.me',
+    request: { name: 'users', arguments: { action: 'me' } }
+  },
+  {
+    operation: 'workspace.search',
+    request: {
+      name: 'workspace',
+      arguments: { action: 'search', query: SEARCH_QUERY, limit: SEARCH_LIMIT }
+    }
+  }
+]
+
+class AcceptanceError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AcceptanceError'
+  }
+}
+
+const TextContentSchema = z
+  .object({
+    type: z.literal('text'),
+    text: z.string()
+  })
+  .passthrough()
+const ImageContentSchema = z
+  .object({
+    type: z.literal('image'),
+    data: z.string(),
+    mimeType: z.string()
+  })
+  .passthrough()
+const AudioContentSchema = z
+  .object({
+    type: z.literal('audio'),
+    data: z.string(),
+    mimeType: z.string()
+  })
+  .passthrough()
+const ResourceContentSchema = z
+  .object({
+    type: z.literal('resource'),
+    resource: z.union([
+      z.object({ uri: z.string(), text: z.string() }).passthrough(),
+      z.object({ uri: z.string(), blob: z.string() }).passthrough()
+    ])
+  })
+  .passthrough()
+const ResourceLinkSchema = z
+  .object({
+    type: z.literal('resource_link'),
+    uri: z.string(),
+    name: z.string()
+  })
+  .passthrough()
+const ContentBlockSchema = z.discriminatedUnion('type', [
+  TextContentSchema,
+  ImageContentSchema,
+  AudioContentSchema,
+  ResourceContentSchema,
+  ResourceLinkSchema
+])
+
+const CallToolResultSchema = z
+  .object({
+    isError: z.boolean().optional(),
+    content: z.array(ContentBlockSchema).min(1)
+  })
+  .passthrough()
+const SearchPayloadSchema = z
+  .object({
+    action: z.literal('search').optional(),
+    query: z.string().optional(),
+    total: z.number().int().nonnegative(),
+    results: z.array(z.record(z.string(), z.unknown()))
+  })
+  .strict()
+
+const ReadOnlyToolCallSchema = z.union([
+  z
+    .object({
+      name: z.literal('workspace'),
+      arguments: z.object({ action: z.literal('info') }).strict()
+    })
+    .strict(),
+  z
+    .object({
+      name: z.literal('users'),
+      arguments: z.object({ action: z.literal('me') }).strict()
+    })
+    .strict(),
+  z
+    .object({
+      name: z.literal('workspace'),
+      arguments: z
+        .object({
+          action: z.literal('search'),
+          query: z.literal(SEARCH_QUERY),
+          limit: z.literal(SEARCH_LIMIT)
+        })
+        .strict()
+    })
+    .strict()
+])
+
+export function assertReadOnlyToolCall(request: unknown): asserts request is ToolCall {
+  if (!ReadOnlyToolCallSchema.safeParse(request).success) {
+    throw new AcceptanceError('Request is not an allowed read-only acceptance call')
+  }
+}
+
+function readContent(result: unknown, operation: string): z.infer<typeof ContentBlockSchema>[] {
+  const parsed = CallToolResultSchema.safeParse(result)
+  if (!parsed.success) {
+    throw new AcceptanceError(`${operation} returned a malformed MCP result`)
+  }
+  if (parsed.data.isError === true) {
+    throw new AcceptanceError(`${operation} returned an MCP error`)
+  }
+  return parsed.data.content
+}
+
+function searchResultCount(content: z.infer<typeof ContentBlockSchema>[]): number {
+  if (content.length !== 1) {
+    throw new AcceptanceError('workspace.search returned a malformed result')
+  }
+
+  const parsedBlock = TextContentSchema.safeParse(content[0])
+  if (!parsedBlock.success) {
+    throw new AcceptanceError('workspace.search returned a malformed result')
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(parsedBlock.data.text)
+  } catch {
+    throw new AcceptanceError('workspace.search returned malformed JSON')
+  }
+
+  const parsedPayload = SearchPayloadSchema.safeParse(payload)
+  if (!parsedPayload.success) {
+    throw new AcceptanceError('workspace.search returned a malformed result')
+  }
+
+  const { total, results } = parsedPayload.data
+  if (total > SEARCH_LIMIT || results.length > SEARCH_LIMIT) {
+    throw new AcceptanceError('workspace.search exceeded the result bound')
+  }
+  if (total !== results.length) {
+    throw new AcceptanceError('workspace.search returned inconsistent result metadata')
+  }
+  return total
+}
+
+export async function runReadOnlyAcceptance(
+  client: AcceptanceClient
+): Promise<ReadOnlyAcceptanceSummary> {
+  const operations: OperationSummary[] = []
+
+  for (const { operation, request } of READ_ONLY_CALLS) {
+    assertReadOnlyToolCall(request)
+    let result: unknown
+    try {
+      result = await client.callTool(request)
+    } catch {
+      throw new AcceptanceError(`${operation} call failed`)
+    }
+    const content = readContent(result, operation)
+    operations.push({
+      operation,
+      contentBlocks: content.length,
+      ...(operation === 'workspace.search' ? { resultCount: searchResultCount(content) } : {})
+    })
+  }
+
+  return { status: 'VERIFIED', operations }
+}
+
+export async function runHttpReadOnlyAcceptance(
+  endpoint: URL,
+  bearerToken: string
+): Promise<ReadOnlyAcceptanceSummary> {
+  if (!['http:', 'https:'].includes(endpoint.protocol)) {
+    throw new AcceptanceError('Notion MCP endpoint must use HTTP or HTTPS')
+  }
+  if (typeof bearerToken !== 'string' || bearerToken.trim().length === 0) {
+    throw new AcceptanceError('Notion MCP bearer token is required')
+  }
+
+  let transport: StreamableHTTPClientTransport | undefined
+  try {
+    try {
+      transport = new StreamableHTTPClientTransport(endpoint, {
+        requestInit: { headers: { authorization: `Bearer ${bearerToken}` } }
+      })
+      const client = new Client({ name: 'notion-readonly-provider-acceptance', version: '1.0.0' })
+      await client.connect(transport)
+      return await runReadOnlyAcceptance(client)
+    } catch (error) {
+      if (error instanceof AcceptanceError) throw error
+      throw new AcceptanceError('Read-only acceptance transport failed')
+    }
+  } finally {
+    if (transport) {
+      try {
+        await transport.close()
+      } catch {
+        throw new AcceptanceError('Read-only acceptance transport close failed')
+      }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const endpoint = process.env.NOTION_MCP_URL
+  const bearerToken = process.env.NOTION_MCP_BEARER_TOKEN
+  if (!endpoint || !bearerToken) {
+    console.error(JSON.stringify({ status: 'FAILED', code: 'READ_ONLY_INPUT_MISSING' }))
+    process.exitCode = 1
+    return
+  }
+
+  try {
+    console.log(JSON.stringify(await runHttpReadOnlyAcceptance(new URL(endpoint), bearerToken)))
+  } catch {
+    console.error(JSON.stringify({ status: 'FAILED', code: 'READ_ONLY_ACCEPTANCE_FAILED' }))
+    process.exitCode = 1
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/scripts/provider-readonly-acceptance.ts
+++ b/scripts/provider-readonly-acceptance.ts
@@ -7,10 +7,7 @@ const SEARCH_QUERY = 'provider-acceptance'
 const SEARCH_LIMIT = 3
 
 export interface AcceptanceClient {
-  callTool(request: {
-    name: string
-    arguments?: Record<string, unknown>
-  }): Promise<unknown>
+  callTool(request: { name: string; arguments?: Record<string, unknown> }): Promise<unknown>
 }
 
 interface ToolCall {
@@ -189,9 +186,7 @@ function searchResultCount(content: z.infer<typeof ContentBlockSchema>[]): numbe
   return total
 }
 
-export async function runReadOnlyAcceptance(
-  client: AcceptanceClient
-): Promise<ReadOnlyAcceptanceSummary> {
+export async function runReadOnlyAcceptance(client: AcceptanceClient): Promise<ReadOnlyAcceptanceSummary> {
   const operations: OperationSummary[] = []
 
   for (const { operation, request } of READ_ONLY_CALLS) {
@@ -225,27 +220,31 @@ export async function runHttpReadOnlyAcceptance(
   }
 
   let transport: StreamableHTTPClientTransport | undefined
+  let summary: ReadOnlyAcceptanceSummary | undefined
+  let failure: AcceptanceError | undefined
+
   try {
+    transport = new StreamableHTTPClientTransport(endpoint, {
+      requestInit: { headers: { authorization: `Bearer ${bearerToken}` } }
+    })
+    const client = new Client({ name: 'notion-readonly-provider-acceptance', version: '1.0.0' })
+    await client.connect(transport)
+    summary = await runReadOnlyAcceptance(client)
+  } catch (error) {
+    failure = error instanceof AcceptanceError ? error : new AcceptanceError('Read-only acceptance transport failed')
+  }
+
+  if (transport) {
     try {
-      transport = new StreamableHTTPClientTransport(endpoint, {
-        requestInit: { headers: { authorization: `Bearer ${bearerToken}` } }
-      })
-      const client = new Client({ name: 'notion-readonly-provider-acceptance', version: '1.0.0' })
-      await client.connect(transport)
-      return await runReadOnlyAcceptance(client)
-    } catch (error) {
-      if (error instanceof AcceptanceError) throw error
-      throw new AcceptanceError('Read-only acceptance transport failed')
-    }
-  } finally {
-    if (transport) {
-      try {
-        await transport.close()
-      } catch {
-        throw new AcceptanceError('Read-only acceptance transport close failed')
-      }
+      await transport.close()
+    } catch {
+      failure ??= new AcceptanceError('Read-only acceptance transport close failed')
     }
   }
+
+  if (failure) throw failure
+  if (!summary) throw new AcceptanceError('Read-only acceptance transport failed')
+  return summary
 }
 
 async function main(): Promise<void> {

--- a/tests/provider-readonly-acceptance.test.ts
+++ b/tests/provider-readonly-acceptance.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  assertReadOnlyToolCall,
+  runHttpReadOnlyAcceptance,
+  runReadOnlyAcceptance,
+  type AcceptanceClient
+} from '../scripts/provider-readonly-acceptance.js'
+
+const sdkMocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  callTool: vi.fn(),
+  close: vi.fn(),
+  transportArgs: vi.fn()
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    async connect(...args: unknown[]) {
+      return sdkMocks.connect(...args)
+    }
+
+    async callTool(...args: unknown[]) {
+      return sdkMocks.callTool(...args)
+    }
+  }
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {
+    constructor(...args: unknown[]) {
+      sdkMocks.transportArgs(...args)
+    }
+
+    async close() {
+      return sdkMocks.close()
+    }
+  }
+}))
+
+const secretToken = 'secret-bearer-token'
+const sensitiveId = 'private-page-id'
+
+function textResult(value: unknown) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value) }]
+  }
+}
+
+function searchItem(id: string, title: string) {
+  return {
+    id,
+    object: 'page',
+    title,
+    url: `https://notion.example/${id}`,
+    last_edited_time: '2026-08-30T00:00:00.000Z'
+  }
+}
+
+class FakeClient implements AcceptanceClient {
+  readonly calls: Array<{ name: string; arguments?: Record<string, unknown> }> = []
+
+  async callTool(request: { name: string; arguments?: Record<string, unknown> }) {
+    this.calls.push(request)
+
+    if (request.name === 'workspace' && request.arguments?.action === 'search') {
+      return textResult({
+        action: 'search',
+        query: 'provider-acceptance',
+        total: 2,
+        results: [
+          searchItem(sensitiveId, 'Private result'),
+          searchItem('another-private-id', 'Another result')
+        ]
+      })
+    }
+
+    return textResult({ id: sensitiveId, token: secretToken })
+  }
+}
+
+describe('read-only Notion provider acceptance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls only the bounded read-only operations and emits metadata only', async () => {
+    const client = new FakeClient()
+
+    const summary = await runReadOnlyAcceptance(client)
+
+    expect(client.calls).toEqual([
+      { name: 'workspace', arguments: { action: 'info' } },
+      { name: 'users', arguments: { action: 'me' } },
+      {
+        name: 'workspace',
+        arguments: { action: 'search', query: 'provider-acceptance', limit: 3 }
+      }
+    ])
+    expect(summary).toEqual({
+      status: 'VERIFIED',
+      operations: [
+        { operation: 'workspace.info', contentBlocks: 1 },
+        { operation: 'users.me', contentBlocks: 1 },
+        { operation: 'workspace.search', contentBlocks: 1, resultCount: 2 }
+      ]
+    })
+
+    const serialized = JSON.stringify(summary)
+    expect(serialized).not.toContain(secretToken)
+    expect(serialized).not.toContain(sensitiveId)
+    expect(serialized).not.toContain('Private result')
+  })
+
+  it('rejects mutating or widened calls before transport dispatch', async () => {
+    const dispatched: unknown[] = []
+    const guardedDispatch = async (request: unknown) => {
+      assertReadOnlyToolCall(request)
+      dispatched.push(request)
+    }
+
+    await expect(
+      guardedDispatch({ name: 'pages', arguments: { action: 'create' } })
+    ).rejects.toThrow(/not an allowed read-only acceptance call/)
+    await expect(
+      guardedDispatch({
+        name: 'workspace',
+        arguments: { action: 'search', query: 'provider-acceptance', limit: 4 }
+      })
+    ).rejects.toThrow(/not an allowed read-only acceptance call/)
+    expect(dispatched).toEqual([])
+
+    expect(() =>
+      assertReadOnlyToolCall({
+        name: 'workspace',
+        arguments: { action: 'search', limit: 3, query: 'provider-acceptance' }
+      })
+    ).not.toThrow()
+  })
+
+  it('fails closed on provider errors, malformed results, and unbounded search results', async () => {
+    const providerError: AcceptanceClient = {
+      async callTool() {
+        return { isError: true, content: [{ type: 'text', text: secretToken }] }
+      }
+    }
+    await expect(runReadOnlyAcceptance(providerError)).rejects.toThrow(
+      'workspace.info returned an MCP error'
+    )
+    try {
+      await runReadOnlyAcceptance(providerError)
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).not.toContain(secretToken)
+    }
+
+    const malformed: AcceptanceClient = {
+      async callTool(request) {
+        if (request.name === 'workspace' && request.arguments?.action === 'search') {
+          return { content: [{ type: 'text', text: '{not-json' }] }
+        }
+        return textResult({})
+      }
+    }
+    await expect(runReadOnlyAcceptance(malformed)).rejects.toThrow(
+      'workspace.search returned malformed JSON'
+    )
+
+    const tooManyResults: AcceptanceClient = {
+      async callTool(request) {
+        if (request.name === 'workspace' && request.arguments?.action === 'search') {
+          return textResult({
+            action: 'search',
+            query: 'provider-acceptance',
+            total: 4,
+            results: [
+              searchItem('one', 'One'),
+              searchItem('two', 'Two'),
+              searchItem('three', 'Three'),
+              searchItem('four', 'Four')
+            ]
+          })
+        }
+        return textResult({})
+      }
+    }
+    await expect(runReadOnlyAcceptance(tooManyResults)).rejects.toThrow(
+      'workspace.search exceeded the result bound'
+    )
+  })
+
+  it('closes the SDK transport and redacts connection failures', async () => {
+    sdkMocks.connect.mockRejectedValueOnce(new Error(`provider leaked ${secretToken}`))
+
+    let failure: unknown
+    try {
+      await runHttpReadOnlyAcceptance(new URL('https://notion.example/mcp'), secretToken)
+    } catch (error) {
+      failure = error
+    }
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toBe('Read-only acceptance transport failed')
+    expect((failure as Error).message).not.toContain(secretToken)
+    expect(sdkMocks.transportArgs).toHaveBeenCalledWith(
+      expect.any(URL),
+      { requestInit: { headers: { authorization: `Bearer ${secretToken}` } } }
+    )
+    expect(sdkMocks.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/provider-readonly-acceptance.test.ts
+++ b/tests/provider-readonly-acceptance.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  type AcceptanceClient,
   assertReadOnlyToolCall,
   runHttpReadOnlyAcceptance,
-  runReadOnlyAcceptance,
-  type AcceptanceClient
+  runReadOnlyAcceptance
 } from '../scripts/provider-readonly-acceptance.js'
 
 const sdkMocks = vi.hoisted(() => ({
@@ -67,10 +67,7 @@ class FakeClient implements AcceptanceClient {
         action: 'search',
         query: 'provider-acceptance',
         total: 2,
-        results: [
-          searchItem(sensitiveId, 'Private result'),
-          searchItem('another-private-id', 'Another result')
-        ]
+        results: [searchItem(sensitiveId, 'Private result'), searchItem('another-private-id', 'Another result')]
       })
     }
 
@@ -118,9 +115,9 @@ describe('read-only Notion provider acceptance', () => {
       dispatched.push(request)
     }
 
-    await expect(
-      guardedDispatch({ name: 'pages', arguments: { action: 'create' } })
-    ).rejects.toThrow(/not an allowed read-only acceptance call/)
+    await expect(guardedDispatch({ name: 'pages', arguments: { action: 'create' } })).rejects.toThrow(
+      /not an allowed read-only acceptance call/
+    )
     await expect(
       guardedDispatch({
         name: 'workspace',
@@ -143,9 +140,7 @@ describe('read-only Notion provider acceptance', () => {
         return { isError: true, content: [{ type: 'text', text: secretToken }] }
       }
     }
-    await expect(runReadOnlyAcceptance(providerError)).rejects.toThrow(
-      'workspace.info returned an MCP error'
-    )
+    await expect(runReadOnlyAcceptance(providerError)).rejects.toThrow('workspace.info returned an MCP error')
     try {
       await runReadOnlyAcceptance(providerError)
     } catch (error) {
@@ -161,9 +156,7 @@ describe('read-only Notion provider acceptance', () => {
         return textResult({})
       }
     }
-    await expect(runReadOnlyAcceptance(malformed)).rejects.toThrow(
-      'workspace.search returned malformed JSON'
-    )
+    await expect(runReadOnlyAcceptance(malformed)).rejects.toThrow('workspace.search returned malformed JSON')
 
     const tooManyResults: AcceptanceClient = {
       async callTool(request) {
@@ -183,9 +176,7 @@ describe('read-only Notion provider acceptance', () => {
         return textResult({})
       }
     }
-    await expect(runReadOnlyAcceptance(tooManyResults)).rejects.toThrow(
-      'workspace.search exceeded the result bound'
-    )
+    await expect(runReadOnlyAcceptance(tooManyResults)).rejects.toThrow('workspace.search exceeded the result bound')
   })
 
   it('closes the SDK transport and redacts connection failures', async () => {
@@ -201,10 +192,37 @@ describe('read-only Notion provider acceptance', () => {
     expect(failure).toBeInstanceOf(Error)
     expect((failure as Error).message).toBe('Read-only acceptance transport failed')
     expect((failure as Error).message).not.toContain(secretToken)
-    expect(sdkMocks.transportArgs).toHaveBeenCalledWith(
-      expect.any(URL),
-      { requestInit: { headers: { authorization: `Bearer ${secretToken}` } } }
-    )
+    expect(sdkMocks.transportArgs).toHaveBeenCalledWith(expect.any(URL), {
+      requestInit: { headers: { authorization: `Bearer ${secretToken}` } }
+    })
     expect(sdkMocks.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves the primary sanitized failure when transport close also fails', async () => {
+    sdkMocks.connect.mockRejectedValueOnce(new Error(`provider leaked ${secretToken}`))
+    sdkMocks.close.mockRejectedValueOnce(new Error(`close leaked ${secretToken}`))
+
+    await expect(runHttpReadOnlyAcceptance(new URL('https://notion.example/mcp'), secretToken)).rejects.toThrow(
+      'Read-only acceptance transport failed'
+    )
+  })
+
+  it('reports a sanitized close failure after successful read-only calls', async () => {
+    sdkMocks.callTool
+      .mockResolvedValueOnce(textResult({}))
+      .mockResolvedValueOnce(textResult({}))
+      .mockResolvedValueOnce(
+        textResult({
+          action: 'search',
+          query: 'provider-acceptance',
+          total: 0,
+          results: []
+        })
+      )
+    sdkMocks.close.mockRejectedValueOnce(new Error(`close leaked ${secretToken}`))
+
+    await expect(runHttpReadOnlyAcceptance(new URL('https://notion.example/mcp'), secretToken)).rejects.toThrow(
+      'Read-only acceptance transport close failed'
+    )
   })
 })


### PR DESCRIPTION
## Problem
The provider-acceptance lane lacked a source-controlled read-only Notion harness with an explicit operation boundary and redacted output.

## Change
- add an official MCP SDK Streamable HTTP acceptance client
- allow only `workspace.info`, `users.me`, and bounded `workspace.search`
- validate response shapes and result limits with Zod
- reject mutation/widened calls and keep bearer tokens, payloads, and provider errors out of output

## Verification
- `bun x vitest run tests/provider-readonly-acceptance.test.ts` — 4 passed
- `bun run type-check` — both TypeScript configurations passed
- `git diff --check`

No provider/network call was made; this PR closes the source-controlled harness gap only.