### PR TITLE
fix: 🛡️ Sentinel: Fix path traversal validation logic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -69,3 +69,8 @@ Proposals that were reviewed and declined. Closing a PR records the decision whe
 
 - **A wider padding regex for `wrapToolResult`** (`/<(?:[\s/]|\\[nrtfb]|\\u[0-9a-fA-F]{4})*untrusted_notion_content/gi`, PR #1151). Rejected because it is still bypassable: an attacker who types a literal backslash or a double quote produces `\\n` / `\"` in the serialized payload, neither of which the alternation matches. The bug class is closed by anchoring on the tag name (2026-07-25 entry above), not by extending the alternation again.
 - **Relaxing the PR-title Conventional Commits gate for bot-prefixed titles** (`.github/workflows/ci.yml`, proposed alongside PR #1151). Rejected. The gate is red on `🛡️ Sentinel:` / `⚡ Bolt:` / `🎨 Palette:` titles by design: it is the reminder to retype the squash-commit subject as `fix:`/`feat:` so python-semantic-release still parses it. Skipping the job for exactly those titles removes the reminder on the only PRs that need it, and lets a release-invisible commit reach `main`. A security fix must not carry a change that disables the repository's own CI guardrail.
+
+## 2024-05-24 - Overly Restrictive Path Traversal Prevention
+**Vulnerability:** The path traversal prevention logic `key.includes('/..')` blocked legitimate keys that happened to contain `..` followed by other characters (e.g., `better-notion/..name`).
+**Learning:** Using overly broad string matching for security checks can inadvertently break legitimate functionality by causing false positives.
+**Prevention:** Use precise boundary checks for directory traversal sequences (e.g., `includes('/../') || endsWith('/..') || key === '..'`) rather than broad substring matches.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,7 +94,10 @@ const kvOutbound: OutboundHandler<Env> = async (request, env) => {
   // checked before the normal key lookup so it never shadows a real KV key.
   // Security (Sentinel): restrict KV access to the app's own namespace.
   // Directly mapping untrusted paths to KV keys is a vulnerability (E.3).
-  if (key !== '__ready' && (!key.startsWith('better-notion/') || key.includes('/../') || key.includes('/..'))) {
+  if (
+    key !== '__ready' &&
+    (!key.startsWith('better-notion/') || key.includes('/../') || key.endsWith('/..') || key === '..')
+  ) {
     return new Response('forbidden: invalid KV key prefix', { status: 403 })
   }
   if (request.method === 'GET' && key === '__ready') {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -289,6 +289,14 @@ describe('KV security (Sentinel)', () => {
     const res = await kvH(new Request('http://kv.internal/better-notion/../secret'), env as never)
     expect(res.status).toBe(403)
   })
+
+  it('allows valid paths that happen to contain .. but are not directory traversal', async () => {
+    const env = fakeEnv()
+    // A path like "better-notion/..name" is perfectly valid since it's just a key starting with ".."
+    const res = await kvH(new Request('http://kv.internal/better-notion/..name'), env as never)
+    // Should get a 404 (not found) instead of a 403 (forbidden)
+    expect(res.status).toBe(404)
+  })
 })
 
 describe('tombstone contract (W4 dehost preparation & drill)', () => {


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The path traversal prevention logic `key.includes('/..')` was overly restrictive, causing a denial of service (false positive) for legitimate keys that started with `..` (e.g., `better-notion/..name`).
🎯 Impact: Valid requests with keys starting with `..` were incorrectly rejected with a 403 Forbidden status, breaking legitimate functionality.
🔧 Fix: Refined the validation logic to use precise boundary checks (`includes('/../') || endsWith('/..') || key === '..'`) that exclusively target directory traversal sequences.
✅ Verification: Added a unit test in `tests/worker.test.ts` to verify that a path like `better-notion/..name` correctly bypasses the traversal block. Executed the full vitest suite locally to confirm no regressions.

---
*PR created automatically by Jules for task [17513516052238425160](https://jules.google.com/task/17513516052238425160) started by @n24q02m*