### PR TITLE
feat(notion): bound page content reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- version list -->
 
+## Unreleased
+
+### Bug Fixes
+
+- Bound page content reads with continuation cursors and tighten KV traversal checks for legitimate dotted keys.
+
 ## v2.40.1 (2026-08-31)
 
 

--- a/src/docs/pages.md
+++ b/src/docs/pages.md
@@ -29,9 +29,9 @@ Pages may contain **image blocks** and **file blocks**. These are returned as ma
 
 ### get
 ```json
-{"action": "get", "page_id": "xxx"}
+{"action": "get", "page_id": "xxx", "content_limit": 20}
 ```
-Returns all properties including: title, rich_text, select, multi_select, number, checkbox, url, email, phone_number, date, relation, rollup, people, files, formula, created_time, last_edited_time, created_by, last_edited_by, status, unique_id.
+Returns page properties and markdown content. Use `content_limit` (1–100 blocks) to bound the response. When more blocks remain, `content_truncated` is `true` and `next_cursor` can be passed as `content_cursor` in the next request. Omitting `content_limit` preserves the full-content read.
 
 ### get_property
 Retrieve a single page property item with auto-pagination for large properties.
@@ -75,6 +75,8 @@ Move a page to a new parent page.
 - `parent_id` - Parent page or database ID
 - `properties` - Page properties (for database pages)
 - `property_id` - Property ID (required for get_property action)
+- `content_limit` - Maximum number of top-level blocks returned by `get` (1–100)
+- `content_cursor` - Continuation cursor returned by a bounded `get`
 - `icon` - Emoji, external URL (`https://...`), or built-in shorthand (`name:color`, e.g. `document:gray`)
 - `cover` - External URL (`https://...`) or built-in shorthand (e.g. `gradient_1`, `solid_beige`, `nasa_carina_nebula`)
 - `archived` - Archive status (boolean, for update action)

--- a/src/docs/pages.md
+++ b/src/docs/pages.md
@@ -31,7 +31,7 @@ Pages may contain **image blocks** and **file blocks**. These are returned as ma
 ```json
 {"action": "get", "page_id": "xxx", "content_limit": 20}
 ```
-Returns page properties and markdown content. Use `content_limit` (1–100 blocks) to bound the response. When more blocks remain, `content_truncated` is `true` and `next_cursor` can be passed as `content_cursor` in the next request. Omitting `content_limit` preserves the full-content read.
+Returns all properties including: title, rich_text, select, multi_select, number, checkbox, url, email, phone_number, date, relation, rollup, people, files, formula, created_time, last_edited_time, created_by, last_edited_by, status, unique_id. Use `content_limit` (1–100 blocks) to bound the response. When more blocks remain, `content_truncated` is `true` and `next_cursor` can be passed as `content_cursor` in the next request. Omitting `content_limit` preserves the full-content read.
 
 ### get_property
 Retrieve a single page property item with auto-pagination for large properties.

--- a/src/tools/composite/pages.test.ts
+++ b/src/tools/composite/pages.test.ts
@@ -216,6 +216,48 @@ describe('pages', () => {
       })
     })
 
+    it('bounds content and exposes the continuation cursor', async () => {
+      mockNotion.pages.retrieve.mockResolvedValue({
+        id: 'page-3',
+        url: 'https://notion.so/page-3',
+        created_time: '2024-01-01T00:00:00.000Z',
+        last_edited_time: '2024-01-02T00:00:00.000Z',
+        archived: false,
+        properties: {}
+      })
+      mockNotion.blocks.children.list.mockResolvedValue({
+        results: [{ id: 'block-1', type: 'paragraph' }],
+        next_cursor: 'cursor-2',
+        has_more: true
+      })
+
+      const result = (await pages(mockNotion as any, {
+        action: 'get',
+        page_id: 'page-3',
+        content_limit: 1
+      })) as GetPageResult
+
+      expect(mockNotion.blocks.children.list).toHaveBeenCalledWith({
+        block_id: 'page-3',
+        start_cursor: undefined,
+        page_size: 1
+      })
+      expect(result.content_truncated).toBe(true)
+      expect(result.next_cursor).toBe('cursor-2')
+      expect(result.block_count).toBe(1)
+    })
+
+    it('rejects content limits outside the Notion page-size range', async () => {
+      await expect(
+        pages(mockNotion as any, {
+          action: 'get',
+          page_id: 'page-1',
+          content_limit: 101
+        })
+      ).rejects.toThrow('content_limit must be an integer between 1 and 100')
+      expect(mockNotion.pages.retrieve).not.toHaveBeenCalled()
+    })
+
     it('handles pages with no blocks', async () => {
       mockNotion.pages.retrieve.mockResolvedValue({
         id: 'page-2',

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -3,12 +3,11 @@
  * All page operations in one unified interface
  */
 
-import type { NotionBlock } from '../helpers/markdown.js'
-
 import type { Client, PageObjectResponse } from '@notionhq/client'
 import { formatCover } from '../helpers/covers.js'
 import { NotionMCPError, retryWithBackoff, withErrorHandling } from '../helpers/errors.js'
 import { formatIcon } from '../helpers/icons.js'
+import type { NotionBlock } from '../helpers/markdown.js'
 import { blocksToMarkdown, markdownToBlocks } from '../helpers/markdown.js'
 import { autoPaginate, populateDeepChildren, processBatches } from '../helpers/pagination.js'
 import { convertToNotionProperties, extractPageProperties } from '../helpers/properties.js'

--- a/src/tools/composite/pages.ts
+++ b/src/tools/composite/pages.ts
@@ -3,6 +3,8 @@
  * All page operations in one unified interface
  */
 
+import type { NotionBlock } from '../helpers/markdown.js'
+
 import type { Client, PageObjectResponse } from '@notionhq/client'
 import { formatCover } from '../helpers/covers.js'
 import { NotionMCPError, retryWithBackoff, withErrorHandling } from '../helpers/errors.js'
@@ -31,6 +33,36 @@ export interface GetPageResult {
   properties: Record<string, any>
   content: string
   block_count: number
+  content_truncated?: boolean
+  next_cursor?: string | null
+}
+
+export interface PagesInput {
+  action: 'create' | 'get' | 'get_property' | 'update' | 'move' | 'archive' | 'restore' | 'duplicate'
+
+  // Common params
+  page_id?: string
+  page_ids?: string[]
+
+  // Create/Update params
+  title?: string
+  content?: string // Markdown (defaults to append, use replace: true to overwrite)
+  append_content?: string
+  parent_id?: string
+  properties?: Record<string, any>
+  icon?: string
+  cover?: string
+
+  // get_property params
+  property_id?: string
+
+  // get content params
+  content_limit?: number
+  content_cursor?: string
+
+  // Archive/Restore params
+  archived?: boolean
+  replace?: boolean
 }
 
 export interface GetPagePropertyResult {
@@ -39,6 +71,76 @@ export interface GetPagePropertyResult {
   property_id: string
   type: string
   value: any
+}
+
+/**
+ * Get page content as markdown, optionally bounded to one Notion cursor page.
+ * Maps to: GET /v1/pages/{id} + GET /v1/blocks/{id}/children
+ */
+async function getPage(notion: Client, input: PagesInput): Promise<GetPageResult> {
+  if (!input.page_id) {
+    throw new NotionMCPError('page_id is required for get action', 'VALIDATION_ERROR', 'Provide page_id')
+  }
+
+  if (
+    input.content_limit !== undefined &&
+    (!Number.isInteger(input.content_limit) || input.content_limit < 1 || input.content_limit > 100)
+  ) {
+    throw new NotionMCPError(
+      'content_limit must be an integer between 1 and 100',
+      'VALIDATION_ERROR',
+      'Provide a content_limit between 1 and 100'
+    )
+  }
+
+  const page = (await notion.pages.retrieve({ page_id: input.page_id })) as PageObjectResponse
+  const bounded = input.content_limit !== undefined || input.content_cursor !== undefined
+  let blocks: NotionBlock[]
+  let nextCursor: string | null = null
+  let hasMore = false
+
+  if (bounded) {
+    const response = await notion.blocks.children.list({
+      block_id: input.page_id,
+      start_cursor: input.content_cursor,
+      page_size: input.content_limit ?? 100
+    })
+    blocks = response.results as unknown as NotionBlock[]
+    nextCursor = response.next_cursor
+    hasMore = response.has_more
+  } else {
+    blocks = (await autoPaginate((cursor) =>
+      notion.blocks.children.list({
+        block_id: input.page_id!,
+        start_cursor: cursor,
+        page_size: 100
+      })
+    )) as unknown as NotionBlock[]
+  }
+
+  // Recursively fetch children for blocks that need them (tables, toggles, columns)
+  await populateDeepChildren(notion, blocks as unknown as Parameters<typeof populateDeepChildren>[1])
+
+  const result: GetPageResult = {
+    action: 'get',
+    page_id: page.id,
+    url: page.url,
+    created_time: page.created_time,
+    last_edited_time: page.last_edited_time,
+    archived: page.archived,
+    icon: page.icon || null,
+    cover: page.cover || null,
+    properties: extractPageProperties(page.properties),
+    content: blocksToMarkdown(blocks),
+    block_count: blocks.length
+  }
+
+  if (bounded) {
+    result.content_truncated = hasMore
+    result.next_cursor = nextCursor
+  }
+
+  return result
 }
 
 export interface UpdatePageResult {
@@ -74,30 +176,6 @@ export type PagesResult =
   | MovePageResult
   | ArchivePageResult
   | DuplicatePageResult
-
-export interface PagesInput {
-  action: 'create' | 'get' | 'get_property' | 'update' | 'move' | 'archive' | 'restore' | 'duplicate'
-
-  // Common params
-  page_id?: string
-  page_ids?: string[]
-
-  // Create/Update params
-  title?: string
-  content?: string // Markdown (defaults to append, use replace: true to overwrite)
-  append_content?: string
-  parent_id?: string
-  properties?: Record<string, any>
-  icon?: string
-  cover?: string
-
-  // get_property params
-  property_id?: string
-
-  // Archive/Restore params
-  archived?: boolean
-  replace?: boolean
-}
 
 /**
  * Unified pages tool - handles all page operations
@@ -197,49 +275,6 @@ async function createPage(notion: Client, input: PagesInput): Promise<CreatePage
     page_id: page.id,
     url: page.url,
     created: true
-  }
-}
-
-/**
- * Get page with full content as markdown
- * Maps to: GET /v1/pages/{id} + GET /v1/blocks/{id}/children
- */
-async function getPage(notion: Client, input: PagesInput): Promise<GetPageResult> {
-  if (!input.page_id) {
-    throw new NotionMCPError('page_id is required for get action', 'VALIDATION_ERROR', 'Provide page_id')
-  }
-
-  const page = (await notion.pages.retrieve({ page_id: input.page_id })) as PageObjectResponse
-
-  // Get all blocks with auto-pagination
-  const blocks = await autoPaginate((cursor) =>
-    notion.blocks.children.list({
-      block_id: input.page_id!,
-      start_cursor: cursor,
-      page_size: 100
-    })
-  )
-
-  // Recursively fetch children for blocks that need them (tables, toggles, columns)
-  await populateDeepChildren(notion, blocks as any[])
-
-  const markdown = blocksToMarkdown(blocks as any)
-
-  // Extract properties
-  const properties = extractPageProperties(page.properties)
-
-  return {
-    action: 'get',
-    page_id: page.id,
-    url: page.url,
-    created_time: page.created_time,
-    last_edited_time: page.last_edited_time,
-    archived: page.archived,
-    icon: page.icon || null,
-    cover: page.cover || null,
-    properties,
-    content: markdown,
-    block_count: blocks.length
   }
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -90,7 +90,7 @@ const TOOLS = [
   {
     name: 'pages',
     description:
-      'Page CRUD for individual pages and database rows.\n\nActions (required params -> optional):\n- create (parent_id -> title, content, properties, icon, cover)\n- get (page_id): returns markdown content\n- get_property (page_id, property_id)\n- update (page_id -> title, content, append_content, properties, icon, cover, archived)\n- move (page_id, parent_id)\n- archive (page_id) / restore (page_id)\n- duplicate (page_id -> parent_id)\n\nUse `databases` instead for querying or bulk row operations. Property format: simple values auto-convert -- string for title/rich_text/select/status, number for number, boolean for checkbox, string[] for multi_select, ISO date "2025-01-15" for date. Example: properties: {"Name": "My Page", "Status": "In Progress", "Tags": ["tag1", "tag2"], "Due": "2025-06-01", "Count": 42, "Done": true}.',
+      'Page CRUD for individual pages and database rows.\n\nActions (required params -> optional):\n- create (parent_id -> title, content, properties, icon, cover)\n- get (page_id -> content_limit, content_cursor): returns markdown content; bounded reads return content_truncated and next_cursor\n- get_property (page_id, property_id)\n- update (page_id -> title, content, append_content, properties, icon, cover, archived)\n- move (page_id, parent_id)\n- archive (page_id) / restore (page_id)\n- duplicate (page_id -> parent_id)\n\nUse `databases` instead for querying or bulk row operations. Property format: simple values auto-convert -- string for title/rich_text/select/status, number for number, boolean for checkbox, string[] for multi_select, ISO date "2025-01-15" for date. Example: properties: {"Name": "My Page", "Status": "In Progress", "Tags": ["urgent", "work"]}',
     annotations: {
       title: 'Pages',
       readOnlyHint: false,
@@ -111,6 +111,13 @@ const TOOLS = [
         title: { type: 'string', description: 'Page title' },
         content: { type: 'string', description: 'Markdown content' },
         append_content: { type: 'string', description: 'Markdown to append' },
+        content_limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 100,
+          description: 'Max page blocks to return for get; use next_cursor to continue'
+        },
+        content_cursor: { type: 'string', description: 'Cursor from a previous bounded pages get' },
         parent_id: { type: 'string', description: 'Parent page or database ID' },
         properties: {
           type: 'object',


### PR DESCRIPTION
## Changes
- Add bounded pages get reads with validated limits and continuation cursors
- Tighten KV traversal boundaries without rejecting legitimate dotted keys
- Document and test both contracts

## Verification
- Focused Vitest: 131 passed across pages, registry, and worker regressions
- Full Vitest: 992 passed, 6 failures in existing main CLI tests because installed mcp-core lacks runtime buildCli export
- No runtime deployment or STABLE promotion included